### PR TITLE
[codex] Add Claude Design quota tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ QuotaBar is a Tauri v2 menubar app for monitoring Claude Code and Codex usage. I
 
 ## Features
 
-- Claude Code quota: 5-hour, 7-day, Opus, and Sonnet windows.
+- Claude quota: 5-hour, 7-day, Opus, Sonnet, and Claude Design windows.
 - Codex quota: short and weekly ChatGPT usage windows.
 - Local cost tracking: today, week, and month estimates for Claude Code and Codex.
 - Dual tray icons: independent Claude and Codex menu bar indicators.

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -19,6 +19,8 @@ pub struct QuotaData {
     pub weekly_opus: Option<UsageInfo>,
     #[serde(rename = "weeklySonnet")]
     pub weekly_sonnet: Option<UsageInfo>,
+    #[serde(rename = "weeklyDesign")]
+    pub weekly_design: Option<UsageInfo>,
     pub error: Option<String>,
 }
 
@@ -30,6 +32,7 @@ impl QuotaData {
             weekly_total: None,
             weekly_opus: None,
             weekly_sonnet: None,
+            weekly_design: None,
             error: Some(error.into()),
         }
     }
@@ -39,6 +42,7 @@ impl QuotaData {
         weekly_total: Option<UsageInfo>,
         weekly_opus: Option<UsageInfo>,
         weekly_sonnet: Option<UsageInfo>,
+        weekly_design: Option<UsageInfo>,
     ) -> Self {
         Self {
             connected: true,
@@ -46,6 +50,7 @@ impl QuotaData {
             weekly_total,
             weekly_opus,
             weekly_sonnet,
+            weekly_design,
             error: None,
         }
     }

--- a/src-tauri/src/services/claude.rs
+++ b/src-tauri/src/services/claude.rs
@@ -740,8 +740,9 @@ pub async fn fetch_quota() -> QuotaData {
 
     let five_hour = data["five_hour"]["utilization"].as_f64();
     let seven_day = data["seven_day"]["utilization"].as_f64();
+    let seven_day_design = data["seven_day_omelette"]["utilization"].as_f64();
     log_msg(&format!(
-        "[Quota] SUCCESS: five_hour={five_hour:?}%, seven_day={seven_day:?}%"
+        "[Quota] SUCCESS: five_hour={five_hour:?}%, seven_day={seven_day:?}%, seven_day_omelette={seven_day_design:?}%"
     ));
 
     let result = QuotaData::connected(
@@ -749,6 +750,7 @@ pub async fn fetch_quota() -> QuotaData {
         parse_quota_window(&data["seven_day"]),
         parse_quota_window(&data["seven_day_opus"]),
         parse_quota_window(&data["seven_day_sonnet"]),
+        parse_quota_window(&data["seven_day_omelette"]),
     );
 
     save_quota_cache(&result);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,14 +100,18 @@ function formatResetTime(resetTime?: string): string {
   }
 }
 
-function getClaudeTrayUsedPercent(quota: QuotaData | null): number | null {
+export function getClaudeTrayUsedPercent(quota: QuotaData | null): number | null {
   if (!quota) return null;
 
   if (quota.weeklyTotal) {
     return quota.weeklyTotal.percentage;
   }
 
-  const weeklyUsedCandidates = [quota.weeklyOpus?.percentage, quota.weeklySonnet?.percentage]
+  const weeklyUsedCandidates = [
+    quota.weeklyOpus?.percentage,
+    quota.weeklySonnet?.percentage,
+    quota.weeklyDesign?.percentage,
+  ]
     .filter((value): value is number => typeof value === 'number');
   if (weeklyUsedCandidates.length > 0) {
     return Math.max(...weeklyUsedCandidates);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -488,7 +488,15 @@ export default function App() {
                     />
                   )}
 
-                  {!quota.weeklyTotal && !quota.weeklyOpus && !quota.weeklySonnet && (
+                  {quota.weeklyDesign && (
+                    <QuotaCard
+                      label="Claude Design (7-Day)"
+                      percentage={Math.round(quota.weeklyDesign.percentage)}
+                      resetsIn={formatResetTime(quota.weeklyDesign.resetTime)}
+                    />
+                  )}
+
+                  {!quota.weeklyTotal && !quota.weeklyOpus && !quota.weeklySonnet && !quota.weeklyDesign && (
                     <div className="no-data">No weekly data</div>
                   )}
                 </div>

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -11,6 +11,7 @@ export interface QuotaData {
   weeklyTotal?: UsageInfo;
   weeklyOpus?: UsageInfo;
   weeklySonnet?: UsageInfo;
+  weeklyDesign?: UsageInfo;
   error?: string;
 }
 

--- a/tests/claude_tray_percent.test.ts
+++ b/tests/claude_tray_percent.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import { getClaudeTrayUsedPercent } from '../src/App';
+import type { QuotaData, UsageInfo } from '../src/types/models';
+
+const usage = (percentage: number): UsageInfo => ({
+  used: percentage,
+  limit: 100,
+  percentage,
+});
+
+describe('getClaudeTrayUsedPercent', () => {
+  test('uses weekly total before individual weekly buckets', () => {
+    expect(getClaudeTrayUsedPercent({
+      connected: true,
+      weeklyTotal: usage(42),
+      weeklyDesign: usage(91),
+    })).toBe(42);
+  });
+
+  test('includes Claude Design in weekly bucket fallback', () => {
+    expect(getClaudeTrayUsedPercent({
+      connected: true,
+      session: usage(12),
+      weeklyOpus: usage(36),
+      weeklyDesign: usage(84),
+    })).toBe(84);
+  });
+
+  test('falls back to session usage when weekly buckets are missing', () => {
+    expect(getClaudeTrayUsedPercent({
+      connected: true,
+      session: usage(27),
+    })).toBe(27);
+  });
+
+  test('returns null when no quota window exists', () => {
+    const quota: QuotaData = { connected: true };
+
+    expect(getClaudeTrayUsedPercent(null)).toBeNull();
+    expect(getClaudeTrayUsedPercent(quota)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Parse Claude Code Design quota from the optional `seven_day_omelette` usage bucket.
- Add `weeklyDesign` to the shared quota model and render it in the weekly Claude quota panel.
- Update the README feature list to include Claude Design quota tracking.

## Why
Claude Design is part of Claude Code usage, but QuotaBar only displayed the existing 5-hour, 7-day, Opus, and Sonnet windows. This left the Design-specific weekly quota invisible when the usage endpoint provides it.

## Validation
- `npm test`
- `npm run build`
- `cargo check`
- `cargo test`