### PR TITLE
Fix missing quota usage parsing

### DIFF
--- a/src-tauri/src/services/claude.rs
+++ b/src-tauri/src/services/claude.rs
@@ -296,7 +296,7 @@ fn parse_quota_window(value: &serde_json::Value) -> Option<UsageInfo> {
         return None;
     }
 
-    let utilization = value["utilization"].as_f64().unwrap_or(0.0);
+    let utilization = value.get("utilization")?.as_f64()?;
     let resets_at = value["resets_at"].as_str().map(ToString::to_string);
 
     Some(UsageInfo {
@@ -475,14 +475,61 @@ pub async fn fetch_quota() -> QuotaData {
         "[Quota] SUCCESS: five_hour={five_hour:?}%, seven_day={seven_day:?}%, seven_day_omelette={seven_day_design:?}%"
     ));
 
+    let session = parse_quota_window(&data["five_hour"]);
+    let weekly_total = parse_quota_window(&data["seven_day"]);
+    let weekly_opus = parse_quota_window(&data["seven_day_opus"]);
+    let weekly_sonnet = parse_quota_window(&data["seven_day_sonnet"]);
+    let weekly_design = parse_quota_window(&data["seven_day_omelette"]);
+
+    if session.is_none()
+        && weekly_total.is_none()
+        && weekly_opus.is_none()
+        && weekly_sonnet.is_none()
+        && weekly_design.is_none()
+    {
+        log_msg("[Quota] parse error: no numeric quota utilization fields");
+        return QuotaData::disconnected(
+            "Failed to parse response: no numeric quota utilization fields",
+        );
+    }
+
     let result = QuotaData::connected(
-        parse_quota_window(&data["five_hour"]),
-        parse_quota_window(&data["seven_day"]),
-        parse_quota_window(&data["seven_day_opus"]),
-        parse_quota_window(&data["seven_day_sonnet"]),
-        parse_quota_window(&data["seven_day_omelette"]),
+        session,
+        weekly_total,
+        weekly_opus,
+        weekly_sonnet,
+        weekly_design,
     );
 
     save_quota_cache(&result);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_quota_window;
+    use serde_json::json;
+
+    #[test]
+    fn parse_quota_window_requires_numeric_utilization() {
+        assert!(parse_quota_window(&json!({ "resets_at": "2026-06-06T00:00:00Z" })).is_none());
+        assert!(parse_quota_window(&json!({ "utilization": "0" })).is_none());
+    }
+
+    #[test]
+    fn parse_quota_window_maps_numeric_utilization() {
+        let parsed = parse_quota_window(&json!({
+            "utilization": 42.5,
+            "resets_at": "2026-06-06T00:00:00Z"
+        }));
+        let window = match parsed {
+            Some(window) => window,
+            None => panic!("numeric utilization should parse"),
+        };
+
+        assert_eq!(window.used, 42.5);
+        assert_eq!(window.limit, 100.0);
+        assert_eq!(window.percentage, 42.5);
+        assert_eq!(window.reset_time.as_deref(), Some("2026-06-06T00:00:00Z"));
+    }
 }

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -82,12 +82,11 @@ fn read_auth_json() -> Result<serde_json::Value, String> {
     serde_json::from_str(&content).map_err(|e| format!("Failed to parse auth.json: {e}"))
 }
 
-fn parse_used_percent(window: &serde_json::Value) -> f64 {
-    let value = window["used_percent"]
-        .as_f64()
-        .or_else(|| window["used_percent"].as_i64().map(|v| v as f64))
-        .unwrap_or(0.0);
-    value.clamp(0.0, 100.0)
+fn parse_used_percent(window: &serde_json::Value) -> Option<f64> {
+    window
+        .get("used_percent")
+        .and_then(|value| value.as_f64().or_else(|| value.as_i64().map(|v| v as f64)))
+        .map(|value| value.clamp(0.0, 100.0))
 }
 
 fn parse_rate_limit_window(window: &serde_json::Value) -> Option<CodexRateLimitWindow> {
@@ -96,7 +95,7 @@ fn parse_rate_limit_window(window: &serde_json::Value) -> Option<CodexRateLimitW
     }
 
     Some(CodexRateLimitWindow {
-        used_percent: parse_used_percent(window),
+        used_percent: parse_used_percent(window)?,
         window_minutes: window["limit_window_seconds"]
             .as_i64()
             .map(|s| (s + 59) / 60),
@@ -364,6 +363,12 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
         .get("secondary_window")
         .and_then(parse_rate_limit_window);
 
+    if primary.is_none() && secondary.is_none() {
+        return CodexRateLimits::disconnected(
+            "Failed to parse response: no numeric Codex rate limit usage fields",
+        );
+    }
+
     let credits = data["credits"].as_object().map(|credits| CodexCredits {
         has_credits: credits
             .get("has_credits")
@@ -392,4 +397,48 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
         *guard = Some(limits.clone());
     }
     limits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_rate_limit_window;
+    use serde_json::json;
+
+    #[test]
+    fn parse_rate_limit_window_requires_numeric_used_percent() {
+        assert!(parse_rate_limit_window(&json!({ "limit_window_seconds": 18_000 })).is_none());
+        assert!(parse_rate_limit_window(&json!({ "used_percent": "0" })).is_none());
+    }
+
+    #[test]
+    fn parse_rate_limit_window_maps_numeric_used_percent() {
+        let parsed = parse_rate_limit_window(&json!({
+            "used_percent": 61.8,
+            "limit_window_seconds": 18_000,
+            "reset_at": 1_781_000_000
+        }));
+        let window = match parsed {
+            Some(window) => window,
+            None => panic!("numeric used_percent should parse"),
+        };
+
+        assert_eq!(window.used_percent, 61.8);
+        assert_eq!(window.window_minutes, Some(300));
+        assert_eq!(window.resets_at, Some(1_781_000_000));
+    }
+
+    #[test]
+    fn parse_rate_limit_window_clamps_numeric_used_percent() {
+        let high = match parse_rate_limit_window(&json!({ "used_percent": 120 })) {
+            Some(window) => window,
+            None => panic!("numeric used_percent should parse"),
+        };
+        let low = match parse_rate_limit_window(&json!({ "used_percent": -5 })) {
+            Some(window) => window,
+            None => panic!("numeric used_percent should parse"),
+        };
+
+        assert_eq!(high.used_percent, 100.0);
+        assert_eq!(low.used_percent, 0.0);
+    }
 }


### PR DESCRIPTION
Summary
- require numeric Claude `utilization` before constructing quota windows
- require numeric Codex `used_percent` before constructing rate-limit windows
- return parse errors when successful provider responses contain no usable usage windows
- add Rust parser coverage for missing, non-numeric, valid, and clamped values

Verification
- npm ci
- npm test
- npm run build
- cargo fmt --check
- cargo test
- cargo check

Closes #3
