### PR TITLE
Add Shipwise readiness scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report a reproducible QuotaBar problem.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect instead?
+    validations:
+      required: true
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Provider
+      options:
+        - Claude
+        - Codex
+        - Cursor
+        - Antigravity
+        - Tray or window
+        - Build or install
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. Open QuotaBar...
+        2. Click...
+        3. See...
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Paste logs, screenshots, or exact error text. Do not include tokens, cookies, or secrets.
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      placeholder: v0.2.0 or commit SHA
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: macOS 15.5, Windows 11, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security or secret exposure
+    url: https://github.com/majiayu000/quotabar/security/advisories/new
+    about: Report token, credential, or security-sensitive issues privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest a scoped QuotaBar improvement.
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow or limitation should this improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the smallest useful change.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: What should this request avoid changing?
+  - type: textarea
+    id: validation
+    attributes:
+      label: Done when
+      description: What visible behavior or command output proves this is complete?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- Describe the user-visible or repository-facing change.
+
+## Verification
+
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] `cd src-tauri && cargo check`
+- [ ] `cd src-tauri && cargo test`
+
+## Scope
+
+- [ ] No provider tokens, cookies, sessions, or secrets are committed.
+- [ ] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm test
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Check Rust formatting
+        run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
+
+      - name: Check Rust crate
+        run: cargo check --manifest-path src-tauri/Cargo.toml
+
+      - name: Run Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable QuotaBar changes should be summarized here before a release is cut.
+
+## Unreleased
+
+- Added CI coverage for frontend tests, frontend build, Rust formatting, Rust check, and Rust tests.
+- Added GitHub issue templates and a pull request template.
+- Documented release artifact paths and current limitations.
+
+## 0.2.0
+
+- Existing application version. Historical release notes were not tracked before this changelog.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ QuotaBar is a Tauri v2 menubar app for monitoring Claude Code, Codex, Cursor, an
   - `src-tauri/src/services/tray.rs`
   - `src-tauri/src/services/tray_icon.rs`
   - `src-tauri/src/services/window.rs`
+- Release notes:
+  - `CHANGELOG.md`
+  - `docs/release.md`
 
 ## Requirements
 
@@ -93,6 +96,10 @@ Windows installer output:
 `src-tauri/target/release/bundle/msi/`
 `src-tauri/target/release/bundle/nsis/`
 
+## Release Artifacts
+
+There is no published GitHub release yet. When a release is cut, build from a clean checkout and attach the generated platform artifact from the paths above to the matching GitHub release tag. See `docs/release.md` for the release checklist.
+
 ## Install / Run
 
 macOS:
@@ -122,6 +129,15 @@ npm test
 cd src-tauri && cargo check
 cd src-tauri && cargo test
 ```
+
+## Limitations
+
+- QuotaBar reads local provider auth state; it does not manage provider login flows.
+- Claude quota depends on Claude Code OAuth credentials and Anthropic's current usage response shape.
+- Codex quota depends on `~/.codex/auth.json` and ChatGPT usage windows returned by the current backend API.
+- Cursor quota requires Cursor sign-in or `CURSOR_SESSION_TOKEN`.
+- Antigravity support currently reports provider availability only; quota windows are not exposed yet.
+- Cost estimates are derived from local logs and may be empty until provider tools have written usage history.
 
 ## Troubleshooting
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,41 @@
+# Release Notes
+
+QuotaBar does not currently have a published GitHub release.
+
+## Build Artifacts
+
+Release builds should be produced from a clean checkout with:
+
+```bash
+npm ci
+npm run tauri build -- --bundles app
+```
+
+macOS app bundle:
+
+```text
+src-tauri/target/release/bundle/macos/QuotaBar.app
+```
+
+Windows installer bundles:
+
+```text
+src-tauri/target/release/bundle/msi/
+src-tauri/target/release/bundle/nsis/
+```
+
+Attach the generated platform bundle to the GitHub release for the matching tag.
+
+## Pre-release Verification
+
+Run these commands before tagging:
+
+```bash
+npm test
+npm run build
+cd src-tauri && cargo fmt --check
+cd src-tauri && cargo check
+cd src-tauri && cargo test
+```
+
+Do not include provider tokens, cookies, session files, or local auth material in release artifacts.


### PR DESCRIPTION
Summary
- add GitHub CI for frontend tests/build and Rust fmt/check/test
- add issue templates, PR template, changelog, and release checklist
- document release artifact paths and current limitations in README/docs

Verification
- npm ci
- git diff --check
- npm test
- npm run build
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml

Notes
- Related issue: https://github.com/majiayu000/quotabar/issues/4
- This is a partial readiness PR only.
- This does not close the related issue because real screenshot/GIF proof and a published release asset still need to be produced from the app.
