### PR TITLE
[codex] Fix local cost refresh and Codex priority pricing

### DIFF
--- a/specs/GH10/product.md
+++ b/specs/GH10/product.md
@@ -1,0 +1,24 @@
+# GH-10 Product Spec: Local Cost Pricing Policy
+
+## Goals
+
+- `LOCAL COST` 在应用保持打开时会持续刷新，不会因为只在组件挂载时查询一次而长时间停在旧值。
+- Codex 本地成本对 `gpt-5.4` / `gpt-5.5` 使用 ccstats pricing cache 中的 priority 价格和 US regional multiplier，避免把 priority 使用量按 base 价格低估。
+- 当 QuotaBar 无法取得已知 Codex 模型所需的 priority/regional 价格字段时，用户看到错误，而不是继续展示明显偏低的金额。
+- Tauri command 返回字符串错误时，前端展示真实错误文本，而不是泛化成 `Failed to load cost summary`。
+
+## Non-Goals
+
+- 不改变 `CostOverview` 的前端响应字段。
+- 不新增 provider、价格配置 UI 或远程网络请求。
+- 不修改 ccstats 上游包。
+- 不关闭 GitHub issue；最终关闭动作需要人类 gate。
+
+## Acceptance Criteria
+
+- 成本组件有默认自动刷新节奏，刷新时强制绕过 QuotaBar 五分钟缓存。
+- Codex USD 成本在本地根据 `~/.cache/ccstats/pricing.json` 重新应用 priority 价格和 US regional multiplier。
+- `gpt-5.4` / `gpt-5.5` 的 price policy 缺失或字段不完整时，后端返回明确错误。
+- 成本 UI 能展示 Tauri 返回的字符串错误。
+- 非 USD range 不应用 USD regional policy。
+- Rust 和 TypeScript 验证通过。

--- a/specs/GH10/tasks.md
+++ b/specs/GH10/tasks.md
@@ -1,0 +1,17 @@
+# GH-10 Tasks: Local Cost Pricing Policy
+
+## Implementation Tasks
+
+- [x] `LCOST-T1` Owner: codex. Done when: GitHub issue #10 和 `specs/GH10` 记录目标、技术方案和验收标准。Verify: `gh issue view 10 --json number,title,url,state` and `find specs/GH10 -maxdepth 1 -type f -print`.
+- [x] `LCOST-T2` Owner: codex. Done when: `CostSummarySection` 默认自动刷新并在 interval tick 时 force refresh。Verify: `npx tsc --noEmit`.
+- [x] `LCOST-T3` Owner: codex. Done when: Codex priority/regional pricing 从 ccstats pricing cache 解析，不再把 `gpt-5.4` / `gpt-5.5` 价格硬编码在 `cost.rs`。Verify: `rg -n "input_cost_per_token_priority|regional_processing_uplift_multiplier_us|gpt-5\\.5" src-tauri/src/services`.
+- [x] `LCOST-T4` Owner: codex. Done when: pricing policy 缺失会返回明确错误，USD Codex range 会按 priority/regional 重算。Verify: `cargo test --manifest-path src-tauri/Cargo.toml codex_pricing::tests` and `cargo test --manifest-path src-tauri/Cargo.toml cost::tests`.
+- [x] `LCOST-T5` Owner: codex. Done when: Tauri 字符串错误能在成本 UI 中保留真实错误文本。Verify: `npm test -- --run`.
+- [x] `LCOST-T6` Owner: codex. Done when: QuotaBar 优先读取 ccstats upstream 的 `~/.cache/ccstats/pricing.json`，并在第一个候选路径缺失时继续读取 fallback。Verify: `cargo test --manifest-path src-tauri/Cargo.toml codex_pricing::tests`.
+- [x] `LCOST-T7` Owner: codex. Done when: 项目验证与 app bundle 构建通过。Verify: `cargo check --manifest-path src-tauri/Cargo.toml && cargo test --manifest-path src-tauri/Cargo.toml && npx tsc --noEmit && npm test -- --run && npm run tauri -- build --bundles app`.
+
+## Handoff Notes
+
+Linked issue: https://github.com/majiayu000/quotabar/issues/10
+
+`implx` 以 single-agent bounded tranche 执行；没有创建 PR，没有执行 merge/close gate。

--- a/specs/GH10/tech.md
+++ b/specs/GH10/tech.md
@@ -1,0 +1,33 @@
+# GH-10 Tech Spec: Local Cost Pricing Policy
+
+## Proposed Design
+
+前端 `CostSummarySection` 增加默认自动刷新 interval。interval 触发时调用 `backend.getCostOverview(source, true)`，让后端强制重建成本摘要。组件卸载时清理 interval。
+
+前端错误展示使用一个小的 error normalization helper。Tauri command rejection 可能是字符串，不一定是 `Error` 实例；字符串错误必须原样展示，空字符串或未知错误才回退到 `Failed to load cost summary`。
+
+后端保留 ccstats 的 multi-range 聚合路径，但在 Codex + USD 的结果映射完成后增加 QuotaBar 本地 pricing policy 层：
+
+- 优先从 ccstats upstream 使用的 `~/.cache/ccstats/pricing.json` 读取 LiteLLM 价格表，并保留 `dirs::cache_dir()/ccstats/pricing.json` 作为兼容 fallback。
+- 对 `gpt-5.4` / `gpt-5.5` 要求存在 `input_cost_per_token_priority`、`output_cost_per_token_priority`、`cache_read_input_token_cost_priority` 和 `regional_processing_uplift_multiplier_us`。
+- 使用 `input_tokens * priority_input + (output_tokens + reasoning_tokens) * priority_output + cache_read_tokens * priority_cache_read`，再乘以 US regional multiplier。
+- 未知模型保留 ccstats 原始成本；已知 Codex 模型缺少 policy 时返回错误，防止 silent low estimate。
+
+将 pricing cache 读取和计算拆到独立 service module，避免 `cost.rs` 继续承载价格表细节。
+
+## Test Plan
+
+- 单元测试 pricing JSON 解析和 `gpt-5.5` priority + US regional 成本计算。
+- 单元测试 pricing cache 第一个候选路径不存在时会继续读取 fallback 路径。
+- 单元测试缺失 priority/regional 字段时返回错误。
+- 单元测试 Codex USD range 会重算模型和 range 成本。
+- 单元测试 Tauri 字符串错误不会被泛化吞掉。
+- 运行 `cargo check --manifest-path src-tauri/Cargo.toml`。
+- 运行 `cargo test --manifest-path src-tauri/Cargo.toml`。
+- 运行 `npx tsc --noEmit`。
+- 运行 `npm test -- --run`。
+- 运行 `npm run tauri -- build --bundles app`。
+
+## Rollback Plan
+
+回滚 `CostSummarySection` 的 interval 逻辑和后端 pricing policy module。回滚后 QuotaBar 会恢复只展示 ccstats 当前返回成本的行为。

--- a/src-tauri/src/services/codex_pricing.rs
+++ b/src-tauri/src/services/codex_pricing.rs
@@ -173,7 +173,7 @@ fn model_lookup_keys(model: &str) -> Vec<String> {
     keys
 }
 
-fn requires_codex_priority_policy(model: &str) -> bool {
+pub(crate) fn requires_codex_priority_policy(model: &str) -> bool {
     matches!(
         normalize_openai_model_key(model).as_str(),
         "gpt-5.4" | "gpt-5.4-2026-03-05" | "gpt-5.5" | "gpt-5.5-2026-04-23"

--- a/src-tauri/src/services/codex_pricing.rs
+++ b/src-tauri/src/services/codex_pricing.rs
@@ -1,0 +1,336 @@
+use serde::Deserialize;
+use std::{collections::HashMap, fs, path::PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct CodexPriorityPricingPolicy {
+    models: HashMap<String, LiteLlmModelPricing>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CodexTokenUsage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub cache_read_tokens: i64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CodexPriorityPricing {
+    input: f64,
+    output: f64,
+    cache_read: f64,
+    regional_multiplier: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LiteLlmModelPricing {
+    input_cost_per_token_priority: Option<f64>,
+    output_cost_per_token_priority: Option<f64>,
+    cache_read_input_token_cost_priority: Option<f64>,
+    regional_processing_uplift_multiplier_us: Option<f64>,
+}
+
+impl CodexPriorityPricingPolicy {
+    pub fn load_from_default_cache() -> Result<Self, String> {
+        Self::load_from_cache_paths(pricing_cache_candidate_paths()?)
+    }
+
+    fn load_from_cache_paths(paths: Vec<PathBuf>) -> Result<Self, String> {
+        let mut checked_paths = Vec::with_capacity(paths.len());
+        for path in paths {
+            checked_paths.push(path.display().to_string());
+            match fs::read_to_string(&path) {
+                Ok(content) => {
+                    return Self::from_litellm_json_str(&content)
+                        .map_err(|err| format!("{err} at {}", path.display()));
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(err) => {
+                    return Err(format!(
+                        "Failed to read ccstats pricing cache at {}: {err}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+
+        Err(format!(
+            "Failed to read ccstats pricing cache; checked {}",
+            checked_paths.join(", ")
+        ))
+    }
+
+    pub(crate) fn from_litellm_json_str(content: &str) -> Result<Self, String> {
+        let raw: HashMap<String, LiteLlmModelPricing> = serde_json::from_str(content)
+            .map_err(|err| format!("Failed to parse ccstats pricing cache: {err}"))?;
+        let models = raw
+            .into_iter()
+            .map(|(model, pricing)| (normalize_model_key(&model), pricing))
+            .collect();
+
+        Ok(Self { models })
+    }
+
+    pub fn calculate_us_priority_cost(
+        &self,
+        model: &str,
+        usage: CodexTokenUsage,
+    ) -> Result<Option<f64>, String> {
+        validate_tokens(model, usage)?;
+
+        let Some(pricing) = self.priority_pricing(model)? else {
+            return Ok(None);
+        };
+        let output_tokens = usage.output_tokens + usage.reasoning_tokens;
+        let cost = (usage.input_tokens as f64 * pricing.input
+            + output_tokens as f64 * pricing.output
+            + usage.cache_read_tokens as f64 * pricing.cache_read)
+            * pricing.regional_multiplier;
+
+        Ok(Some(cost))
+    }
+
+    fn priority_pricing(&self, model: &str) -> Result<Option<CodexPriorityPricing>, String> {
+        let requires_policy = requires_codex_priority_policy(model);
+        let Some(entry) = self.lookup_model(model) else {
+            if requires_policy {
+                return Err(format!(
+                    "ccstats pricing cache is missing Codex priority pricing for {model}"
+                ));
+            }
+            return Ok(None);
+        };
+
+        match priority_pricing_from_entry(model, entry) {
+            Ok(pricing) => Ok(Some(pricing)),
+            Err(err) if requires_policy => Err(err),
+            Err(_) => Ok(None),
+        }
+    }
+
+    fn lookup_model(&self, model: &str) -> Option<&LiteLlmModelPricing> {
+        for key in model_lookup_keys(model) {
+            if let Some(pricing) = self.models.get(&key) {
+                return Some(pricing);
+            }
+        }
+        None
+    }
+}
+
+fn priority_pricing_from_entry(
+    model: &str,
+    entry: &LiteLlmModelPricing,
+) -> Result<CodexPriorityPricing, String> {
+    Ok(CodexPriorityPricing {
+        input: required_field(
+            model,
+            "input_cost_per_token_priority",
+            entry.input_cost_per_token_priority,
+        )?,
+        output: required_field(
+            model,
+            "output_cost_per_token_priority",
+            entry.output_cost_per_token_priority,
+        )?,
+        cache_read: required_field(
+            model,
+            "cache_read_input_token_cost_priority",
+            entry.cache_read_input_token_cost_priority,
+        )?,
+        regional_multiplier: required_field(
+            model,
+            "regional_processing_uplift_multiplier_us",
+            entry.regional_processing_uplift_multiplier_us,
+        )?,
+    })
+}
+
+fn required_field(model: &str, field: &str, value: Option<f64>) -> Result<f64, String> {
+    value.ok_or_else(|| format!("ccstats pricing cache is missing {field} for {model}"))
+}
+
+fn validate_tokens(model: &str, usage: CodexTokenUsage) -> Result<(), String> {
+    if usage.input_tokens < 0
+        || usage.output_tokens < 0
+        || usage.reasoning_tokens < 0
+        || usage.cache_read_tokens < 0
+    {
+        return Err(format!(
+            "Codex token usage for {model} contains negative values"
+        ));
+    }
+
+    Ok(())
+}
+
+fn model_lookup_keys(model: &str) -> Vec<String> {
+    let normalized = normalize_model_key(model);
+    let mut keys = vec![normalized.clone()];
+    if let Some(stripped) = normalized.strip_prefix("openai/") {
+        keys.push(stripped.to_string());
+    }
+    keys
+}
+
+fn requires_codex_priority_policy(model: &str) -> bool {
+    matches!(
+        normalize_openai_model_key(model).as_str(),
+        "gpt-5.4" | "gpt-5.4-2026-03-05" | "gpt-5.5" | "gpt-5.5-2026-04-23"
+    )
+}
+
+fn normalize_openai_model_key(model: &str) -> String {
+    let normalized = normalize_model_key(model);
+    normalized
+        .strip_prefix("openai/")
+        .unwrap_or(&normalized)
+        .to_string()
+}
+
+fn normalize_model_key(model: &str) -> String {
+    model.trim().to_ascii_lowercase()
+}
+
+fn pricing_cache_candidate_paths() -> Result<Vec<PathBuf>, String> {
+    let mut paths = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(".cache").join("ccstats").join("pricing.json"));
+    }
+    if let Some(cache_dir) = dirs::cache_dir() {
+        paths.push(cache_dir.join("ccstats").join("pricing.json"));
+    }
+    paths.dedup();
+
+    if paths.is_empty() {
+        return Err("Failed to resolve ccstats pricing cache directory".to_string());
+    }
+
+    Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PRICING_FIXTURE: &str = r#"{
+      "gpt-5.5": {
+        "input_cost_per_token_priority": 0.00001,
+        "output_cost_per_token_priority": 0.00006,
+        "cache_read_input_token_cost_priority": 0.000001,
+        "regional_processing_uplift_multiplier_us": 1.1
+      },
+      "other-model": {
+        "input_cost_per_token": 0.00001
+      }
+    }"#;
+
+    #[test]
+    fn calculates_priority_regional_cost_from_pricing_cache() {
+        let policy = parse_policy(PRICING_FIXTURE);
+        let cost = match policy.calculate_us_priority_cost(
+            "gpt-5.5",
+            CodexTokenUsage {
+                input_tokens: 1_000_000,
+                output_tokens: 2_000_000,
+                reasoning_tokens: 3_000_000,
+                cache_read_tokens: 4_000_000,
+            },
+        ) {
+            Ok(Some(cost)) => cost,
+            Ok(None) => panic!("gpt-5.5 should have priority pricing"),
+            Err(err) => panic!("cost should calculate: {err}"),
+        };
+
+        assert!((cost - 345.4).abs() < 0.001);
+    }
+
+    #[test]
+    fn errors_when_required_codex_priority_fields_are_missing() {
+        let policy = parse_policy(r#"{"gpt-5.5": {}}"#);
+        let err = match policy.calculate_us_priority_cost(
+            "gpt-5.5",
+            CodexTokenUsage {
+                input_tokens: 1,
+                output_tokens: 1,
+                reasoning_tokens: 0,
+                cache_read_tokens: 0,
+            },
+        ) {
+            Ok(_) => panic!("missing required Codex priority fields should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err.contains("input_cost_per_token_priority"));
+    }
+
+    #[test]
+    fn ignores_unknown_models_without_priority_policy() {
+        let policy = parse_policy(PRICING_FIXTURE);
+        let cost = match policy.calculate_us_priority_cost(
+            "other-model",
+            CodexTokenUsage {
+                input_tokens: 1,
+                output_tokens: 1,
+                reasoning_tokens: 0,
+                cache_read_tokens: 0,
+            },
+        ) {
+            Ok(cost) => cost,
+            Err(err) => panic!("unknown model should not fail: {err}"),
+        };
+
+        assert_eq!(cost, None);
+    }
+
+    #[test]
+    fn loads_first_existing_pricing_cache_path() {
+        let base = std::env::temp_dir().join(format!(
+            "quotabar-codex-pricing-test-{}",
+            std::process::id()
+        ));
+        let missing = base.join("missing").join("pricing.json");
+        let existing = base.join("existing").join("pricing.json");
+        if let Some(parent) = existing.parent() {
+            if let Err(err) = fs::create_dir_all(parent) {
+                panic!("failed to create test pricing cache directory: {err}");
+            }
+        }
+        if let Err(err) = fs::write(&existing, PRICING_FIXTURE) {
+            panic!("failed to write test pricing cache: {err}");
+        }
+
+        let policy =
+            match CodexPriorityPricingPolicy::load_from_cache_paths(vec![missing, existing]) {
+                Ok(policy) => policy,
+                Err(err) => panic!("expected fallback cache path to load: {err}"),
+            };
+        let cost = match policy.calculate_us_priority_cost(
+            "gpt-5.5",
+            CodexTokenUsage {
+                input_tokens: 1,
+                output_tokens: 1,
+                reasoning_tokens: 0,
+                cache_read_tokens: 1,
+            },
+        ) {
+            Ok(Some(cost)) => cost,
+            Ok(None) => panic!("gpt-5.5 should have priority pricing"),
+            Err(err) => panic!("cost should calculate: {err}"),
+        };
+
+        assert!(cost > 0.0);
+        match fs::remove_dir_all(&base) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => panic!("failed to remove test pricing cache directory: {err}"),
+        }
+    }
+
+    fn parse_policy(content: &str) -> CodexPriorityPricingPolicy {
+        match CodexPriorityPricingPolicy::from_litellm_json_str(content) {
+            Ok(policy) => policy,
+            Err(err) => panic!("fixture should parse: {err}"),
+        }
+    }
+}

--- a/src-tauri/src/services/cost.rs
+++ b/src-tauri/src/services/cost.rs
@@ -1,6 +1,8 @@
 //! Local cost summaries powered by the `ccstats` SDK.
 
-use crate::services::codex_pricing::{CodexPriorityPricingPolicy, CodexTokenUsage};
+use crate::services::codex_pricing::{
+    requires_codex_priority_policy, CodexPriorityPricingPolicy, CodexTokenUsage,
+};
 use ccstats::{
     summarize_cost_ranges, CostSummary, ModelCostSummary, MultiSummaryOptions, TokenBreakdown,
     UsageRange, UsageSource,
@@ -142,11 +144,7 @@ fn build_cost_overview(
     let currency = batch.currency;
     let generated_at = batch.generated_at;
     let mut ranges = map_batch_ranges(&range_specs, batch.summaries)?;
-    if batch.source == UsageSource::Codex
-        && ranges
-            .iter()
-            .any(|range| range.currency.eq_ignore_ascii_case("USD"))
-    {
+    if batch.source == UsageSource::Codex && ranges_require_codex_priority_policy(&ranges) {
         let pricing_policy = CodexPriorityPricingPolicy::load_from_default_cache()?;
         apply_codex_priority_costs(&mut ranges, &pricing_policy)?;
     }
@@ -253,6 +251,16 @@ fn apply_codex_priority_costs(
     }
 
     Ok(())
+}
+
+fn ranges_require_codex_priority_policy(ranges: &[CostRangeSummary]) -> bool {
+    ranges.iter().any(|range| {
+        range.currency.eq_ignore_ascii_case("USD")
+            && range
+                .models
+                .iter()
+                .any(|model| requires_codex_priority_policy(&model.model))
+    })
 }
 
 fn normalize_optional(value: Option<String>) -> Option<String> {
@@ -473,5 +481,35 @@ mod tests {
         };
         assert!((cost - 345.4).abs() < 0.001);
         assert_eq!(ranges[0].models[0].cost_usd, Some(cost));
+    }
+
+    #[test]
+    fn priority_policy_is_required_only_for_known_codex_usd_models() {
+        let mut ranges = vec![CostRangeSummary {
+            range: "today".to_string(),
+            label: "Today".to_string(),
+            since: None,
+            until: None,
+            currency: "USD".to_string(),
+            cost: Some(1.0),
+            cost_usd: Some(1.0),
+            tokens: token_breakdown(10, 0, 0, 0),
+            models: vec![CostModelSummary {
+                model: "other-model".to_string(),
+                cost: Some(1.0),
+                cost_usd: Some(1.0),
+                tokens: token_breakdown(10, 0, 0, 0),
+            }],
+            valid_entries: 1,
+            skipped_entries: 0,
+            elapsed_ms: 0.0,
+        }];
+        assert!(!ranges_require_codex_priority_policy(&ranges));
+
+        ranges[0].models[0].model = "gpt-5.5".to_string();
+        assert!(ranges_require_codex_priority_policy(&ranges));
+
+        ranges[0].currency = "EUR".to_string();
+        assert!(!ranges_require_codex_priority_policy(&ranges));
     }
 }

--- a/src-tauri/src/services/cost.rs
+++ b/src-tauri/src/services/cost.rs
@@ -1,5 +1,6 @@
 //! Local cost summaries powered by the `ccstats` SDK.
 
+use crate::services::codex_pricing::{CodexPriorityPricingPolicy, CodexTokenUsage};
 use ccstats::{
     summarize_cost_ranges, CostSummary, ModelCostSummary, MultiSummaryOptions, TokenBreakdown,
     UsageRange, UsageSource,
@@ -140,7 +141,15 @@ fn build_cost_overview(
     let display_name = batch.display_name;
     let currency = batch.currency;
     let generated_at = batch.generated_at;
-    let ranges = map_batch_ranges(&range_specs, batch.summaries)?;
+    let mut ranges = map_batch_ranges(&range_specs, batch.summaries)?;
+    if batch.source == UsageSource::Codex
+        && ranges
+            .iter()
+            .any(|range| range.currency.eq_ignore_ascii_case("USD"))
+    {
+        let pricing_policy = CodexPriorityPricingPolicy::load_from_default_cache()?;
+        apply_codex_priority_costs(&mut ranges, &pricing_policy)?;
+    }
     let overview = CostOverview {
         source: source_name,
         display_name,
@@ -207,6 +216,43 @@ fn map_batch_ranges(
     }
 
     Ok(ranges)
+}
+
+fn apply_codex_priority_costs(
+    ranges: &mut [CostRangeSummary],
+    pricing_policy: &CodexPriorityPricingPolicy,
+) -> Result<(), String> {
+    for range in ranges {
+        if !range.currency.eq_ignore_ascii_case("USD") {
+            continue;
+        }
+
+        let mut range_cost = 0.0;
+        let mut has_cost = false;
+        for model in &mut range.models {
+            let usage = CodexTokenUsage {
+                input_tokens: model.tokens.input_tokens,
+                output_tokens: model.tokens.output_tokens,
+                reasoning_tokens: model.tokens.reasoning_tokens,
+                cache_read_tokens: model.tokens.cache_read_tokens,
+            };
+            if let Some(cost) = pricing_policy.calculate_us_priority_cost(&model.model, usage)? {
+                model.cost = Some(cost);
+                model.cost_usd = Some(cost);
+            }
+            if let Some(cost) = model.cost_usd {
+                range_cost += cost;
+                has_cost = true;
+            }
+        }
+
+        if has_cost {
+            range.cost = Some(range_cost);
+            range.cost_usd = Some(range_cost);
+        }
+    }
+
+    Ok(())
 }
 
 fn normalize_optional(value: Option<String>) -> Option<String> {
@@ -311,6 +357,22 @@ mod tests {
         }
     }
 
+    fn token_breakdown(
+        input_tokens: i64,
+        output_tokens: i64,
+        reasoning_tokens: i64,
+        cache_read_tokens: i64,
+    ) -> CostTokenBreakdown {
+        CostTokenBreakdown {
+            input_tokens,
+            output_tokens,
+            reasoning_tokens,
+            cache_creation_tokens: 0,
+            cache_read_tokens,
+            total_tokens: input_tokens + output_tokens + reasoning_tokens + cache_read_tokens,
+        }
+    }
+
     #[test]
     fn maps_batch_summaries_to_ui_ranges_in_order() {
         let specs = cost_range_specs();
@@ -363,5 +425,53 @@ mod tests {
         };
 
         assert!(err.contains("ccstats returned ThisMonth for week cost range"));
+    }
+
+    #[test]
+    fn applies_codex_priority_regional_costs_for_usd_ranges() {
+        let pricing_policy = CodexPriorityPricingPolicy::from_litellm_json_str(
+            r#"{
+              "gpt-5.5": {
+                "input_cost_per_token_priority": 0.00001,
+                "output_cost_per_token_priority": 0.00006,
+                "cache_read_input_token_cost_priority": 0.000001,
+                "regional_processing_uplift_multiplier_us": 1.1
+              }
+            }"#,
+        );
+        let pricing_policy = match pricing_policy {
+            Ok(policy) => policy,
+            Err(err) => panic!("fixture should parse: {err}"),
+        };
+        let mut ranges = vec![CostRangeSummary {
+            range: "today".to_string(),
+            label: "Today".to_string(),
+            since: None,
+            until: None,
+            currency: "USD".to_string(),
+            cost: Some(0.0),
+            cost_usd: Some(0.0),
+            tokens: token_breakdown(1_000_000, 2_000_000, 3_000_000, 4_000_000),
+            models: vec![CostModelSummary {
+                model: "gpt-5.5".to_string(),
+                cost: Some(0.0),
+                cost_usd: Some(0.0),
+                tokens: token_breakdown(1_000_000, 2_000_000, 3_000_000, 4_000_000),
+            }],
+            valid_entries: 1,
+            skipped_entries: 0,
+            elapsed_ms: 0.0,
+        }];
+
+        if let Err(err) = apply_codex_priority_costs(&mut ranges, &pricing_policy) {
+            panic!("Codex priority costs should recalculate: {err}");
+        }
+
+        let cost = match ranges[0].cost_usd {
+            Some(cost) => cost,
+            None => panic!("cost should be recalculated"),
+        };
+        assert!((cost - 345.4).abs() < 0.001);
+        assert_eq!(ranges[0].models[0].cost_usd, Some(cost));
     }
 }

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod antigravity;
 pub mod claude;
 pub mod codex;
+pub mod codex_pricing;
 pub mod cost;
 pub mod cursor;
 pub mod http;

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -5,6 +5,19 @@ import type { CostOverview, CostRangeSummary, CostSource } from '../types/models
 interface CostSummarySectionProps {
   source: CostSource;
   refreshKey?: number;
+  autoRefreshIntervalMs?: number;
+}
+
+const DEFAULT_AUTO_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+export function getCostSummaryErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string' && err.trim()) return err;
+  if (err && typeof err === 'object' && 'message' in err) {
+    const message = err.message;
+    if (typeof message === 'string' && message.trim()) return message;
+  }
+  return 'Failed to load cost summary';
 }
 
 function formatMoney(value: number | null | undefined, currency: string): string {
@@ -52,13 +65,18 @@ function pickPrimaryRange(overview: CostOverview | null): CostRangeSummary | nul
   );
 }
 
-export default function CostSummarySection({ source, refreshKey = 0 }: CostSummarySectionProps) {
+export default function CostSummarySection({
+  source,
+  refreshKey = 0,
+  autoRefreshIntervalMs = DEFAULT_AUTO_REFRESH_INTERVAL_MS,
+}: CostSummarySectionProps) {
   const [overview, setOverview] = useState<CostOverview | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    let interval: number | undefined;
 
     const loadCost = async (force: boolean) => {
       try {
@@ -70,7 +88,7 @@ export default function CostSummarySection({ source, refreshKey = 0 }: CostSumma
         }
       } catch (err) {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load cost summary');
+          setError(getCostSummaryErrorMessage(err));
         }
       } finally {
         if (!cancelled) {
@@ -80,11 +98,19 @@ export default function CostSummarySection({ source, refreshKey = 0 }: CostSumma
     };
 
     loadCost(refreshKey > 0);
+    if (autoRefreshIntervalMs > 0) {
+      interval = window.setInterval(() => {
+        void loadCost(true);
+      }, autoRefreshIntervalMs);
+    }
 
     return () => {
       cancelled = true;
+      if (interval !== undefined) {
+        window.clearInterval(interval);
+      }
     };
-  }, [source, refreshKey]);
+  }, [source, refreshKey, autoRefreshIntervalMs]);
 
   const primaryRange = useMemo(() => pickPrimaryRange(overview), [overview]);
   const topModels = primaryRange?.models.slice(0, 3) ?? [];

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -10,6 +10,16 @@ interface CostSummarySectionProps {
 
 const DEFAULT_AUTO_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
+export function startCostSummaryAutoRefresh(
+  autoRefreshIntervalMs: number,
+  loadCost: (force: boolean) => void | Promise<void>,
+): ReturnType<typeof setInterval> | undefined {
+  if (autoRefreshIntervalMs <= 0) return undefined;
+  return setInterval(() => {
+    void loadCost(true);
+  }, autoRefreshIntervalMs);
+}
+
 export function getCostSummaryErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   if (typeof err === 'string' && err.trim()) return err;
@@ -98,16 +108,12 @@ export default function CostSummarySection({
     };
 
     loadCost(refreshKey > 0);
-    if (autoRefreshIntervalMs > 0) {
-      interval = window.setInterval(() => {
-        void loadCost(true);
-      }, autoRefreshIntervalMs);
-    }
+    interval = startCostSummaryAutoRefresh(autoRefreshIntervalMs, loadCost);
 
     return () => {
       cancelled = true;
       if (interval !== undefined) {
-        window.clearInterval(interval);
+        clearInterval(interval);
       }
     };
   }, [source, refreshKey, autoRefreshIntervalMs]);

--- a/tests/cost_summary_error.test.ts
+++ b/tests/cost_summary_error.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from 'vitest';
-import { getCostSummaryErrorMessage } from '../src/components/CostSummarySection';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  getCostSummaryErrorMessage,
+  startCostSummaryAutoRefresh,
+} from '../src/components/CostSummarySection';
 
 describe('getCostSummaryErrorMessage', () => {
   test('preserves string errors returned by Tauri commands', () => {
@@ -11,5 +14,35 @@ describe('getCostSummaryErrorMessage', () => {
   test('falls back only for empty or unknown errors', () => {
     expect(getCostSummaryErrorMessage('')).toBe('Failed to load cost summary');
     expect(getCostSummaryErrorMessage(null)).toBe('Failed to load cost summary');
+  });
+});
+
+describe('startCostSummaryAutoRefresh', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('refreshes with force enabled on interval ticks', () => {
+    vi.useFakeTimers();
+    const loadCost = vi.fn();
+    const interval = startCostSummaryAutoRefresh(1000, loadCost);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(loadCost).toHaveBeenCalledTimes(1);
+    expect(loadCost).toHaveBeenCalledWith(true);
+    if (interval !== undefined) clearInterval(interval);
+  });
+
+  test('stops refreshing after interval cleanup', () => {
+    vi.useFakeTimers();
+    const loadCost = vi.fn();
+    const interval = startCostSummaryAutoRefresh(1000, loadCost);
+
+    vi.advanceTimersByTime(1000);
+    if (interval !== undefined) clearInterval(interval);
+    vi.advanceTimersByTime(1000);
+
+    expect(loadCost).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/cost_summary_error.test.ts
+++ b/tests/cost_summary_error.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'vitest';
+import { getCostSummaryErrorMessage } from '../src/components/CostSummarySection';
+
+describe('getCostSummaryErrorMessage', () => {
+  test('preserves string errors returned by Tauri commands', () => {
+    expect(getCostSummaryErrorMessage('ccstats pricing cache is missing Codex priority pricing')).toBe(
+      'ccstats pricing cache is missing Codex priority pricing',
+    );
+  });
+
+  test('falls back only for empty or unknown errors', () => {
+    expect(getCostSummaryErrorMessage('')).toBe('Failed to load cost summary');
+    expect(getCostSummaryErrorMessage(null)).toBe('Failed to load cost summary');
+  });
+});


### PR DESCRIPTION
## Summary

Refs #10.

This PR fixes two related LOCAL COST issues:

- the cost section could stay stale because it only refreshed on mount/manual refresh while the backend cache lived for five minutes
- Codex cost was underestimated because ccstats summary cost does not expose Codex priority pricing and US regional uplift policy

It also fixes the UI error path so string errors returned by Tauri commands are shown directly instead of being collapsed into `Failed to load cost summary`.

## Changes

- Add a default five-minute auto-refresh interval for `CostSummarySection`, using forced backend refreshes on interval ticks.
- Add `codex_pricing` backend service to read ccstats LiteLLM pricing cache.
- Recalculate Codex USD range/model costs with priority input/output/cache-read prices and US regional multiplier.
- Prefer ccstats upstream cache path `~/.cache/ccstats/pricing.json`, with `dirs::cache_dir()/ccstats/pricing.json` as fallback.
- Add SpecRail packet under `specs/GH10`.
- Add tests for pricing policy parsing, missing policy fields, cache path fallback, and Tauri string error display.

## Root Cause

QuotaBar treated ccstats returned cost as final, but ccstats currently drops pricing policy details such as priority tier and regional uplift from its summary model. QuotaBar also looked for the pricing cache via macOS `dirs::cache_dir()`, while ccstats upstream stores pricing data at `~/.cache/ccstats/pricing.json`.

## Verification

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npx tsc --noEmit`
- `npm test -- --run`
- `npm run tauri -- build --bundles app`

## Gate Notes

Draft PR only. This does not close #10 and does not request merge approval.