### PR TITLE
[codex] Add Claude Fable 5 quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This screenshot is captured from the production React UI in browser preview with
 
 - Claude tray value:
   - prefers `weeklyTotal`
-  - falls back to max of `weeklyOpus`, `weeklySonnet`, and `weeklyDesign`
+  - falls back to max of `weeklyOpus`, `weeklySonnet`, `weeklyDesign`, and `weeklyFable5`
   - falls back to current session usage
 - Codex tray value:
   - prefers `secondary_window.used_percent`

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -21,6 +21,8 @@ pub struct QuotaData {
     pub weekly_sonnet: Option<UsageInfo>,
     #[serde(rename = "weeklyDesign")]
     pub weekly_design: Option<UsageInfo>,
+    #[serde(rename = "weeklyFable5")]
+    pub weekly_fable5: Option<UsageInfo>,
     pub error: Option<String>,
 }
 
@@ -33,6 +35,7 @@ impl QuotaData {
             weekly_opus: None,
             weekly_sonnet: None,
             weekly_design: None,
+            weekly_fable5: None,
             error: Some(error.into()),
         }
     }
@@ -43,6 +46,7 @@ impl QuotaData {
         weekly_opus: Option<UsageInfo>,
         weekly_sonnet: Option<UsageInfo>,
         weekly_design: Option<UsageInfo>,
+        weekly_fable5: Option<UsageInfo>,
     ) -> Self {
         Self {
             connected: true,
@@ -51,6 +55,7 @@ impl QuotaData {
             weekly_opus,
             weekly_sonnet,
             weekly_design,
+            weekly_fable5,
             error: None,
         }
     }

--- a/src-tauri/src/services/claude.rs
+++ b/src-tauri/src/services/claude.rs
@@ -20,6 +20,13 @@ const CREDENTIAL_NAMES: [&str; 4] = [
     "Claude-credentials",
     "claudecode-credentials",
 ];
+const FABLE5_QUOTA_KEYS: [&str; 5] = [
+    "seven_day_fable5",
+    "seven_day_fable_5",
+    "seven_day_fable",
+    "seven_day_claude_fable5",
+    "seven_day_claude_fable_5",
+];
 
 static REQUEST_COUNT: AtomicU64 = AtomicU64::new(0);
 static LAST_REQUEST_TIME: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
@@ -307,6 +314,10 @@ fn parse_quota_window(value: &serde_json::Value) -> Option<UsageInfo> {
     })
 }
 
+fn parse_first_quota_window(data: &serde_json::Value, keys: &[&str]) -> Option<UsageInfo> {
+    keys.iter().find_map(|key| parse_quota_window(&data[*key]))
+}
+
 fn get_cached_quota() -> Option<QuotaData> {
     let guard = quota_cache().lock().ok()?;
     let cached = guard.as_ref()?;
@@ -471,8 +482,11 @@ pub async fn fetch_quota() -> QuotaData {
     let five_hour = data["five_hour"]["utilization"].as_f64();
     let seven_day = data["seven_day"]["utilization"].as_f64();
     let seven_day_design = data["seven_day_omelette"]["utilization"].as_f64();
+    let seven_day_fable5 = FABLE5_QUOTA_KEYS
+        .iter()
+        .find_map(|key| data[*key]["utilization"].as_f64());
     log_msg(&format!(
-        "[Quota] SUCCESS: five_hour={five_hour:?}%, seven_day={seven_day:?}%, seven_day_omelette={seven_day_design:?}%"
+        "[Quota] SUCCESS: five_hour={five_hour:?}%, seven_day={seven_day:?}%, seven_day_omelette={seven_day_design:?}%, seven_day_fable5={seven_day_fable5:?}%"
     ));
 
     let session = parse_quota_window(&data["five_hour"]);
@@ -480,12 +494,14 @@ pub async fn fetch_quota() -> QuotaData {
     let weekly_opus = parse_quota_window(&data["seven_day_opus"]);
     let weekly_sonnet = parse_quota_window(&data["seven_day_sonnet"]);
     let weekly_design = parse_quota_window(&data["seven_day_omelette"]);
+    let weekly_fable5 = parse_first_quota_window(&data, &FABLE5_QUOTA_KEYS);
 
     if session.is_none()
         && weekly_total.is_none()
         && weekly_opus.is_none()
         && weekly_sonnet.is_none()
         && weekly_design.is_none()
+        && weekly_fable5.is_none()
     {
         log_msg("[Quota] parse error: no numeric quota utilization fields");
         return QuotaData::disconnected(
@@ -499,6 +515,7 @@ pub async fn fetch_quota() -> QuotaData {
         weekly_opus,
         weekly_sonnet,
         weekly_design,
+        weekly_fable5,
     );
 
     save_quota_cache(&result);
@@ -507,7 +524,7 @@ pub async fn fetch_quota() -> QuotaData {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_quota_window;
+    use super::{parse_first_quota_window, parse_quota_window};
     use serde_json::json;
 
     #[test]
@@ -531,5 +548,25 @@ mod tests {
         assert_eq!(window.limit, 100.0);
         assert_eq!(window.percentage, 42.5);
         assert_eq!(window.reset_time.as_deref(), Some("2026-06-06T00:00:00Z"));
+    }
+
+    #[test]
+    fn parse_first_quota_window_accepts_fable5_aliases() {
+        let parsed = parse_first_quota_window(
+            &json!({
+                "seven_day_fable_5": {
+                    "utilization": 63.0,
+                    "resets_at": "2026-07-09T00:00:00Z"
+                }
+            }),
+            &["seven_day_fable5", "seven_day_fable_5", "seven_day_fable"],
+        );
+        let window = match parsed {
+            Some(window) => window,
+            None => panic!("fable5 alias should parse"),
+        };
+
+        assert_eq!(window.percentage, 63.0);
+        assert_eq!(window.reset_time.as_deref(), Some("2026-07-09T00:00:00Z"));
     }
 }

--- a/src-tauri/src/services/claude.rs
+++ b/src-tauri/src/services/claude.rs
@@ -524,8 +524,8 @@ pub async fn fetch_quota() -> QuotaData {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_first_quota_window, parse_quota_window};
-    use serde_json::json;
+    use super::{parse_first_quota_window, parse_quota_window, FABLE5_QUOTA_KEYS};
+    use serde_json::{json, Value};
 
     #[test]
     fn parse_quota_window_requires_numeric_utilization() {
@@ -552,21 +552,25 @@ mod tests {
 
     #[test]
     fn parse_first_quota_window_accepts_fable5_aliases() {
-        let parsed = parse_first_quota_window(
-            &json!({
-                "seven_day_fable_5": {
-                    "utilization": 63.0,
+        for (index, key) in FABLE5_QUOTA_KEYS.iter().enumerate() {
+            let utilization = 60.0 + index as f64;
+            let mut data = serde_json::Map::new();
+            data.insert(
+                (*key).to_string(),
+                json!({
+                    "utilization": utilization,
                     "resets_at": "2026-07-09T00:00:00Z"
-                }
-            }),
-            &["seven_day_fable5", "seven_day_fable_5", "seven_day_fable"],
-        );
-        let window = match parsed {
-            Some(window) => window,
-            None => panic!("fable5 alias should parse"),
-        };
+                }),
+            );
 
-        assert_eq!(window.percentage, 63.0);
-        assert_eq!(window.reset_time.as_deref(), Some("2026-07-09T00:00:00Z"));
+            let parsed = parse_first_quota_window(&Value::Object(data), &FABLE5_QUOTA_KEYS);
+            let window = match parsed {
+                Some(window) => window,
+                None => panic!("{key} should parse as Fable 5 usage"),
+            };
+
+            assert_eq!(window.percentage, utilization);
+            assert_eq!(window.reset_time.as_deref(), Some("2026-07-09T00:00:00Z"));
+        }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import QuotaCard from './components/QuotaCard';
 import ActionButtons from './components/ActionButtons';
 import ThemeSelector, { ThemeName } from './components/ThemeSelector';
 import TabSwitcher, { TabName } from './components/TabSwitcher';
+import ClaudePanel from './components/ClaudePanel';
 import CodexPanel from './components/CodexPanel';
 import CursorPanel from './components/CursorPanel';
 import AntigravityPanel from './components/AntigravityPanel';
 import TrayToggles, { type TrayToggleEntry } from './components/TrayToggles';
-import CostSummarySection from './components/CostSummarySection';
 import { backend, hasTauriBackend } from './services/backend';
 import { SERVICE_META, SERVICES } from './services/service_meta';
 import {
@@ -115,27 +114,6 @@ function getInitialTrayEnabledState(): TrayEnabledState {
   return state;
 }
 
-function formatResetTime(resetTime?: string): string {
-  if (!resetTime) return 'N/A';
-  try {
-    const reset = new Date(resetTime);
-    const now = new Date();
-    const diff = reset.getTime() - now.getTime();
-    if (diff <= 0) return 'Soon';
-
-    const hours = Math.floor(diff / (1000 * 60 * 60));
-    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
-
-    if (hours > 24) {
-      const days = Math.floor(hours / 24);
-      return `${days}d ${hours % 24}h`;
-    }
-    return `${hours}h ${minutes}m`;
-  } catch {
-    return 'N/A';
-  }
-}
-
 export function getClaudeTrayUsedPercent(quota: QuotaData | null): number | null {
   if (!quota) return null;
 
@@ -147,6 +125,7 @@ export function getClaudeTrayUsedPercent(quota: QuotaData | null): number | null
     quota.weeklyOpus?.percentage,
     quota.weeklySonnet?.percentage,
     quota.weeklyDesign?.percentage,
+    quota.weeklyFable5?.percentage,
   ]
     .filter((value): value is number => typeof value === 'number');
   if (weeklyUsedCandidates.length > 0) {
@@ -606,94 +585,14 @@ export default function App() {
       <div className="container" ref={containerRef}>
         <div className="panel-scroll">
           {activeTab === 'claude' && (
-            <>
-              {claudeLoading && !quota && (
-                <div className="loading-state">Loading Claude quota...</div>
-              )}
-
-              {claudeError && (
-                <div className="error-banner">
-                  <span className="error-icon">!</span>
-                  <span className="error-text">{claudeError}</span>
-                </div>
-              )}
-
-              {!claudeError && quota && (
-                <div className="quota-list">
-                  <div className="section">
-                    <div className="section-title">
-                      CURRENT SESSION
-                      <span className="plan-tag">Claude Code</span>
-                    </div>
-                    {quota.session ? (
-                      <QuotaCard
-                        label="5-Hour Usage"
-                        percentage={Math.round(quota.session.percentage)}
-                        resetsIn={formatResetTime(quota.session.resetTime)}
-                      />
-                    ) : (
-                      <div className="no-data">No session data</div>
-                    )}
-                  </div>
-
-                  <div className="section">
-                    <div className="section-title">
-                      WEEKLY LIMITS
-                      <span className="plan-tag">Claude Code</span>
-                    </div>
-
-                    {quota.weeklyTotal && (
-                      <QuotaCard
-                        label="7-Day Usage"
-                        percentage={Math.round(quota.weeklyTotal.percentage)}
-                        resetsIn={formatResetTime(quota.weeklyTotal.resetTime)}
-                      />
-                    )}
-
-                    {quota.weeklyOpus && (
-                      <QuotaCard
-                        label="Opus (7-Day)"
-                        percentage={Math.round(quota.weeklyOpus.percentage)}
-                        resetsIn={formatResetTime(quota.weeklyOpus.resetTime)}
-                      />
-                    )}
-
-                    {quota.weeklySonnet && (
-                      <QuotaCard
-                        label="Sonnet (7-Day)"
-                        percentage={Math.round(quota.weeklySonnet.percentage)}
-                        resetsIn={formatResetTime(quota.weeklySonnet.resetTime)}
-                      />
-                    )}
-
-                    {quota.weeklyDesign && (
-                      <QuotaCard
-                        label="Claude Design (7-Day)"
-                        percentage={Math.round(quota.weeklyDesign.percentage)}
-                        resetsIn={formatResetTime(quota.weeklyDesign.resetTime)}
-                      />
-                    )}
-
-                    {!quota.weeklyTotal && !quota.weeklyOpus && !quota.weeklySonnet && !quota.weeklyDesign && (
-                      <div className="no-data">No weekly data</div>
-                    )}
-                  </div>
-
-                  {windowVisible && (
-                    <CostSummarySection source="claude" refreshKey={claudeCostRefreshNonce} />
-                  )}
-                </div>
-              )}
-
-              {!claudeError && !quota && !claudeLoading && (
-                <div className="empty-state">
-                  <p>Unable to load quota data</p>
-                  <button onClick={handleRefresh} className="retry-btn">
-                    Try Again
-                  </button>
-                </div>
-              )}
-            </>
+            <ClaudePanel
+              quota={quota}
+              loading={claudeLoading}
+              error={claudeError}
+              windowVisible={windowVisible}
+              costRefreshKey={claudeCostRefreshNonce}
+              onRetry={handleRefresh}
+            />
           )}
 
           <div style={{ display: activeTab === 'codex' ? 'block' : 'none' }}>

--- a/src/components/ClaudePanel.tsx
+++ b/src/components/ClaudePanel.tsx
@@ -1,0 +1,139 @@
+import CostSummarySection from './CostSummarySection';
+import QuotaCard from './QuotaCard';
+import type { QuotaData } from '../types/models';
+import { formatResetTime } from '../utils/quota_format';
+
+interface ClaudePanelProps {
+  quota: QuotaData | null;
+  loading: boolean;
+  error: string | null;
+  windowVisible: boolean;
+  costRefreshKey: number;
+  onRetry: () => void;
+}
+
+function formatClaudeResetTime(resetTime?: string): string {
+  return formatResetTime(resetTime, {
+    emptyLabel: 'N/A',
+    expiredLabel: 'Soon',
+    showZeroHours: true,
+  });
+}
+
+function hasWeeklyData(quota: QuotaData): boolean {
+  return Boolean(
+    quota.weeklyTotal ||
+      quota.weeklyOpus ||
+      quota.weeklySonnet ||
+      quota.weeklyDesign ||
+      quota.weeklyFable5,
+  );
+}
+
+export default function ClaudePanel({
+  quota,
+  loading,
+  error,
+  windowVisible,
+  costRefreshKey,
+  onRetry,
+}: ClaudePanelProps) {
+  return (
+    <>
+      {loading && !quota && (
+        <div className="loading-state">Loading Claude quota...</div>
+      )}
+
+      {error && (
+        <div className="error-banner">
+          <span className="error-icon">!</span>
+          <span className="error-text">{error}</span>
+        </div>
+      )}
+
+      {!error && quota && (
+        <div className="quota-list">
+          <div className="section">
+            <div className="section-title">
+              CURRENT SESSION
+              <span className="plan-tag">Claude Code</span>
+            </div>
+            {quota.session ? (
+              <QuotaCard
+                label="5-Hour Usage"
+                percentage={Math.round(quota.session.percentage)}
+                resetsIn={formatClaudeResetTime(quota.session.resetTime)}
+              />
+            ) : (
+              <div className="no-data">No session data</div>
+            )}
+          </div>
+
+          <div className="section">
+            <div className="section-title">
+              WEEKLY LIMITS
+              <span className="plan-tag">Claude Code</span>
+            </div>
+
+            {quota.weeklyTotal && (
+              <QuotaCard
+                label="7-Day Usage"
+                percentage={Math.round(quota.weeklyTotal.percentage)}
+                resetsIn={formatClaudeResetTime(quota.weeklyTotal.resetTime)}
+              />
+            )}
+
+            {quota.weeklyOpus && (
+              <QuotaCard
+                label="Opus (7-Day)"
+                percentage={Math.round(quota.weeklyOpus.percentage)}
+                resetsIn={formatClaudeResetTime(quota.weeklyOpus.resetTime)}
+              />
+            )}
+
+            {quota.weeklySonnet && (
+              <QuotaCard
+                label="Sonnet (7-Day)"
+                percentage={Math.round(quota.weeklySonnet.percentage)}
+                resetsIn={formatClaudeResetTime(quota.weeklySonnet.resetTime)}
+              />
+            )}
+
+            {quota.weeklyDesign && (
+              <QuotaCard
+                label="Claude Design (7-Day)"
+                percentage={Math.round(quota.weeklyDesign.percentage)}
+                resetsIn={formatClaudeResetTime(quota.weeklyDesign.resetTime)}
+              />
+            )}
+
+            {quota.weeklyFable5 && (
+              <QuotaCard
+                label="Fable 5 (7-Day)"
+                percentage={Math.round(quota.weeklyFable5.percentage)}
+                resetsIn={formatClaudeResetTime(quota.weeklyFable5.resetTime)}
+              />
+            )}
+
+            {!hasWeeklyData(quota) && (
+              <div className="no-data">No weekly data</div>
+            )}
+          </div>
+
+          {windowVisible && (
+            <CostSummarySection source="claude" refreshKey={costRefreshKey} />
+          )}
+        </div>
+      )}
+
+      {!error && !quota && !loading && (
+        <div className="empty-state">
+          <p>Unable to load quota data</p>
+          <button onClick={onRetry} className="retry-btn">
+            Try Again
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { backend } from '../services/backend';
 import CostSummarySection from './CostSummarySection';
 import type { CodexData, CodexRateLimits, CodexStats } from '../types/models';
-import { formatPlanType, getProgressStyle } from '../utils/quota_format';
+import { formatPlanType, formatResetTime, getProgressStyle } from '../utils/quota_format';
 
 interface CodexPanelProps {
   onConnectionChange?: (connected: boolean) => void;
@@ -38,28 +38,6 @@ function formatWindowLabel(minutes?: number): string {
     return `${hours}h`;
   }
   return `${minutes}m`;
-}
-
-function formatResetTime(resetAt?: number): string {
-  if (!resetAt) return '';
-  const date = new Date(resetAt * 1000);
-  const now = new Date();
-  const diffMs = date.getTime() - now.getTime();
-
-  if (diffMs <= 0) return 'now';
-
-  const diffMinutes = Math.max(1, Math.floor(diffMs / 60000));
-  if (diffMinutes < 60) return `${diffMinutes}m`;
-
-  const diffHours = Math.floor(diffMinutes / 60);
-  const remainingMinutes = diffMinutes % 60;
-  if (diffHours < 24) {
-    return remainingMinutes > 0 ? `${diffHours}h ${remainingMinutes}m` : `${diffHours}h`;
-  }
-
-  const diffDays = Math.floor(diffHours / 24);
-  const remainingHours = diffHours % 24;
-  return remainingHours > 0 ? `${diffDays}d ${remainingHours}h` : `${diffDays}d`;
 }
 
 function getTrayUsedPercent(limits: CodexRateLimits): number | null {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -12,6 +12,7 @@ export interface QuotaData {
   weeklyOpus?: UsageInfo;
   weeklySonnet?: UsageInfo;
   weeklyDesign?: UsageInfo;
+  weeklyFable5?: UsageInfo;
   error?: string;
 }
 

--- a/src/utils/quota_format.ts
+++ b/src/utils/quota_format.ts
@@ -5,6 +5,47 @@ export function formatPlanType(planType?: string, fallback = 'Unknown'): string 
   return planType.charAt(0).toUpperCase() + planType.slice(1);
 }
 
+interface ResetTimeFormatOptions {
+  emptyLabel?: string;
+  expiredLabel?: string;
+  showZeroHours?: boolean;
+}
+
+export function formatResetTime(
+  resetAt?: string | number,
+  options: ResetTimeFormatOptions = {},
+): string {
+  const { emptyLabel = '', expiredLabel = 'now', showZeroHours = false } = options;
+  if (!resetAt) return emptyLabel;
+
+  try {
+    const date = typeof resetAt === 'number'
+      ? new Date(resetAt * 1000)
+      : new Date(resetAt);
+    const diffMs = date.getTime() - Date.now();
+
+    if (!Number.isFinite(diffMs)) return emptyLabel;
+    if (diffMs <= 0) return expiredLabel;
+
+    const diffMinutes = Math.max(1, Math.floor(diffMs / 60000));
+    if (diffMinutes < 60) {
+      return showZeroHours ? `0h ${diffMinutes}m` : `${diffMinutes}m`;
+    }
+
+    const diffHours = Math.floor(diffMinutes / 60);
+    const remainingMinutes = diffMinutes % 60;
+    if (diffHours < 24) {
+      return remainingMinutes > 0 ? `${diffHours}h ${remainingMinutes}m` : `${diffHours}h`;
+    }
+
+    const diffDays = Math.floor(diffHours / 24);
+    const remainingHours = diffHours % 24;
+    return remainingHours > 0 ? `${diffDays}d ${remainingHours}h` : `${diffDays}d`;
+  } catch {
+    return emptyLabel;
+  }
+}
+
 export function getProgressColor(usedPercent: number): string {
   if (usedPercent >= 90) return '#ef4444';
   if (usedPercent >= 75) return '#f59e0b';

--- a/tests/claude_tray_percent.test.ts
+++ b/tests/claude_tray_percent.test.ts
@@ -20,6 +20,7 @@ describe('getClaudeTrayUsedPercent', () => {
       connected: true,
       weeklyTotal: usage(42),
       weeklyDesign: usage(91),
+      weeklyFable5: usage(96),
     })).toBe(42);
   });
 
@@ -30,6 +31,15 @@ describe('getClaudeTrayUsedPercent', () => {
       weeklyOpus: usage(36),
       weeklyDesign: usage(84),
     })).toBe(84);
+  });
+
+  test('includes Fable 5 in weekly bucket fallback', () => {
+    expect(getClaudeTrayUsedPercent({
+      connected: true,
+      session: usage(12),
+      weeklyOpus: usage(36),
+      weeklyFable5: usage(87),
+    })).toBe(87);
   });
 
   test('falls back to session usage when weekly buckets are missing', () => {


### PR DESCRIPTION
## Summary

- Add Claude Code weekly Fable 5 quota support through a new `weeklyFable5` field.
- Parse the likely Anthropic usage bucket aliases: `seven_day_fable5`, `seven_day_fable_5`, `seven_day_fable`, `seven_day_claude_fable5`, and `seven_day_claude_fable_5`.
- Split the Claude quota UI out of `App.tsx` into `ClaudePanel` so adding the new weekly card does not push `App.tsx` over the file-size guard.
- Reuse a shared reset-time formatter for Claude and Codex panels.

## Why

Claude Code has started surfacing Fable 5 usage in newer builds, but QuotaBar only modeled session, weekly total, Opus, Sonnet, and Claude Design buckets. When Anthropic returns a Fable 5 weekly bucket, the app should show it instead of dropping it silently.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npx tsc --noEmit`
- `npm test -- --run`
- `npm run tauri -- build --bundles app`

## Runtime note

A live Anthropic usage request on this machine still returned no Fable 5 bucket for the current account; the running app log shows the new parser logging `seven_day_fable5=None`. The UI will show the Fable 5 card once Anthropic includes one of the supported bucket names.
