### PR TITLE
feat: show Codex rate-limit reset credits

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,7 +2,8 @@ use tauri::{AppHandle, State};
 
 use crate::{
     domain::models::{
-        AntigravityData, CodexData, CodexRateLimits, CodexStats, CursorData, QuotaData,
+        AntigravityData, CodexData, CodexRateLimits, CodexResetCredits, CodexStats, CursorData,
+        QuotaData,
     },
     services::{antigravity, claude, codex, cost, cursor, link, tray, window},
 };
@@ -25,6 +26,11 @@ pub async fn get_codex_stats() -> Result<CodexStats, String> {
 #[tauri::command]
 pub async fn get_codex_rate_limits() -> Result<CodexRateLimits, String> {
     Ok(codex::fetch_codex_rate_limits().await)
+}
+
+#[tauri::command]
+pub async fn get_codex_reset_credits() -> Result<CodexResetCredits, String> {
+    Ok(codex::fetch_codex_reset_credits().await)
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -150,6 +150,36 @@ impl CodexRateLimits {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexResetCredit {
+    pub status: String,
+    pub title: Option<String>,
+    #[serde(rename = "grantedAt")]
+    pub granted_at: Option<String>,
+    #[serde(rename = "expiresAt")]
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexResetCredits {
+    pub connected: bool,
+    #[serde(rename = "availableCount")]
+    pub available_count: u32,
+    pub credits: Vec<CodexResetCredit>,
+    pub error: Option<String>,
+}
+
+impl CodexResetCredits {
+    pub fn disconnected(error: impl Into<String>) -> Self {
+        Self {
+            connected: false,
+            available_count: 0,
+            credits: Vec::new(),
+            error: Some(error.into()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CursorData {
     pub connected: bool,
     #[serde(rename = "planType")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
             commands::get_codex_info,
             commands::get_codex_stats,
             commands::get_codex_rate_limits,
+            commands::get_codex_reset_credits,
             commands::get_cursor_info,
             commands::get_antigravity_info,
             commands::get_cost_overview,

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -1,5 +1,6 @@
 use crate::domain::models::{
-    CodexCredits, CodexData, CodexRateLimitWindow, CodexRateLimits, CodexStats,
+    CodexCredits, CodexData, CodexRateLimitWindow, CodexRateLimits, CodexResetCredit,
+    CodexResetCredits, CodexStats,
 };
 use crate::services::http::{is_transient_os_error, shared_http_client};
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
@@ -399,10 +400,124 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
     limits
 }
 
+fn parse_reset_credit(credit: &serde_json::Value) -> Option<CodexResetCredit> {
+    Some(CodexResetCredit {
+        status: credit["status"].as_str()?.to_string(),
+        title: credit["title"].as_str().map(ToString::to_string),
+        granted_at: credit["granted_at"].as_str().map(ToString::to_string),
+        expires_at: credit["expires_at"].as_str().map(ToString::to_string),
+    })
+}
+
+pub async fn fetch_codex_reset_credits() -> CodexResetCredits {
+    let auth_json = match read_auth_json() {
+        Ok(v) => v,
+        Err(error) => return CodexResetCredits::disconnected(error),
+    };
+
+    let access_token = match auth_json["tokens"]["access_token"].as_str() {
+        Some(token) => token,
+        None => return CodexResetCredits::disconnected("No access_token found in auth.json"),
+    };
+
+    let account_id = auth_json["tokens"]["id_token"]
+        .as_str()
+        .and_then(decode_jwt_payload)
+        .and_then(|payload| {
+            payload["https://api.openai.com/auth"]["chatgpt_account_id"]
+                .as_str()
+                .map(ToString::to_string)
+        });
+
+    let client = shared_http_client();
+    let mut request = client
+        .get("https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")
+        .header("Authorization", format!("Bearer {access_token}"))
+        .header("User-Agent", "codex-cli")
+        .timeout(std::time::Duration::from_secs(10));
+
+    if let Some(account_id) = account_id {
+        request = request.header("ChatGPT-Account-Id", account_id);
+    }
+
+    let response = match request.send().await {
+        Ok(resp) => resp,
+        Err(err) => return CodexResetCredits::disconnected(format!("Network error: {err}")),
+    };
+
+    if response.status().as_u16() == 401 || response.status().as_u16() == 403 {
+        return CodexResetCredits::disconnected("Token expired. Please run 'codex' to re-login.");
+    }
+
+    if !response.status().is_success() {
+        return CodexResetCredits::disconnected(format!("API error: {}", response.status()));
+    }
+
+    let data = match response.json::<serde_json::Value>().await {
+        Ok(data) => data,
+        Err(err) => {
+            return CodexResetCredits::disconnected(format!("Failed to parse response: {err}"))
+        }
+    };
+
+    let credits: Vec<CodexResetCredit> = data["credits"]
+        .as_array()
+        .map(|items| items.iter().filter_map(parse_reset_credit).collect())
+        .unwrap_or_default();
+
+    let available_count = data["available_count"]
+        .as_u64()
+        .map(|count| count.min(u32::MAX as u64) as u32)
+        .unwrap_or_else(|| {
+            credits
+                .iter()
+                .filter(|credit| credit.status == "available")
+                .count() as u32
+        });
+
+    CodexResetCredits {
+        connected: true,
+        available_count,
+        credits,
+        error: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::parse_rate_limit_window;
+    use super::{parse_rate_limit_window, parse_reset_credit};
     use serde_json::json;
+
+    #[test]
+    fn parse_reset_credit_requires_status() {
+        assert!(parse_reset_credit(&json!({ "title": "Full reset" })).is_none());
+    }
+
+    #[test]
+    fn parse_reset_credit_maps_summary_fields_only() {
+        let parsed = parse_reset_credit(&json!({
+            "id": "credit-secret-id",
+            "status": "available",
+            "title": "Full reset (Weekly + 5 hr)",
+            "granted_at": "2026-06-18T00:41:07.776451Z",
+            "expires_at": "2026-07-18T00:41:07.776451Z"
+        }));
+        let credit = match parsed {
+            Some(credit) => credit,
+            None => panic!("credit with status should parse"),
+        };
+
+        assert_eq!(credit.status, "available");
+        assert_eq!(credit.title.as_deref(), Some("Full reset (Weekly + 5 hr)"));
+        assert_eq!(
+            credit.granted_at.as_deref(),
+            Some("2026-06-18T00:41:07.776451Z")
+        );
+        assert_eq!(
+            credit.expires_at.as_deref(),
+            Some("2026-07-18T00:41:07.776451Z")
+        );
+    }
 
     #[test]
     fn parse_rate_limit_window_requires_numeric_used_percent() {

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { backend } from '../services/backend';
 import CostSummarySection from './CostSummarySection';
-import type { CodexData, CodexRateLimits, CodexStats } from '../types/models';
+import type { CodexData, CodexRateLimits, CodexResetCredits, CodexStats } from '../types/models';
 import { formatPlanType, formatResetTime, getProgressStyle } from '../utils/quota_format';
 
 interface CodexPanelProps {
@@ -25,6 +25,19 @@ function formatSubscriptionDate(dateStr?: string): string {
   } catch {
     return dateStr;
   }
+}
+
+function formatCreditDate(dateStr?: string): string {
+  if (!dateStr) return 'Unknown';
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return dateStr;
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }
 
 function formatWindowLabel(minutes?: number): string {
@@ -61,6 +74,7 @@ export default function CodexPanel({
   const [codexData, setCodexData] = useState<CodexData | null>(null);
   const [codexStats, setCodexStats] = useState<CodexStats | null>(null);
   const [rateLimits, setRateLimits] = useState<CodexRateLimits | null>(null);
+  const [resetCredits, setResetCredits] = useState<CodexResetCredits | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -69,15 +83,17 @@ export default function CodexPanel({
       setLoading(true);
       setError(null);
 
-      const [info, stats, limits] = await Promise.all([
+      const [info, stats, limits, credits] = await Promise.all([
         backend.getCodexInfo(),
         backend.getCodexStats(),
         backend.getCodexRateLimits(),
+        backend.getCodexResetCredits(),
       ]);
 
       setCodexData(info);
       setCodexStats(stats);
       setRateLimits(limits);
+      setResetCredits(credits);
 
       if (limits.error) {
         setError(limits.error);
@@ -216,6 +232,29 @@ export default function CodexPanel({
                   </div>
                 </div>
               )}
+            </div>
+          )}
+
+          {/* Rate-limit Reset Credits Section */}
+          {resetCredits?.connected && resetCredits.availableCount > 0 && (
+            <div className="section">
+              <div className="section-title">
+                RESET CREDITS
+                <span className="plan-tag">{resetCredits.availableCount} available</span>
+              </div>
+              {resetCredits.credits
+                .filter((credit) => credit.status === 'available')
+                .sort((a, b) => (a.expiresAt ?? '').localeCompare(b.expiresAt ?? ''))
+                .map((credit, index) => (
+                  <div className="quota-card" key={`${credit.expiresAt ?? 'unknown'}-${index}`}>
+                    <div className="quota-header">
+                      <span className="quota-label">{credit.title ?? 'Rate limit reset'}</span>
+                    </div>
+                    <div className="reset-time">
+                      Expires {formatCreditDate(credit.expiresAt)}
+                    </div>
+                  </div>
+                ))}
             </div>
           )}
 

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -3,6 +3,7 @@ import type {
   AntigravityData,
   CodexData,
   CodexRateLimits,
+  CodexResetCredits,
   CodexStats,
   CostOverview,
   CostSource,
@@ -41,6 +42,10 @@ export const backend = {
 
   getCodexRateLimits() {
     return invokeBackend<CodexRateLimits>('get_codex_rate_limits');
+  },
+
+  getCodexResetCredits() {
+    return invokeBackend<CodexResetCredits>('get_codex_reset_credits');
   },
 
   getCursorInfo() {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -52,6 +52,20 @@ export interface CodexRateLimits {
   error?: string;
 }
 
+export interface CodexResetCredit {
+  status: string;
+  title?: string;
+  grantedAt?: string;
+  expiresAt?: string;
+}
+
+export interface CodexResetCredits {
+  connected: boolean;
+  availableCount: number;
+  credits: CodexResetCredit[];
+  error?: string;
+}
+
 export interface CursorData {
   connected: boolean;
   planType?: string;


### PR DESCRIPTION
## What

Adds a **RESET CREDITS** section to the Codex panel showing rate-limit reset credits (the free "Full reset (Weekly + 5 hr)" grants) from `chatgpt.com/backend-api/wham/rate-limit-reset-credits`.

- Reuses the existing `~/.codex/auth.json` access token + JWT-decoded account id, same as `wham/usage`
- New `get_codex_reset_credits` Tauri command / `fetch_codex_reset_credits()` service
- Panel shows available count and each credit's title + expiry converted to local time, sorted by expiry; section is hidden when no credits are available
- Only summary fields (status/title/granted_at/expires_at) cross the boundary — credit ids, user ids, and tokens are never exposed
- 401/403 maps to the existing "Token expired" re-login hint

## Verification

- Live endpoint tested locally: HTTP 200, credits parsed correctly
- `cargo check` + `cargo test` pass (2 new parser unit tests)
- `tsc --noEmit` and `bun run test` (17 tests) pass