### PR TITLE
docs: spec QuotaBar UI redesign

### DIFF
--- a/specs/GH16/product.md
+++ b/specs/GH16/product.md
@@ -1,0 +1,35 @@
+# GH-16 Product Spec: macOS Glass Popover Shell and Provider Overview
+
+Linked issue: https://github.com/majiayu000/quotabar/issues/16
+
+## Goals
+
+- Make QuotaBar's main popover match the redesign package's macOS glass shell: translucent surface, blur/saturation, 16px-class radius, hairline edge, highlight overlay, and dense menubar-app spacing.
+- Add an overview-first provider experience that summarizes Claude, Codex, Cursor, and Antigravity before drilling into a provider detail panel.
+- Show provider identity with stable service metadata: icon or initials, brand color, status, usage percentage, and empty/offline state.
+- Preserve current QuotaBar behavior: tray activation switches tabs, manual refresh targets the active provider, dashboard opens the active provider, quit still exits the app, and tray visibility guard still prevents disabling every tray.
+
+## Non-Goals
+
+- Do not implement detailed provider quota rows, upcoming resets, tips, local cost redesign, settings view, desktop widget, or notification runtime behavior in this issue.
+- Do not change backend quota, cost, tray, or auth response contracts.
+- Do not seed demo usage values in production UI. Missing data must render as blank, offline, pending, or `--`, not `0%`.
+- Do not remove or regress PR #15 Codex reset credits. This issue may ship before #15, but it must not make the later Bonus resets integration harder.
+
+## Acceptance Criteria
+
+- The app shell visually matches the redesign direction in light and dark themes without a solid white rectangular background.
+- Provider navigation includes an `Overview` state plus Claude, Codex, Cursor, and Antigravity.
+- Provider summary tiles display real connected/loading/offline status and a real usage percentage when available; no-data states do not invent values.
+- The overview lists the most constrained real quota windows, sorted by highest used percentage, with provider/window label, percent, and reset text when available.
+- Existing provider panels still open from provider selection without losing current quota, cost, loading, retry, or error behavior.
+- Browser preview without a Tauri backend still communicates backend-unavailable state and does not show fake provider usage.
+- If the popover width changes from the current 320px toward the redesign's 340px shell, Tauri window sizing and preview docs are updated consistently.
+
+## Verification
+
+- `npx tsc --noEmit`
+- `npm test`
+- `npm run build`
+- If Tauri sizing/window code changes: `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`
+- Attach a browser or Tauri screenshot to the implementation PR.

--- a/specs/GH16/tasks.md
+++ b/specs/GH16/tasks.md
@@ -1,0 +1,14 @@
+# GH-16 Tasks
+
+## Implementation Tasks
+
+- [x] `UI16-T1` Owner: codex. Done when: GitHub issue #16 and this SpecRail packet define the shell/overview scope. Verify: `find specs/GH16 -maxdepth 1 -type f -print`.
+- [ ] `UI16-T2` Owner: codex. Done when: app shell uses redesign glass surface tokens without a solid rectangular backing. Verify: visual screenshot plus `rg -n "glass|backdrop-filter|provider-overview|overview" src`.
+- [ ] `UI16-T3` Owner: codex. Done when: tab state supports `overview` and concrete provider tabs without breaking tray activation. Verify: `npx tsc --noEmit` and targeted tests if helpers are extracted.
+- [ ] `UI16-T4` Owner: codex. Done when: provider summary tiles render real connected/loading/offline/no-data states for all services. Verify: browser preview with no Tauri backend and at least one connected-provider manual check.
+- [ ] `UI16-T5` Owner: codex. Done when: overview most-constrained rows are derived from real data only and sorted by used percentage. Verify: unit tests for sorting/no-data behavior if helper is extracted.
+- [ ] `UI16-T6` Owner: codex. Done when: project verification passes. Verify: `npx tsc --noEmit && npm test && npm run build`.
+
+## Handoff Notes
+
+This should be the first implementation PR in the UI redesign stack. Do not merge it into PR #15. If PR #15 is still open, keep this branch based on `main` and record that GH-17 has the reset-credit dependency.

--- a/specs/GH16/tech.md
+++ b/specs/GH16/tech.md
@@ -1,0 +1,62 @@
+# GH-16 Tech Spec: macOS Glass Popover Shell and Provider Overview
+
+## Proposed Design
+
+Build this as the first implementation PR in the UI redesign stack. It should start from `main` or from a branch that already contains any merged prerequisite UI/spec work, but it must not be based on the open PR #15 unless the implementation deliberately becomes a stacked PR.
+
+### App Shell
+
+- Update the React/CSS shell around `src/App.tsx` and `src/styles.css` to provide the glass popover surface.
+- Keep the app root transparent so the Tauri popover does not show a white rectangular backing.
+- Use CSS custom properties for glass surface, hairline edge, text colors, service accents, and progress colors so later provider detail and settings PRs can reuse the same theme tokens.
+- Keep scroll and height behavior compatible with the existing resize cap. The popover should remain usable in a menubar context, not become a full landing page.
+
+### Overview State
+
+- Extend tab state to include `overview` while preserving `TrayServiceName` for actual tray service IDs.
+- Tray activation events should still select the concrete provider tab.
+- The default tab can remain the saved provider when valid, but a new install should prefer `overview` if that does not disrupt tray activation.
+- Persist the new tab value only if it is explicitly supported by the tab storage validation.
+
+### Provider Summary Model
+
+Create a small frontend summary model derived from existing state:
+
+- Claude: `getClaudeTrayUsedPercent(quota)` plus session/weekly reset labels when present.
+- Codex/Cursor: callback-reported `usedPercent`, `connected`, and `loading`.
+- Antigravity: connected/pending state, with no usage percentage unless a real backend value exists.
+
+The summary model must distinguish:
+
+- `number` usage percentage
+- `null` no data
+- disconnected/offline
+- loading/syncing
+
+No UI path may coerce no-data to `0`.
+
+### Likely Files
+
+- `src/App.tsx`
+- `src/components/TabSwitcher.tsx`
+- `src/services/service_meta.ts`
+- `src/styles.css`
+- Potentially `src-tauri/src/services/window.rs` and docs if width/sizing changes.
+
+## Dependency Notes
+
+- GH-17 will reuse the overview summary and glass tokens, so keep names stable and avoid one-off CSS.
+- GH-18 will reuse the footer/settings shell, so avoid moving settings into a shape that blocks a settings view.
+- GH-19 may reuse the same provider summary data for static preview/widget design.
+
+## Test Plan
+
+- Unit-test pure summary helpers if they are extracted.
+- `npx tsc --noEmit`
+- `npm test`
+- `npm run build`
+- If Tauri window dimensions/config change: `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`
+
+## Rollback Plan
+
+Revert the GH-16 implementation PR. Because this issue should not change backend contracts, rollback should restore the previous shell/provider switcher without data migration.

--- a/specs/GH17/product.md
+++ b/specs/GH17/product.md
@@ -1,0 +1,35 @@
+# GH-17 Product Spec: Provider Detail Panels, Resets, Tips, and Cost Cards
+
+Linked issue: https://github.com/majiayu000/quotabar/issues/17
+
+## Goals
+
+- Redesign active provider detail panels to match the package's main view: provider header, plan/status, quota sections, progress rows, reset copy, smart tips, upcoming resets, and local cost cards.
+- Preserve current provider semantics for Claude, Codex, Cursor, and Antigravity.
+- Present Codex rate-limit reset credits from PR #15 as the design's Bonus resets/Gifted section.
+- Keep local cost summaries for Claude, Codex, and Cursor, while making unsupported Antigravity cost/quota states explicit.
+
+## Non-Goals
+
+- Do not change ccstats calculations, pricing policy, auth handling, or backend response shapes except where PR #15 already adds reset credits.
+- Do not implement the settings view, tray controls redesign, desktop widget, or native notifications.
+- Do not silently hide backend/frontend errors.
+- Do not directly overwrite current `CodexPanel.tsx` with the zip snapshot, because that snapshot is based on `origin/main` and would remove PR #15 reset credits.
+
+## Acceptance Criteria
+
+- Claude, Codex, Cursor, and Antigravity detail panels use the redesign visual structure while retaining their current loading, error, retry, and no-data behavior.
+- Codex Bonus resets shows available reset credits from PR #15 with available count, available-only filtering, title fallback, expiry text, and stable expiry ordering.
+- Generic Codex credits and Bonus resets remain separate concepts in the UI.
+- Upcoming resets uses real reset timestamps from provider data where available and omits unsupported rows.
+- Smart tips are derived from real high-usage states or are hidden; no demo copy appears in production for missing data.
+- Local cost cards keep Today, This Week, and This Month semantics and continue to display cached/error/loading states correctly.
+- Missing quota/cost data renders as blank, offline, pending, or `--`, not fake `0%`.
+
+## Verification
+
+- `npx tsc --noEmit`
+- `npm test`
+- `npm run build`
+- If PR #15 backend contracts are included or modified: `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`
+- Manual check with Codex reset credits data if available, or mocked frontend fixture without exposing tokens/account data.

--- a/specs/GH17/tasks.md
+++ b/specs/GH17/tasks.md
@@ -1,0 +1,15 @@
+# GH-17 Tasks
+
+## Implementation Tasks
+
+- [x] `UI17-T1` Owner: codex. Done when: GitHub issue #17 and this SpecRail packet define detail panel scope and PR #15 dependency. Verify: `find specs/GH17 -maxdepth 1 -type f -print`.
+- [ ] `UI17-T2` Owner: codex. Done when: implementation base decision is recorded: updated `main` after PR #15 merge, stacked on PR #15, or Bonus resets deferred with explicit follow-up. Verify: PR body includes the decision.
+- [ ] `UI17-T3` Owner: codex. Done when: provider detail panels share redesign row/card structure without losing provider-specific data semantics. Verify: `npx tsc --noEmit`.
+- [ ] `UI17-T4` Owner: codex. Done when: Codex Bonus resets preserves PR #15 reset credits and does not mix them with generic Codex credits. Verify: targeted frontend tests or screenshot/fixture evidence.
+- [ ] `UI17-T5` Owner: codex. Done when: upcoming resets and smart tips use real data only and omit missing/unsupported data. Verify: unit tests for helper functions if extracted.
+- [ ] `UI17-T6` Owner: codex. Done when: local cost redesign preserves loading/error/cached/refresh semantics. Verify: `npm test`.
+- [ ] `UI17-T7` Owner: codex. Done when: project verification passes. Verify: `npx tsc --noEmit && npm test && npm run build`.
+
+## Handoff Notes
+
+This is likely the highest-conflict UI PR because it touches panels and `src/styles.css`. Do not run it in parallel with GH-18 writable work unless file ownership is split or one branch is stacked after the other.

--- a/specs/GH17/tech.md
+++ b/specs/GH17/tech.md
@@ -1,0 +1,89 @@
+# GH-17 Tech Spec: Provider Detail Panels, Resets, Tips, and Cost Cards
+
+## Proposed Design
+
+Implement after GH-16 shell/overview is stable. This work should be a separate implementation PR because it touches shared panel and cost components.
+
+## PR #15 Dependency
+
+GH-17 depends on the Codex reset-credit data contract from PR #15:
+
+- `CodexResetCredits`
+- `backend.getCodexResetCredits()`
+- `get_codex_reset_credits` Tauri command
+- Codex service parser for `wham/rate-limit-reset-credits`
+
+If PR #15 is merged before GH-17 starts, base GH-17 on updated `main`. If PR #15 is still open, choose one explicitly:
+
+- create GH-17 as a stacked PR on `feat/codex-reset-credits`, or
+- implement all non-reset-credit detail work and leave Bonus resets disabled behind a clearly documented follow-up.
+
+Do not silently remove the reset-credit fetch or types.
+
+## Detail Panel Structure
+
+Use shared presentational pieces where they reduce duplication:
+
+- provider detail header
+- quota section
+- quota progress row
+- reset timeline row
+- tip card
+- bonus reset row
+- local cost card grid
+- empty/offline panel state
+
+Shared components must accept explicit no-data states instead of converting absent data into numeric zero.
+
+## Upcoming Resets
+
+Build a frontend-only timeline from existing provider data:
+
+- Claude session and weekly reset timestamps where present.
+- Codex primary/secondary reset timestamps where present.
+- Cursor reset timestamp where present.
+- Antigravity pending state omitted unless real reset data exists later.
+
+Timeline rows should sort by reset time and omit invalid/missing timestamps.
+
+## Smart Tips
+
+Tips should be conservative:
+
+- show only for real high-usage thresholds, such as a row over an agreed threshold;
+- hide when data is missing or provider is disconnected;
+- avoid implying routing advice when the app cannot know available alternatives.
+
+## Local Cost Cards
+
+`CostSummarySection` should keep the existing backend contract and refresh behavior:
+
+- active-provider fetch only where currently intended;
+- forced refresh on manual refresh;
+- string errors preserved;
+- cached state visible.
+
+## Likely Files
+
+- `src/components/ClaudePanel.tsx`
+- `src/components/CodexPanel.tsx`
+- `src/components/CursorPanel.tsx`
+- `src/components/AntigravityPanel.tsx`
+- `src/components/QuotaCard.tsx`
+- `src/components/CostSummarySection.tsx`
+- `src/types/models.ts`
+- `src/services/backend.ts`
+- `src/styles.css`
+
+## Test Plan
+
+- Unit-test pure timeline/sorting/tip helpers if extracted.
+- Unit-test string error preservation if `CostSummarySection` is changed.
+- `npx tsc --noEmit`
+- `npm test`
+- `npm run build`
+- If backend reset-credit code is touched: `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`
+
+## Rollback Plan
+
+Revert the GH-17 implementation PR. If it is stacked on PR #15, rollback must preserve the reset-credit branch and only remove detail redesign changes.

--- a/specs/GH18/product.md
+++ b/specs/GH18/product.md
@@ -1,0 +1,35 @@
+# GH-18 Product Spec: Settings View, Tray Controls, and Footer Actions
+
+Linked issue: https://github.com/majiayu000/quotabar/issues/18
+
+## Goals
+
+- Redesign the settings experience from the current compact foldout into a settings view or equivalent compact panel matching the design package.
+- Preserve and polish existing settings: theme, macOS Hide Dock, and per-provider tray toggles.
+- Keep the at-least-one-tray-enabled guard visible and reliable.
+- Redesign bottom actions to match the design footer while keeping Refresh, Dashboard, and Quit behavior scoped to the active provider/app.
+- Leave space for future panel section and notification settings without presenting unsupported controls as functional.
+
+## Non-Goals
+
+- Do not implement native notification scheduling or quota threshold alerts in this issue.
+- Do not change backend tray command protocols.
+- Do not modify high-context workflow files such as `AGENTS.md`, `WORKFLOW.md`, hooks, or settings files.
+- Do not create fake settings that appear to work but are not wired to state or backend behavior.
+
+## Acceptance Criteria
+
+- Settings UI is usable within the menubar popover height and 320-340px width constraints, without overlapping text or footer controls.
+- Theme selection, Hide Dock, settings expanded/view state, and tray visibility continue to persist with existing storage keys unless a migration is explicitly documented.
+- Tray toggles list all services and still prevent disabling the final enabled tray.
+- Footer actions operate on the active provider: refresh active data, open active dashboard, quit app.
+- Loading/disabled states are visible and accessible.
+- Tray activation event still switches to the selected provider.
+- Any future-looking settings are either hidden, disabled with clear text, or implemented end-to-end.
+
+## Verification
+
+- `npx tsc --noEmit`
+- `npm test`
+- `npm run build`
+- Manual checks for theme persistence, Hide Dock on macOS, tray toggles, final-tray guard toast, active-provider refresh/dashboard, and quit behavior.

--- a/specs/GH18/tasks.md
+++ b/specs/GH18/tasks.md
@@ -1,0 +1,14 @@
+# GH-18 Tasks
+
+## Implementation Tasks
+
+- [x] `UI18-T1` Owner: codex. Done when: GitHub issue #18 and this SpecRail packet define settings/footer scope. Verify: `find specs/GH18 -maxdepth 1 -type f -print`.
+- [ ] `UI18-T2` Owner: codex. Done when: settings view or compact panel preserves theme, Hide Dock, and current storage keys. Verify: `npx tsc --noEmit` and manual persistence check.
+- [ ] `UI18-T3` Owner: codex. Done when: tray toggles preserve per-service enablement and final-tray guard. Verify: targeted tests if helper logic changes, plus manual guard check.
+- [ ] `UI18-T4` Owner: codex. Done when: footer actions match active-provider behavior and loading states. Verify: manual active-tab refresh/dashboard checks.
+- [ ] `UI18-T5` Owner: codex. Done when: unsupported future settings are not shipped as working controls. Verify: PR review against visible controls.
+- [ ] `UI18-T6` Owner: codex. Done when: project verification passes. Verify: `npx tsc --noEmit && npm test && npm run build`.
+
+## Handoff Notes
+
+GH-18 should not run as a parallel writable implementation with GH-17 because both touch `App.tsx` and `styles.css`. Use a stacked PR or wait for the earlier UI implementation branch to stabilize.

--- a/specs/GH18/tech.md
+++ b/specs/GH18/tech.md
@@ -1,0 +1,66 @@
+# GH-18 Tech Spec: Settings View, Tray Controls, and Footer Actions
+
+## Proposed Design
+
+Implement after GH-16 shell work, and coordinate with GH-17 because both touch `src/App.tsx` and `src/styles.css`.
+
+## Settings State
+
+Preserve existing storage keys unless the implementation includes a documented migration:
+
+- `claude-quota-theme`
+- `claude-quota-dock-hidden`
+- `claude-quota-tab`
+- `claude-quota-settings-expanded`
+- per-provider tray visibility keys from `src/services/tray_visibility.ts`
+
+The settings view can be represented as a local UI mode, separate from provider tabs, so tray activation and provider tab persistence remain stable.
+
+## Tray Controls
+
+Continue using `getSavedTrayEnabled`, `saveTrayEnabled`, and `shouldShowTray`.
+
+The guard behavior remains:
+
+- at least one service remains enabled;
+- blocked disable attempt leaves state unchanged;
+- user receives visible toast/message.
+
+Do not reinterpret disconnected services as disabled. Enabled-but-disconnected is still a meaningful tray preference.
+
+## Footer Actions
+
+Footer actions should call the existing app handlers:
+
+- refresh active provider and active cost summary where supported;
+- open active provider dashboard;
+- quit app.
+
+If provider panels keep internal dashboard buttons, the implementation must decide whether to remove duplicates or keep both intentionally. The PR body should record the decision.
+
+## Future Settings
+
+Design package includes menu bar style, panel sections, notifications, recent events, and cycle-one-icon controls. This issue may add layout affordances for them only if they are disabled or fully wired. Do not ship interactive controls without behavior.
+
+## Likely Files
+
+- `src/App.tsx`
+- `src/components/ActionButtons.tsx`
+- `src/components/TabSwitcher.tsx`
+- `src/components/ThemeSelector.tsx`
+- `src/components/TrayToggles.tsx`
+- `src/services/service_meta.ts`
+- `src/services/tray_visibility.ts`
+- `src/styles.css`
+
+## Test Plan
+
+- Unit-test any extracted localStorage or settings-mode helpers.
+- `npx tsc --noEmit`
+- `npm test`
+- `npm run build`
+- Manual Tauri check for dock visibility and quit behavior.
+
+## Rollback Plan
+
+Revert the GH-18 implementation PR. Existing localStorage keys should continue to work because this issue should not require a destructive settings migration.

--- a/specs/GH19/product.md
+++ b/specs/GH19/product.md
@@ -1,0 +1,31 @@
+# GH-19 Product Spec: Desktop Widget, Notification, and Preview Assets
+
+Linked issue: https://github.com/majiayu000/quotabar/issues/19
+
+## Goals
+
+- Bring the redesign package's desktop widget, notification mock, menu bar state, and no-provider preview into the repository as clear product/design assets.
+- Update documentation previews to reflect the new UI direction while preserving the no-secret demo proof contract.
+- Explicitly separate static preview/mock assets from runtime desktop widget or native notification functionality.
+- Document how screenshots/assets were captured or generated so they can be refreshed.
+
+## Non-Goals
+
+- Do not implement a real macOS desktop widget, second Tauri window, or native notification scheduler unless this issue is explicitly expanded in a later implementation PR.
+- Do not add account identifiers, tokens, cookies, sessions, or real private usage data to committed screenshots.
+- Do not change quota/cost business logic.
+- Do not present widget or notification mocks as shipped runtime features.
+
+## Acceptance Criteria
+
+- README/docs show redesign-aligned preview assets with clear captions and privacy scope.
+- Assets are stored under stable, intentional paths and exclude unused export clutter.
+- If desktop widget/notification remain mocks, docs say they are previews, not current runtime features.
+- The old red-marked header treatment from `uploads/pasted-1783093579022-0.png` is not used as target UI.
+- Preview image(s) contain no secrets and no fake live account data.
+- If runtime notifications are later included under this issue, denied/unavailable permission states are visible and errors are not silently swallowed.
+
+## Verification
+
+- `npm test` or documented static/docs verification.
+- If runtime Tauri notification/window code is added: `cargo check --manifest-path src-tauri/Cargo.toml`, `cargo test --manifest-path src-tauri/Cargo.toml`, `npx tsc --noEmit`, and `npm test`.

--- a/specs/GH19/tasks.md
+++ b/specs/GH19/tasks.md
@@ -1,0 +1,14 @@
+# GH-19 Tasks
+
+## Implementation Tasks
+
+- [x] `UI19-T1` Owner: codex. Done when: GitHub issue #19 and this SpecRail packet define assets/runtime boundaries. Verify: `find specs/GH19 -maxdepth 1 -type f -print`.
+- [ ] `UI19-T2` Owner: codex. Done when: required redesign preview assets are copied into stable docs/assets paths without unused export clutter. Verify: `find docs/assets -maxdepth 2 -type f -print`.
+- [ ] `UI19-T3` Owner: codex. Done when: README/docs distinguish current screenshots from static mock previews and document privacy scope. Verify: docs review.
+- [ ] `UI19-T4` Owner: codex. Done when: screenshot refresh steps are documented. Verify: `rg -n "screenshot|preview|capture|privacy" README.md docs`.
+- [ ] `UI19-T5` Owner: codex. Done when: any runtime notification/widget expansion has explicit capability, permission, error, dedupe, and verification coverage. Verify: PR checklist if runtime code is included.
+- [ ] `UI19-T6` Owner: codex. Done when: verification passes. Verify: `npm test` for docs/assets-only, or full frontend/Rust checks if runtime code is touched.
+
+## Handoff Notes
+
+Default implementation is docs/assets only. A real desktop widget or native notification system should be split into its own implementation PR unless the product scope is explicitly expanded.

--- a/specs/GH19/tech.md
+++ b/specs/GH19/tech.md
@@ -1,0 +1,57 @@
+# GH-19 Tech Spec: Desktop Widget, Notification, and Preview Assets
+
+## Proposed Design
+
+Treat this issue as documentation/assets first. Runtime widget/notification behavior must be a deliberate follow-up or an explicit expansion of the implementation PR.
+
+## Asset Handling
+
+Use only assets needed by the repo:
+
+- redesign preview screenshot(s)
+- no-provider browser preview replacement, if updated
+- service icons if licensing/source policy is acceptable
+
+Avoid committing design-tool support files such as `support.js` or full HTML exports unless they are explicitly needed for documentation.
+
+## Documentation
+
+Update docs to state:
+
+- which previews are current app screenshots;
+- which previews are static design mocks;
+- that no provider credentials, account identifiers, tokens, cookies, or sessions are included;
+- how to refresh the screenshots.
+
+Existing files likely involved:
+
+- `README.md`
+- `docs/demo-proof.md`
+- `docs/assets/*`
+
+## Runtime Notification or Widget Expansion
+
+If this issue is expanded to include runtime notifications:
+
+- choose and configure a Tauri notification capability/dependency explicitly;
+- request/check permissions and show denied/unavailable errors;
+- deduplicate notifications by provider/window/threshold;
+- never notify from missing or demo data;
+- add settings only if wired end-to-end.
+
+If this issue is expanded to include a real desktop widget:
+
+- define whether it is a second Tauri window, a platform widget, or an app-owned floating panel;
+- specify lifecycle, positioning, hide/show behavior, and interaction with the menubar popover;
+- keep provider summary data shared with GH-16.
+
+## Test Plan
+
+- Static/docs diff review for asset paths and captions.
+- `npm test` if docs/static changes do not affect code.
+- `npx tsc --noEmit && npm test` if frontend code is touched.
+- Add Rust checks/tests if Tauri runtime behavior is added.
+
+## Rollback Plan
+
+Revert the GH-19 implementation PR. Because docs/assets should not change runtime behavior by default, rollback is expected to be low risk unless runtime notification/widget code is added.


### PR DESCRIPTION
## What

Adds SpecRail packets for the QuotaBar UI redesign from `/Users/apple/Downloads/Quotabar UI optimization.zip`.

Created and links these issues:

- #16 UI redesign: macOS glass popover shell and provider overview
- #17 UI redesign: provider detail panels, resets, tips, and cost cards
- #18 UI redesign: settings view, tray controls, and footer actions
- #19 UI redesign: desktop widget, notification, and preview assets

## Scope

This is spec-only. It does not change product code.

The specs intentionally keep implementation PRs separate because the redesign shares `App.tsx` and `styles.css` across multiple areas. GH-17 explicitly records the dependency on PR #15 so Codex reset credits are preserved and presented as Bonus resets instead of being removed by the older zip source snapshot.

## Threads evidence

Used native Codex threads for read-only planning:

- design planner: inspected the design HTML/images and identified shell, overview, widget, notification, and asset boundaries
- integration planner: inspected current UI and PR #15 impact, identifying reset-credit dependency and shared-file conflict risks

Both lanes were read-only and closed after results were integrated.

## Verification

- `npm ci`
- `npx tsc --noEmit`
- `npm test` (5 files, 17 tests)
- `git diff --cached --check`

## Implementation order proposed

1. #16 shell + overview
2. #17 provider details + Bonus resets, after PR #15 is merged or as an explicit stacked PR
3. #18 settings/footer after #16/#17 shared layout stabilizes
4. #19 docs/assets by default; runtime widget/notifications only if explicitly expanded