### PR TITLE
feat: redesign provider detail panels

### DIFF
--- a/src/components/AntigravityPanel.tsx
+++ b/src/components/AntigravityPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { backend } from '../services/backend';
 import type { AntigravityData } from '../types/models';
+import ProviderDetailHeader from './ProviderDetailHeader';
 
 interface AntigravityPanelProps {
   onConnectionChange?: (connected: boolean) => void;
@@ -25,7 +26,9 @@ export default function AntigravityPanel({
       const info = await backend.getAntigravityInfo();
       setData(info);
       onConnectionChange?.(info.connected);
-    } catch {
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load Antigravity status';
+      setData({ connected: false, status: 'error', error: message });
       onConnectionChange?.(false);
     } finally {
       setLoading(false);
@@ -60,6 +63,13 @@ export default function AntigravityPanel({
 
   return (
     <div className="codex-panel">
+      <ProviderDetailHeader
+        service="antigravity"
+        status={data?.connected ? 'Preview' : 'Pending'}
+        plan="Antigravity"
+        usedPercent={null}
+      />
+
       <div className="section">
         <div className="section-title">
           ANTIGRAVITY
@@ -78,6 +88,10 @@ export default function AntigravityPanel({
             the paid tier ships.
           </p>
         </div>
+      </div>
+
+      <div className="unsupported-state">
+        Local cost and reset timeline are not available for Antigravity until a stable usage API exists.
       </div>
 
       <button className="open-dashboard-btn" onClick={handleOpenDashboard}>

--- a/src/components/ClaudePanel.tsx
+++ b/src/components/ClaudePanel.tsx
@@ -1,7 +1,12 @@
 import CostSummarySection from './CostSummarySection';
 import QuotaCard from './QuotaCard';
+import ProviderDetailHeader from './ProviderDetailHeader';
+import ResetTimeline from './ResetTimeline';
+import SmartTip from './SmartTip';
 import type { QuotaData } from '../types/models';
 import { formatResetTime } from '../utils/quota_format';
+import { buildClaudeQuotaWindows, sortMostConstrained } from '../services/provider_summary';
+import { getHighUsageTip } from '../services/detail_helpers';
 
 interface ClaudePanelProps {
   quota: QuotaData | null;
@@ -38,6 +43,9 @@ export default function ClaudePanel({
   costRefreshKey,
   onRetry,
 }: ClaudePanelProps) {
+  const windows = buildClaudeQuotaWindows(quota);
+  const topWindow = sortMostConstrained(windows)[0];
+
   return (
     <>
       {loading && !quota && (
@@ -52,7 +60,15 @@ export default function ClaudePanel({
       )}
 
       {!error && quota && (
-        <div className="quota-list">
+        <div className="detail-stack">
+          <ProviderDetailHeader
+            service="claude"
+            status={quota.connected ? 'Connected' : 'Offline'}
+            plan="Claude Code"
+            usedPercent={topWindow?.usedPercent ?? null}
+          />
+          <SmartTip message={getHighUsageTip(windows)} />
+
           <div className="section">
             <div className="section-title">
               CURRENT SESSION
@@ -119,6 +135,8 @@ export default function ClaudePanel({
               <div className="no-data">No weekly data</div>
             )}
           </div>
+
+          <ResetTimeline windows={windows} />
 
           {windowVisible && (
             <CostSummarySection source="claude" refreshKey={costRefreshKey} />

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState, useCallback } from 'react';
 import { backend } from '../services/backend';
 import CostSummarySection from './CostSummarySection';
+import ProviderDetailHeader from './ProviderDetailHeader';
+import ResetTimeline from './ResetTimeline';
+import SmartTip from './SmartTip';
 import type { CodexData, CodexRateLimits, CodexResetCredits, CodexStats } from '../types/models';
-import { buildCodexQuotaWindows, type QuotaWindowSummary } from '../services/provider_summary';
+import { buildCodexQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
+import { getAvailableResetCredits, getHighUsageTip } from '../services/detail_helpers';
 import { formatPlanType, formatResetTime, getProgressStyle } from '../utils/quota_format';
 
 interface CodexPanelProps {
@@ -157,6 +161,9 @@ export default function CodexPanel({
   const hasRateLimits = rateLimits?.primary || rateLimits?.secondary;
   const connected = rateLimits?.connected || codexData?.connected;
   const planType = rateLimits?.planType || codexData?.planType;
+  const windows = buildCodexQuotaWindows(rateLimits);
+  const topWindow = sortMostConstrained(windows)[0];
+  const availableResetCredits = getAvailableResetCredits(resetCredits);
 
   return (
     <div className="codex-panel">
@@ -169,6 +176,14 @@ export default function CodexPanel({
 
       {connected && (
         <div className="codex-content">
+          <ProviderDetailHeader
+            service="codex"
+            status={connected ? 'Connected' : 'Offline'}
+            plan={`Codex ${formatPlanType(planType)}`}
+            usedPercent={topWindow?.usedPercent ?? null}
+          />
+          <SmartTip message={getHighUsageTip(windows)} />
+
           {/* Rate Limits Section */}
           {hasRateLimits && (
             <div className="section">
@@ -240,18 +255,16 @@ export default function CodexPanel({
             </div>
           )}
 
-          {/* Rate-limit Reset Credits Section */}
-          {resetCredits?.connected && resetCredits.availableCount > 0 && (
+          {/* Bonus Reset Credits Section */}
+          {availableResetCredits.length > 0 && (
             <div className="section">
               <div className="section-title">
-                RESET CREDITS
-                <span className="plan-tag">{resetCredits.availableCount} available</span>
+                BONUS RESETS
+                <span className="plan-tag">{availableResetCredits.length} gifted</span>
               </div>
-              {resetCredits.credits
-                .filter((credit) => credit.status === 'available')
-                .sort((a, b) => (a.expiresAt ?? '').localeCompare(b.expiresAt ?? ''))
-                .map((credit, index) => (
-                  <div className="quota-card" key={`${credit.expiresAt ?? 'unknown'}-${index}`}>
+              <div className="bonus-reset-list">
+                {availableResetCredits.map((credit, index) => (
+                  <div className="bonus-reset-card" key={`${credit.expiresAt ?? 'unknown'}-${index}`}>
                     <div className="quota-header">
                       <span className="quota-label">{credit.title ?? 'Rate limit reset'}</span>
                     </div>
@@ -260,8 +273,11 @@ export default function CodexPanel({
                     </div>
                   </div>
                 ))}
+              </div>
             </div>
           )}
+
+          <ResetTimeline windows={windows} />
 
           {/* Subscription Section (only if no rate limits) */}
           {!hasRateLimits && codexData && (

--- a/src/components/CursorPanel.tsx
+++ b/src/components/CursorPanel.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState, useCallback } from 'react';
 import { backend } from '../services/backend';
 import CostSummarySection from './CostSummarySection';
+import ProviderDetailHeader from './ProviderDetailHeader';
+import ResetTimeline from './ResetTimeline';
+import SmartTip from './SmartTip';
 import type { CursorData } from '../types/models';
-import { buildCursorQuotaWindows, type QuotaWindowSummary } from '../services/provider_summary';
+import { buildCursorQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
+import { getHighUsageTip } from '../services/detail_helpers';
 import { formatPlanType, getProgressStyle } from '../utils/quota_format';
 
 interface CursorPanelProps {
@@ -104,6 +108,8 @@ export default function CursorPanel({
 
   const percentage = cursorData?.percentage ?? null;
   const resetLabel = formatResetDate(cursorData?.resetAt);
+  const windows = buildCursorQuotaWindows(cursorData);
+  const topWindow = sortMostConstrained(windows)[0];
 
   return (
     <div className="codex-panel">
@@ -116,6 +122,14 @@ export default function CursorPanel({
 
       {cursorData?.connected && (
         <div className="codex-content">
+          <ProviderDetailHeader
+            service="cursor"
+            status="Connected"
+            plan={`Cursor ${formatPlanType(cursorData.planType, 'Unknown')}`}
+            usedPercent={topWindow?.usedPercent ?? null}
+          />
+          <SmartTip message={getHighUsageTip(windows)} />
+
           <div className="section">
             <div className="section-title">
               USAGE
@@ -157,6 +171,8 @@ export default function CursorPanel({
               </div>
             )}
           </div>
+
+          <ResetTimeline windows={windows} />
 
           {showCostSummary && (
             <CostSummarySection source="cursor" refreshKey={manualRefreshNonce} />

--- a/src/components/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader.tsx
@@ -1,0 +1,32 @@
+import type { CSSProperties } from 'react';
+import { SERVICE_META } from '../services/service_meta';
+import type { TrayServiceName } from '../services/tray_visibility';
+
+interface ProviderDetailHeaderProps {
+  service: TrayServiceName;
+  status: string;
+  plan?: string;
+  usedPercent?: number | null;
+}
+
+export default function ProviderDetailHeader({
+  service,
+  status,
+  plan,
+  usedPercent,
+}: ProviderDetailHeaderProps) {
+  const meta = SERVICE_META[service];
+  const style = { '--service-accent': meta.accent } as CSSProperties;
+  const usageLabel = usedPercent == null ? '--' : `${Math.round(usedPercent)}%`;
+
+  return (
+    <div className="provider-detail-header" style={style}>
+      <span className="provider-detail-icon" aria-hidden="true">{meta.initials}</span>
+      <span className="provider-detail-copy">
+        <span className="provider-detail-name">{meta.label}</span>
+        <span className="provider-detail-status">{plan ? `${plan} / ${status}` : status}</span>
+      </span>
+      <span className="provider-detail-usage">{usageLabel}</span>
+    </div>
+  );
+}

--- a/src/components/ResetTimeline.tsx
+++ b/src/components/ResetTimeline.tsx
@@ -1,0 +1,25 @@
+import type { QuotaWindowSummary } from '../services/provider_summary';
+import { sortUpcomingResets } from '../services/provider_summary';
+
+interface ResetTimelineProps {
+  windows: QuotaWindowSummary[];
+}
+
+export default function ResetTimeline({ windows }: ResetTimelineProps) {
+  const upcoming = sortUpcomingResets(windows).slice(0, 4);
+  if (upcoming.length === 0) return null;
+
+  return (
+    <div className="section">
+      <div className="section-title">Upcoming resets</div>
+      <div className="reset-timeline">
+        {upcoming.map((window) => (
+          <div className="reset-timeline-row" key={`${window.provider}-${window.label}-${window.resetAtMs}`}>
+            <span>{window.label}</span>
+            <strong>{window.resetLabel}</strong>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SmartTip.tsx
+++ b/src/components/SmartTip.tsx
@@ -1,0 +1,13 @@
+interface SmartTipProps {
+  message: string | null;
+}
+
+export default function SmartTip({ message }: SmartTipProps) {
+  if (!message) return null;
+  return (
+    <div className="smart-tip">
+      <span className="smart-tip-label">Tip</span>
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/src/services/detail_helpers.ts
+++ b/src/services/detail_helpers.ts
@@ -1,0 +1,23 @@
+import type { CodexResetCredit, CodexResetCredits } from '../types/models';
+import type { QuotaWindowSummary } from './provider_summary';
+
+export function getHighUsageTip(
+  windows: QuotaWindowSummary[],
+  threshold = 80,
+): string | null {
+  const window = [...windows]
+    .filter((item) => item.usedPercent >= threshold)
+    .sort((a, b) => b.usedPercent - a.usedPercent)[0];
+
+  if (!window) return null;
+  return `${window.providerLabel} ${window.label} is at ${Math.round(window.usedPercent)}%.`;
+}
+
+export function getAvailableResetCredits(
+  resetCredits: CodexResetCredits | null,
+): CodexResetCredit[] {
+  if (!resetCredits?.connected || resetCredits.availableCount <= 0) return [];
+  return resetCredits.credits
+    .filter((credit) => credit.status === 'available')
+    .sort((a, b) => (a.expiresAt ?? '').localeCompare(b.expiresAt ?? ''));
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -981,6 +981,148 @@ html, body, #root {
   gap: 12px;
 }
 
+.detail-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.provider-detail-header {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--service-accent) 30%, var(--hairline));
+  border-radius: 12px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--service-accent) 12%, transparent), transparent 66%),
+    var(--glass-strong);
+  box-shadow: var(--shadow-sm), inset 0 1px 0 color-mix(in srgb, white 18%, transparent);
+}
+
+.provider-detail-icon {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  color: var(--service-accent);
+  background: color-mix(in srgb, var(--service-accent) 10%, var(--bg-card));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--service-accent) 70%, transparent);
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.provider-detail-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.provider-detail-name,
+.provider-detail-status {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.provider-detail-name {
+  color: var(--text-primary);
+  font-size: 16px;
+  line-height: 1.1;
+  font-weight: 850;
+}
+
+.provider-detail-status {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 720;
+}
+
+.provider-detail-usage {
+  flex: 0 0 auto;
+  min-width: 44px;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--service-accent) 10%, var(--bg-card));
+  color: var(--service-accent);
+  font-family: var(--metric-font);
+  font-size: 12px;
+  font-weight: 850;
+  text-align: center;
+}
+
+.smart-tip,
+.unsupported-state {
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--color-warning) 28%, var(--hairline));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-warning-bg) 42%, var(--bg-card));
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.smart-tip-label {
+  flex: 0 0 auto;
+  color: var(--color-warning);
+  font-weight: 850;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.reset-timeline,
+.bonus-reset-list {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.reset-timeline-row,
+.bonus-reset-card {
+  min-width: 0;
+  padding: 9px 10px;
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  background: var(--glass-strong);
+  box-shadow: var(--shadow-sm), inset 0 1px 0 color-mix(in srgb, white 14%, transparent);
+}
+
+.reset-timeline-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.reset-timeline-row span,
+.reset-timeline-row strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reset-timeline-row span {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.reset-timeline-row strong {
+  flex: 0 0 auto;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 850;
+}
+
 .cost-section {
   margin-bottom: 4px;
 }

--- a/tests/detail_helpers.test.ts
+++ b/tests/detail_helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+import { getAvailableResetCredits, getHighUsageTip } from '../src/services/detail_helpers';
+
+describe('detail helpers', () => {
+  test('hides smart tips when usage is missing or below threshold', () => {
+    expect(getHighUsageTip([])).toBeNull();
+    expect(getHighUsageTip([{
+      provider: 'codex',
+      providerLabel: 'Codex',
+      label: 'Weekly limit',
+      usedPercent: 79,
+    }])).toBeNull();
+  });
+
+  test('uses the highest real usage window for smart tips', () => {
+    expect(getHighUsageTip([
+      { provider: 'claude', providerLabel: 'Claude', label: 'Session', usedPercent: 82 },
+      { provider: 'codex', providerLabel: 'Codex', label: 'Weekly limit', usedPercent: 91 },
+    ])).toBe('Codex Weekly limit is at 91%.');
+  });
+
+  test('filters and sorts available reset credits only', () => {
+    expect(getAvailableResetCredits({
+      connected: true,
+      availableCount: 2,
+      credits: [
+        { status: 'used', title: 'Used', expiresAt: '2026-07-05T00:00:00Z' },
+        { status: 'available', title: 'Later', expiresAt: '2026-07-07T00:00:00Z' },
+        { status: 'available', title: 'Sooner', expiresAt: '2026-07-06T00:00:00Z' },
+      ],
+    }).map((credit) => credit.title)).toEqual(['Sooner', 'Later']);
+  });
+});


### PR DESCRIPTION
## What

Implements the final UI redesign issue for provider detail panels after PR #15 and PR #21 were merged into `main`.

- Adds shared provider detail headers for Claude, Codex, Cursor, and Antigravity.
- Adds real-data upcoming reset timelines for Claude, Codex, and Cursor; unsupported Antigravity resets stay explicit.
- Adds conservative smart tips only when a real quota window is at or above the high-usage threshold.
- Presents Codex reset credits from PR #15 as Bonus resets/Gifted, using available-only filtering, title fallback, expiry text, and stable expiry ordering.
- Keeps generic Codex credits separate from Bonus resets.
- Keeps local cost summary contract and loading/error/cached behavior intact.
- Surfaces Antigravity status fetch errors instead of silently swallowing them.

Closes #17

## Base decision

PR #15 (`feat/codex-reset-credits`) and PR #21 (`feat: redesign QuotaBar popover overview`) are already merged, so this branch is based on updated `main` and uses the merged reset-credit contract directly.

## Verification

- `npx tsc --noEmit`
- `npm test` (7 files, 23 tests)
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml` (32 passed, 1 ignored)
