### PR TITLE
fix(ci): restore clean dependency install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",
+        "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "2.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -1440,6 +1441,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-notification": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/src-tauri/src/services/tray_icon.rs
+++ b/src-tauri/src/services/tray_icon.rs
@@ -377,7 +377,12 @@ mod tests {
 
     #[test]
     fn generate_icon_returns_png_bytes() {
-        let bytes = generate_tray_icon(TrayIconIdentity::Claude, Some(73), 44, TrayIconStyle::Percent);
+        let bytes = generate_tray_icon(
+            TrayIconIdentity::Claude,
+            Some(73),
+            44,
+            TrayIconStyle::Percent,
+        );
         assert!(!bytes.is_empty());
     }
 
@@ -389,16 +394,41 @@ mod tests {
 
     #[test]
     fn service_badges_produce_distinct_icons() {
-        let claude = generate_tray_icon(TrayIconIdentity::Claude, Some(42), 44, TrayIconStyle::Percent);
-        let codex = generate_tray_icon(TrayIconIdentity::Codex, Some(42), 44, TrayIconStyle::Percent);
+        let claude = generate_tray_icon(
+            TrayIconIdentity::Claude,
+            Some(42),
+            44,
+            TrayIconStyle::Percent,
+        );
+        let codex = generate_tray_icon(
+            TrayIconIdentity::Codex,
+            Some(42),
+            44,
+            TrayIconStyle::Percent,
+        );
         assert_ne!(claude, codex);
     }
 
     #[test]
     fn tray_icon_distinguishes_full_usage_from_ninety_nine() {
-        let ninety_nine = generate_tray_icon(TrayIconIdentity::Claude, Some(99), 44, TrayIconStyle::Percent);
-        let full = generate_tray_icon(TrayIconIdentity::Claude, Some(100), 44, TrayIconStyle::Percent);
-        let over_limit = generate_tray_icon(TrayIconIdentity::Claude, Some(130), 44, TrayIconStyle::Percent);
+        let ninety_nine = generate_tray_icon(
+            TrayIconIdentity::Claude,
+            Some(99),
+            44,
+            TrayIconStyle::Percent,
+        );
+        let full = generate_tray_icon(
+            TrayIconIdentity::Claude,
+            Some(100),
+            44,
+            TrayIconStyle::Percent,
+        );
+        let over_limit = generate_tray_icon(
+            TrayIconIdentity::Claude,
+            Some(130),
+            44,
+            TrayIconStyle::Percent,
+        );
 
         assert_ne!(ninety_nine, full);
         assert_eq!(full, over_limit);


### PR DESCRIPTION
## 摘要

- 同步 `package-lock.json`，补上 `@tauri-apps/plugin-notification@2.3.3` 的锁定记录。
- 运行 rustfmt 修复 `tray_icon.rs` 测试里的格式问题，避免 CI 在 `cargo fmt --check` 阶段继续失败。

Fixes #23

## 验证

- [x] `npm ci`
- [x] `npm test`
- [x] `npm run build`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`

日志保存在本地 `/tmp/quotabar-gh23-logs/`。