### PR TITLE
fix(ci): remove GitHub Actions runner annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   verify:
     name: Verify
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## 摘要

- 将 CI runner 从 `macos-latest` 固定为 `macos-15`，避免 macOS 26 迁移 annotation 和发布前环境漂移。
- 将 `actions/checkout` 升级到 `v7`。
- 将 `actions/setup-node` 升级到 `v6`。

Fixes #25

## 验证

- [x] `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ci yaml ok'"`\n- [x] `git diff --check`\n- [x] `npm ci`\n- [x] `npm test`\n- [x] `npm run build`\n- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`\n- [x] `cargo check --manifest-path src-tauri/Cargo.toml`\n- [x] `cargo test --manifest-path src-tauri/Cargo.toml`\n\n本地日志在 `/tmp/quotabar-gh25-logs/`。