### PR TITLE
chore: prepare first public release readiness

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,64 @@
+name: Release Artifacts
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/release-artifacts.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "src-tauri/**"
+      - "src/**"
+      - "docs/release.md"
+      - "README.md"
+
+permissions:
+  contents: read
+
+jobs:
+  bundle:
+    name: Bundle ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS
+            runner: macos-15
+            bundles: dmg
+            artifact_name: quotabar-macos-dmg
+            artifact_paths: |
+              src-tauri/target/release/bundle/dmg/*.dmg
+          - name: Windows
+            runner: windows-2022
+            bundles: msi,nsis
+            artifact_name: quotabar-windows-installers
+            artifact_paths: |
+              src-tauri/target/release/bundle/msi/*.msi
+              src-tauri/target/release/bundle/nsis/*.exe
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build desktop bundle
+        run: npm run tauri build -- --bundles ${{ matrix.bundles }}
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_paths }}
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Added an artifact-only GitHub Actions workflow for macOS and Windows release bundle inspection.
+- Added SECURITY, CONTRIBUTING, and CODE_OF_CONDUCT files for public project readiness.
+- Replaced the disabled Tauri CSP with a restricted policy for bundled UI assets and IPC.
+- Clarified first-release gates, source-build fallback, and the no-auto-publish release boundary.
 - Reduced local cost refresh work by using ccstats multi-range summaries for Today, This Week, and This Month in one pass.
 - Added a browser-preview demo proof screenshot and documented its no-credential capture scope.
 - Report an explicit desktop-backend-unavailable error when the UI is opened outside Tauri.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+QuotaBar uses GitHub issues and pull requests for technical collaboration.
+
+## Expected Behavior
+
+- Be direct, specific, and respectful.
+- Keep reports actionable with reproduction steps, versions, screenshots, or
+  logs when relevant.
+- Redact provider tokens, cookies, sessions, account identifiers, and local auth
+  paths before posting.
+- Assume disagreement should be resolved with evidence from code, docs, tests, or
+  provider behavior.
+
+## Unacceptable Behavior
+
+- Posting secrets or someone else's private account data.
+- Harassment, threats, insults, or repeated off-topic disruption.
+- Asking maintainers or users to bypass provider terms, scrape private data, or
+  share credentials.
+- Mass-posting unrelated promotion or generated noise.
+
+## Enforcement
+
+Maintainers may edit, hide, or delete unsafe content; close issues that cannot be
+made actionable; and block accounts that repeatedly violate these rules.
+
+Report security-sensitive or credential-related issues through GitHub private
+security advisories instead of public issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to QuotaBar
+
+QuotaBar is a Tauri v2 desktop app with a React frontend and Rust backend. Keep
+changes focused on quota visibility, local cost visibility, tray behavior,
+release readiness, or clear documentation gaps.
+
+## Setup
+
+```bash
+npm ci
+npm run tauri dev
+```
+
+Requirements:
+
+- macOS or Windows for desktop runtime work.
+- Node.js with npm.
+- Rust stable toolchain.
+- Tauri prerequisites for the target platform.
+
+## Verification
+
+Run these before opening a pull request:
+
+```bash
+npm test
+npm run build
+cargo fmt --manifest-path src-tauri/Cargo.toml --check
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+For release or installer changes, also run:
+
+```bash
+npm run tauri build -- --bundles app
+```
+
+Use `docs/release.md` for release artifact work.
+
+## Security and Data Rules
+
+- Do not commit provider tokens, cookies, session files, API keys, or local auth
+  material.
+- Do not paste real provider account identifiers into tests, docs, issues, or
+  screenshots.
+- Missing provider data should render unavailable/blank/error states, not fake
+  zero usage.
+- If a change touches auth state, release artifacts, Tauri permissions, CSP,
+  opener behavior, or notifications, call that out in the PR.
+
+## Pull Requests
+
+- Link the GitHub issue or SpecRail packet when one exists.
+- Keep UI copy honest about provider limitations and pending support.
+- Update README, docs, tests, and changelog when user-visible behavior changes.
+- Do not publish releases, attach public artifacts, or change branch protection
+  from a pull request.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # QuotaBar
 
+[![CI](https://github.com/majiayu000/quotabar/actions/workflows/ci.yml/badge.svg)](https://github.com/majiayu000/quotabar/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 <p align="center">
   <img src="src-tauri/icons/app-icon.svg" alt="QuotaBar logo" width="128" />
 </p>
@@ -83,31 +86,56 @@ This screenshot is captured from the production React UI in browser preview with
 ## Development
 
 ```bash
-npm install
+npm ci
 npm run tauri dev
 ```
 
 ## Build
 
+Frontend and Rust verification:
+
 ```bash
-npm install
+npm ci
+npm test
+npm run build
+cargo fmt --manifest-path src-tauri/Cargo.toml --check
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Local macOS app bundle:
+
+```bash
 npm run tauri build -- --bundles app
 ```
 
-macOS app bundle output:
-
 `src-tauri/target/release/bundle/macos/QuotaBar.app`
 
-Windows installer output:
+Downloadable release bundles:
 
+```bash
+# macOS
+npm run tauri build -- --bundles dmg
+
+# Windows
+npm run tauri build -- --bundles msi,nsis
+```
+
+Expected output locations:
+
+`src-tauri/target/release/bundle/dmg/`
 `src-tauri/target/release/bundle/msi/`
 `src-tauri/target/release/bundle/nsis/`
 
 ## Release Artifacts
 
-There is no published GitHub release yet. When a release is cut, build from a clean checkout and attach the generated platform artifact from the paths above to the matching GitHub release tag. See `docs/release.md` for the release checklist.
+There is no published GitHub release yet. Until the first release is cut, use the source-build path above.
+
+Release candidates should be built by the `release-artifacts` GitHub Actions workflow or from a clean checkout, then attached manually to the matching GitHub release only after final human approval. The workflow uploads build artifacts for inspection; it does not publish a GitHub Release. See [docs/release.md](docs/release.md) for the release checklist.
 
 ## Install / Run
+
+Until a public release exists, install from a local build.
 
 macOS:
 
@@ -131,10 +159,12 @@ Windows:
 ## Verification
 
 ```bash
-npm run build
 npm test
-cd src-tauri && cargo check
-cd src-tauri && cargo test
+npm run build
+cargo fmt --manifest-path src-tauri/Cargo.toml --check
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+npm run tauri build -- --bundles app
 ```
 
 ## Limitations
@@ -170,15 +200,12 @@ cd src-tauri && cargo test
   - local logs may not exist yet
   - costs are estimated offline from local Claude/Codex logs via `ccstats`
 
-## Repository Rename
+## Support and Security
 
-Recommended GitHub repository name: `quotabar`.
-
-After the repository is renamed on GitHub, update local remotes with:
-
-```bash
-git remote set-url origin https://github.com/majiayu000/quotabar.git
-```
+- Bugs and feature requests: use GitHub issues.
+- Security or credential exposure: use GitHub private security advisories. Do not paste provider tokens, cookies, session files, or local auth material into public issues.
+- Contributor setup and expectations: see [CONTRIBUTING.md](CONTRIBUTING.md).
+- Security scope and reporting: see [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+QuotaBar is a local desktop app. It reads provider auth state from local tools so
+it can show quota and cost information, but it must not store or publish provider
+tokens, cookies, sessions, or account recovery material.
+
+## Reporting
+
+Report security issues privately through GitHub private security advisories:
+
+https://github.com/majiayu000/quotabar/security/advisories/new
+
+Do not open a public issue for credential exposure, token handling bugs, or a
+report that includes local auth paths or session data. Include what you found,
+where it happens, and the smallest reproduction that does not disclose secrets.
+
+## In Scope
+
+- Unsafe handling of Claude Code, Codex, Cursor, or Antigravity auth state.
+- Release artifacts that accidentally include local credentials, logs, sessions,
+  or provider account identifiers.
+- Tauri command, CSP, permission, opener, or notification behavior that exposes
+  local data beyond the app boundary.
+- UI behavior that silently converts missing or invalid quota data into fake zero
+  usage.
+
+## Out of Scope
+
+- Third-party provider service behavior.
+- Provider account recovery, billing disputes, or quota policy decisions.
+- Local usage logs that are already controlled by the user's machine and are not
+  copied into QuotaBar artifacts.
+
+## Project Rules
+
+- Never commit provider tokens, cookies, sessions, API keys, or local auth files.
+- Never paste secrets into public GitHub issues, pull requests, screenshots, or
+  release notes.
+- Release artifacts must be built from a clean checkout and inspected before
+  publication.
+- QuotaBar does not manage provider login flows; users should authenticate with
+  the provider tools directly.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,48 +1,81 @@
-# Release Notes
+# First-Release Runbook
 
-QuotaBar does not currently have a published GitHub release.
+QuotaBar does not currently have a published GitHub Release.
 
-## Build Artifacts
+This runbook prepares release artifacts, but it does not authorize publishing.
+Create the public release only after a human approves the tag, artifacts, release
+notes, and signing/notarization decision.
 
-Release builds should be produced from a clean checkout with:
+## Release Gates
+
+Before tagging:
+
+- Working tree is clean and based on `origin/main`.
+- Version matches in `package.json`, `src-tauri/Cargo.toml`, and
+  `src-tauri/tauri.conf.json`.
+- `CHANGELOG.md` has release notes outside `Unreleased`.
+- README install, limitations, and troubleshooting sections match current
+  behavior.
+- Demo proof has been refreshed or explicitly accepted as current.
+- No provider tokens, cookies, session files, or local auth material are present
+  in the repository or release artifacts.
+- CI is green on `main`.
+
+## Local Verification
+
+Run from a clean checkout:
 
 ```bash
 npm ci
+npm test
+npm run build
+cargo fmt --manifest-path src-tauri/Cargo.toml --check
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
 npm run tauri build -- --bundles app
 ```
 
-macOS app bundle:
-
-```text
-src-tauri/target/release/bundle/macos/QuotaBar.app
-```
-
-Windows installer bundles:
-
-```text
-src-tauri/target/release/bundle/msi/
-src-tauri/target/release/bundle/nsis/
-```
-
-Attach the generated platform bundle to the GitHub release for the matching tag.
-
-## Pre-release Verification
-
-Run these commands before tagging:
-
-```bash
-npm test
-npm run build
-cd src-tauri && cargo fmt --check
-cd src-tauri && cargo check
-cd src-tauri && cargo test
-```
-
-Refresh the visual proof asset before publishing user-facing release notes:
+Refresh the browser-preview visual proof only when the UI has changed:
 
 ```bash
 npm run dev -- --host 127.0.0.1
 npx playwright screenshot --wait-for-timeout=3500 --viewport-size=340,580 http://127.0.0.1:1420 docs/assets/quotabar-no-provider-preview.png
 ```
 
-Do not include provider tokens, cookies, session files, or local auth material in release artifacts.
+## Artifact Workflow
+
+Use the `release-artifacts` workflow to produce downloadable bundles for
+inspection:
+
+```bash
+gh workflow run release-artifacts.yml
+```
+
+The workflow uploads GitHub Actions artifacts only. It does not create tags,
+publish GitHub Releases, or attach files to a public release.
+
+Expected artifact contents:
+
+- macOS: `src-tauri/target/release/bundle/dmg/*.dmg`
+- Windows: `src-tauri/target/release/bundle/msi/*.msi`
+- Windows: `src-tauri/target/release/bundle/nsis/*.exe`
+
+For a local macOS smoke test, build the app bundle and install it:
+
+```bash
+npm run tauri build -- --bundles app
+./scripts/reinstall_and_run.sh
+```
+
+## Publishing
+
+Publishing is a separate human-gated step:
+
+1. Decide whether this release is signed/notarized. Unsigned macOS builds may
+   trigger Gatekeeper warnings and should be labeled as tester builds.
+2. Create an annotated tag only after the release notes are final.
+3. Create the GitHub Release manually.
+4. Attach the inspected workflow artifacts to the release.
+5. Record the release URL and the exact verification commands used.
+
+Do not publish a release from an unreviewed workflow run.

--- a/specs/GH27/product.md
+++ b/specs/GH27/product.md
@@ -1,21 +1,25 @@
-# GH-27 Product Spec: Local Cost Multi-Range Summary
+# GH-27 Product Spec: First Public Release Readiness
 
 ## Goals
 
-- Use the ccstats GH27 multi-range SDK path for QuotaBar local cost summaries.
-- Keep the existing QuotaBar UI response shape for Today, This Week, and This Month.
-- Reduce cold or forced local cost refresh work from repeated per-range scans to one shared ccstats scan.
+- Prepare QuotaBar for a first public desktop-app release without publishing the release.
+- Make the repository understandable and safe for outside users and contributors.
+- Provide a manual release artifact workflow that can build downloadable desktop bundles before a release is cut.
+- Keep the current honest product boundary: provider credentials are read locally, release artifacts are not published yet, and Antigravity quota tracking remains pending provider support.
 
 ## Non-Goals
 
-- Do not change QuotaBar's visible cost UI.
-- Do not add new providers or expose new cost fields.
-- Do not change tray behavior or existing quota polling behavior.
+- Do not publish a GitHub Release.
+- Do not upload installer artifacts to a public release.
+- Do not add branch protection or merge policy settings.
+- Do not add provider quota features or change quota semantics.
 
 ## Acceptance Criteria
 
-- QuotaBar depends on a ccstats revision that includes GH27 `summarize_cost_ranges`.
-- `src-tauri/src/services/cost.rs` calls the multi-range SDK once for Today, This Week, and This Month instead of looping over single-range summaries.
-- The returned `CostOverview` still contains the same range keys and labels: `today`, `week`, and `month`.
-- Cache behavior remains unchanged: non-forced calls can return the five-minute cached overview and forced calls rebuild it.
-- Fresh Rust and TypeScript verification passes.
+- README and release docs explain the current install and release status without stale rename guidance.
+- GitHub metadata no longer points to the old `quota-menubar-tauri` homepage.
+- `SECURITY.md` and `CONTRIBUTING.md` exist with QuotaBar-specific credential and token boundaries.
+- A release workflow can build and upload macOS and Windows desktop artifacts as workflow artifacts without auto-publishing a GitHub Release.
+- Tauri CSP is restricted for the bundled React UI and Tauri IPC instead of being disabled with `csp: null`.
+- The pre-existing upstream ccstats GH27 notes no longer occupy the local `specs/GH27` namespace.
+- Fresh frontend and Rust verification passes.

--- a/specs/GH27/tasks.md
+++ b/specs/GH27/tasks.md
@@ -2,16 +2,14 @@
 
 ## Implementation Tasks
 
-- [x] `SP27-T1` Owner: codex. Done when: QuotaBar has a SpecRail packet for the local cost multi-range work. Verify: `env PYTHONDONTWRITEBYTECODE=1 python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir "$(pwd)/specs/GH27"`.
-- [x] `SP27-T2` Owner: codex. Done when: ccstats is pinned to a revision that exposes `summarize_cost_ranges`. Verify: `rg -n "summarize_cost_ranges|7dbfad0ffc29277da22cd095db067e88982f3f12" src-tauri`.
-- [x] `SP27-T3` Owner: codex. Done when: local cost overview uses one multi-range SDK call for today/week/month. Verify: `rg -n "summarize_cost\\(" src-tauri/src/services/cost.rs` returns no matches.
-- [x] `SP27-T4` Owner: codex. Done when: mapping and mismatch behavior are covered by Rust unit tests. Verify: `cargo test --manifest-path src-tauri/Cargo.toml cost::tests`.
-- [x] `SP27-T5` Owner: codex. Done when: project verification passes. Verify: `cargo check --manifest-path src-tauri/Cargo.toml && cargo test --manifest-path src-tauri/Cargo.toml && npx tsc --noEmit && npm test -- --run`.
-
-## Verification
-
-Record fresh command output in the final report.
+- [x] `REL27-T1` Owner: codex. Done when: the upstream ccstats GH27 notes no longer occupy `specs/GH27`, and this issue has product, tech, and task specs. Verify: `find specs/GH27 specs/UPSTREAM-CCSTATS-GH27 -maxdepth 1 -type f -print`.
+- [x] `REL27-T2` Owner: codex. Done when: README and `docs/release.md` describe the first-release path, source-build fallback, artifact workflow, and no auto-publish boundary. Verify: `rg -n "Release Artifacts|First-release|release-artifacts|Do not publish" README.md docs/release.md`.
+- [x] `REL27-T3` Owner: codex. Done when: public project hygiene files exist for security, contribution, and conduct. Verify: `test -f SECURITY.md && test -f CONTRIBUTING.md && test -f CODE_OF_CONDUCT.md`.
+- [x] `REL27-T4` Owner: codex. Done when: Tauri CSP is restricted instead of `null`. Verify: `rg -n "\"csp\"|ipc: http://ipc.localhost|unsafe-inline" src-tauri/tauri.conf.json`.
+- [x] `REL27-T5` Owner: codex. Done when: a release artifact workflow builds macOS and Windows bundles and uploads workflow artifacts without creating a release. Verify: `rg -n "Release Artifacts|upload-artifact|workflow_dispatch|tauri build" .github/workflows/release-artifacts.yml`.
+- [x] `REL27-T6` Owner: codex. Done when: GitHub repo metadata no longer points to the old `quota-menubar-tauri` homepage. Verify: `gh repo view majiayu000/quotabar --json homepageUrl,description,repositoryTopics`.
+- [x] `REL27-T7` Owner: codex. Done when: project verification passes. Verify: `npm test && npm run build && cargo fmt --manifest-path src-tauri/Cargo.toml --check && cargo check --manifest-path src-tauri/Cargo.toml && cargo test --manifest-path src-tauri/Cargo.toml && npm run tauri build -- --bundles app`.
 
 ## Handoff Notes
 
-This packet references upstream ccstats #27 because QuotaBar has no open local issue for this integration.
+This issue intentionally stops before publishing a GitHub Release. Release creation, public installer upload, signing, notarization, and branch-protection policy changes remain human-gated.

--- a/specs/GH27/tech.md
+++ b/specs/GH27/tech.md
@@ -1,25 +1,42 @@
-# GH-27 Tech Spec: Local Cost Multi-Range Summary
+# GH-27 Tech Spec: First Public Release Readiness
 
 ## Proposed Design
 
-Upgrade QuotaBar's ccstats dependency to a revision containing GH27 and import:
+Use a repository-preparation PR rather than publishing a release directly.
 
-- `summarize_cost_ranges`
-- `MultiSummaryOptions`
+Documentation changes:
 
-In `build_cost_overview`, build the three existing `UsageRange` values, call `summarize_cost_ranges` once, then map the ordered returned summaries back into QuotaBar's existing `CostRangeSummary` structs with the current labels.
+- Update README release and install sections so outside users understand the current no-release state, source-build path, and release artifact plan.
+- Replace the stale repository rename section with support and security-report guidance.
+- Expand `docs/release.md` into a first-release runbook with local verification, release artifact workflow usage, and explicit human gate before tag/release publication.
+- Add `SECURITY.md`, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md` for public project hygiene.
 
-The mapping layer must fail if the SDK returns an unexpected number of summaries. A missing or mismatched SDK result should be an error, not a partial UI fallback.
+Workflow changes:
+
+- Add `.github/workflows/release-artifacts.yml`.
+- Run on pull requests touching release-critical paths and on manual dispatch.
+- Build macOS and Windows bundles on pinned hosted runners.
+- Upload workflow artifacts with `actions/upload-artifact`.
+- Do not create or mutate GitHub Releases.
+
+Security changes:
+
+- Replace `app.security.csp: null` with a restrictive CSP object for local bundled assets, Tauri IPC, inline CSS needed by the current React/CSS stack, and image data URLs.
+- Keep Tauri capabilities scoped to core, opener, and notification permissions.
+
+Metadata changes:
+
+- Update GitHub repository metadata out of band with `gh repo edit` so the homepage no longer points at the old repo and topics reflect current providers.
 
 ## Test Plan
 
-- Unit-test the mapping layer for stable QuotaBar range keys and labels.
-- Unit-test mismatch handling for an unexpected SDK summary count.
-- Run `cargo check --manifest-path src-tauri/Cargo.toml`.
-- Run `cargo test --manifest-path src-tauri/Cargo.toml`.
-- Run `npx tsc --noEmit`.
-- Run `npm test -- --run`.
+- `npm test`
+- `npm run build`
+- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
+- `cargo check --manifest-path src-tauri/Cargo.toml`
+- `cargo test --manifest-path src-tauri/Cargo.toml`
+- `npm run tauri build -- --bundles app`
 
 ## Rollback Plan
 
-Revert the ccstats revision and the `cost.rs` multi-range integration. The existing cache and per-range single summary path can be restored from git history if the upstream SDK API changes.
+Revert the PR. The release workflow is artifact-only and does not publish releases, so rollback does not need to delete release assets. If the CSP breaks the desktop shell, revert only the CSP object to the previous release branch state and keep the docs/community files.

--- a/specs/UPSTREAM-CCSTATS-GH27/product.md
+++ b/specs/UPSTREAM-CCSTATS-GH27/product.md
@@ -1,0 +1,21 @@
+# Upstream ccstats GH-27 Product Note: Local Cost Multi-Range Summary
+
+## Goals
+
+- Use the upstream ccstats GH27 multi-range SDK path for QuotaBar local cost summaries.
+- Keep the existing QuotaBar UI response shape for Today, This Week, and This Month.
+- Reduce cold or forced local cost refresh work from repeated per-range scans to one shared ccstats scan.
+
+## Non-Goals
+
+- Do not change QuotaBar's visible cost UI.
+- Do not add new providers or expose new cost fields.
+- Do not change tray behavior or existing quota polling behavior.
+
+## Acceptance Criteria
+
+- QuotaBar depends on a ccstats revision that includes upstream GH27 `summarize_cost_ranges`.
+- `src-tauri/src/services/cost.rs` calls the multi-range SDK once for Today, This Week, and This Month instead of looping over single-range summaries.
+- The returned `CostOverview` still contains the same range keys and labels: `today`, `week`, and `month`.
+- Cache behavior remains unchanged: non-forced calls can return the five-minute cached overview and forced calls rebuild it.
+- Fresh Rust and TypeScript verification passes.

--- a/specs/UPSTREAM-CCSTATS-GH27/tasks.md
+++ b/specs/UPSTREAM-CCSTATS-GH27/tasks.md
@@ -1,0 +1,17 @@
+# Upstream ccstats GH-27 Tasks
+
+## Implementation Tasks
+
+- [x] `SP27-T1` Owner: codex. Done when: QuotaBar has a retained upstream-note packet for the local cost multi-range work. Verify: `find specs/UPSTREAM-CCSTATS-GH27 -maxdepth 1 -type f -print`.
+- [x] `SP27-T2` Owner: codex. Done when: ccstats is pinned to a revision that exposes `summarize_cost_ranges`. Verify: `rg -n "summarize_cost_ranges|7dbfad0ffc29277da22cd095db067e88982f3f12" src-tauri`.
+- [x] `SP27-T3` Owner: codex. Done when: local cost overview uses one multi-range SDK call for today/week/month. Verify: `rg -n "summarize_cost\\(" src-tauri/src/services/cost.rs` returns no matches.
+- [x] `SP27-T4` Owner: codex. Done when: mapping and mismatch behavior are covered by Rust unit tests. Verify: `cargo test --manifest-path src-tauri/Cargo.toml cost::tests`.
+- [x] `SP27-T5` Owner: codex. Done when: project verification passes. Verify: `cargo check --manifest-path src-tauri/Cargo.toml && cargo test --manifest-path src-tauri/Cargo.toml && npx tsc --noEmit && npm test -- --run`.
+
+## Verification
+
+Record fresh command output in the final report.
+
+## Handoff Notes
+
+This packet references upstream ccstats #27. It is not a local QuotaBar issue packet, so it is intentionally kept outside the `specs/GH<number>` namespace.

--- a/specs/UPSTREAM-CCSTATS-GH27/tech.md
+++ b/specs/UPSTREAM-CCSTATS-GH27/tech.md
@@ -1,0 +1,25 @@
+# Upstream ccstats GH-27 Tech Note: Local Cost Multi-Range Summary
+
+## Proposed Design
+
+Upgrade QuotaBar's ccstats dependency to a revision containing upstream GH27 and import:
+
+- `summarize_cost_ranges`
+- `MultiSummaryOptions`
+
+In `build_cost_overview`, build the three existing `UsageRange` values, call `summarize_cost_ranges` once, then map the ordered returned summaries back into QuotaBar's existing `CostRangeSummary` structs with the current labels.
+
+The mapping layer must fail if the SDK returns an unexpected number of summaries. A missing or mismatched SDK result should be an error, not a partial UI fallback.
+
+## Test Plan
+
+- Unit-test the mapping layer for stable QuotaBar range keys and labels.
+- Unit-test mismatch handling for an unexpected SDK summary count.
+- Run `cargo check --manifest-path src-tauri/Cargo.toml`.
+- Run `cargo test --manifest-path src-tauri/Cargo.toml`.
+- Run `npx tsc --noEmit`.
+- Run `npm test -- --run`.
+
+## Rollback Plan
+
+Revert the ccstats revision and the `cost.rs` multi-range integration. The existing cache and per-range single summary path can be restored from git history if the upstream SDK API changes.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,16 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": {
+        "default-src": "'self'",
+        "connect-src": "ipc: http://ipc.localhost",
+        "img-src": "'self' data: asset: http://asset.localhost",
+        "style-src": "'self' 'unsafe-inline'",
+        "font-src": "'self'",
+        "object-src": "'none'",
+        "base-uri": "'none'",
+        "frame-ancestors": "'none'"
+      }
     },
     "macOSPrivateApi": true
   },


### PR DESCRIPTION
## Summary

- Add first-release docs, public project hygiene files, and an artifact-only release workflow.
- Restrict Tauri CSP instead of leaving it disabled.
- Move the pre-existing upstream ccstats GH27 notes out of the local `specs/GH27` namespace and add a SpecRail packet for QuotaBar issue #27.
- Update GitHub repo metadata separately so the homepage no longer points at the old quota-menubar-tauri repo.

Closes #27

## Verification

- [x] `npm test`
- [x] `npm run build`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] `npm run tauri build -- --bundles app`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-artifacts.yml"); puts "release-artifacts yaml ok"'`\n\n## Scope\n\n- [x] No provider tokens, cookies, sessions, or secrets are committed.\n- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.\n\n## Release boundary\n\nThis PR does not publish a GitHub Release, create a tag, upload public installer artifacts, or change branch protection. Those remain human-gated after artifact inspection.\n