### PR TITLE
docs: specify delivery-first notification dedupe

### DIFF
--- a/specs/GH48/product.md
+++ b/specs/GH48/product.md
@@ -1,0 +1,60 @@
+# GH-48 Product Spec：通知成功送达后才提交去重状态
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/48
+- `complexity: high`
+
+## Problem
+
+当前 `notify()` 在权限检查、plugin load 与 `sendNotification` 之前调用会写入 storage 的 `shouldNotify()`。权限拒绝或 send 抛错时，通知没有送达，却已被 12 小时 dedupe 抑制。`origin/main@dd69b97d391f84b19c4000e817615bfb0028203c` 的 disposable tests 已复现 denial 与 send failure 两条路径均为“0 delivery + next attempt false”。
+
+## Goals
+
+- 把 eligibility read 与 successful-delivery commit 分离。
+- 权限拒绝、permission API/plugin/send 失败均不提交 dedupe，且同 body 后续可重试。
+- 同 body 并发调用至多实际发送一次。
+- 成功发送后才写入 timestamp；12 小时窗口与跨 body 行为不变。
+- post-send storage write 失败时保留 session shadow，避免同 session 重复发送。
+- 以 typed outcome 与固定安全消息让调用方把失败写入现有 event feed；不吞异常、不泄露原始 error。
+
+## Non-Goals
+
+- 不改变 12 小时窗口、threshold、通知标题/body 文案或 OS permission policy。
+- 不自动打开系统设置，不重构 storage adapter/event schema/App 架构。
+- 不为 browser preview 发送通知，不加入依赖或 build config。
+
+## Behavior Invariants
+
+1. `B-001` eligibility 必须只读；missing/expired 为 eligible，recent 为 duplicate，access/decode failure 为 failure，均不得在 send 前写 dedupe。
+2. `B-002` permission denied、permission API/plugin/send failure 必须返回 typed failure、零 dedupe commit、释放 in-flight；下一次同 body 可重新尝试。
+3. `B-003` 只有 `sendNotification` 无异常返回后才记录 body timestamp；窗口内同 body duplicate 不发送，不同 body 独立。
+4. `B-004` 同 body 并发调用由 in-flight guard 合并为至多一次 send；不同 body 不互相阻塞；所有 terminal path 都释放 guard。
+5. `B-005` post-send persistent write failure 使用 storage session shadow 保持本 session dedupe；delivery outcome 仍为 sent，既不伪称未送达也不重复发送。
+6. `B-006` backend unavailable/recent duplicate 返回 typed skipped；permission/dedupe/delivery failure 返回固定无敏感信息的 failure，并通过 `on_failure` 写入 event feed；全量、coverage 与 PR gates 通过。
+
+## Acceptance Criteria
+
+- `shouldNotify(body, now)` 变为 read-only，不再调用 `localStorage.setItem`。
+- `notify` 返回 discriminated union `sent | skipped | failure`；公开类型无 `any`。
+- failure message 只使用固定常量，不包含 title/body、storage key、原始 exception 或 token。
+- App bonus 与 service threshold callers 传入 `on_failure`，只调用 `logEvent('critical', fixedMessage)`，不递归 notify。
+- deterministic tests 覆盖 success/deduped/different body、denial、permission throw、send throw、concurrency、read failure、malformed state、post-send write failure/session shadow、failure callback 与 retry。
+- implementation 仅含 tech spec 8-path allowlist；新增 executable TS/TSX ≥80%，`notifications.ts` 新增 critical paths 100%。
+
+## Boundary Checklist
+
+| 边界 | 结论 |
+| --- | --- |
+| Missing/corrupt storage | missing eligible；corrupt/access failure fail closed 且 failure visible。 |
+| Permission | denied/throw 均不得 commit；later retry eligible。 |
+| Delivery | send throw 不 commit；success 后才 commit。 |
+| Concurrency | same body at most one send；finally release。 |
+| Persistence | post-send write failure uses session shadow；restart may retry but current session不重复。 |
+| Compatibility | window/body identity/settings/defaults unchanged。 |
+| Degradation | 禁止 console-only catch + fake dedupe success。 |
+| Evidence | failure matrix、coverage、full local/CI/current-head review。 |
+
+## Open Questions
+
+- 无。失败语义、commit point、concurrency 与 caller visibility 均已定义。

--- a/specs/GH48/product.md
+++ b/specs/GH48/product.md
@@ -28,9 +28,9 @@
 
 1. `B-001` eligibility 必须只读；missing/expired 为 eligible，recent 为 duplicate，access/decode failure 为 failure，均不得在 send 前写 dedupe。
 2. `B-002` permission denied、permission API/plugin/send failure 必须返回 typed failure、零 dedupe commit、释放 in-flight；下一次同 body 可重新尝试。
-3. `B-003` 只有 `sendNotification` 无异常返回后才记录 body timestamp；窗口内同 body duplicate 不发送，不同 body 独立。
+3. `B-003` 只有 `sendNotification` 无异常返回后才记录 body timestamp；commit 必须 fresh read/merge/prune，防止不同 body 并发 lost update。窗口内同 body duplicate 不发送，不同 body 独立且最终都保留。
 4. `B-004` 同 body 并发调用由 in-flight guard 合并为至多一次 send；不同 body 不互相阻塞；所有 terminal path 都释放 guard。
-5. `B-005` post-send persistent write failure 使用 storage session shadow 保持本 session dedupe；delivery outcome 仍为 sent，既不伪称未送达也不重复发送。
+5. `B-005` module-local session timestamp map 在成功 send 后立即记录并按窗口 pruning；post-send fresh-read 或 persistent write failure 时仍保持本 session dedupe，delivery outcome 为 sent，既不伪称未送达也不重复发送。
 6. `B-006` backend unavailable/recent duplicate 返回 typed skipped；permission/dedupe/delivery failure 返回固定无敏感信息的 failure，并通过 `on_failure` 写入 event feed；全量、coverage 与 PR gates 通过。
 
 ## Acceptance Criteria
@@ -38,7 +38,7 @@
 - `shouldNotify(body, now)` 变为 read-only，不再调用 `localStorage.setItem`。
 - `notify` 返回 discriminated union `sent | skipped | failure`；公开类型无 `any`。
 - failure message 只使用固定常量，不包含 title/body、storage key、原始 exception 或 token。
-- App bonus 与 service threshold callers 传入 `on_failure`，只调用 `logEvent('critical', fixedMessage)`，不递归 notify。
+- App bonus 与 service 80%/95% 三个 callers 全部通过同一 tested failure-options helper 传入 `on_failure`；TypeScript AST gate 证明三个 callsite 的第三参数 exact，helper callback 只调用 `logEvent('critical', fixedMessage)` 且零递归 notify。
 - deterministic tests 覆盖 success/deduped/different body、denial、permission throw、send throw、concurrency、read failure、malformed state、post-send write failure/session shadow、failure callback 与 retry。
 - implementation 仅含 tech spec 8-path allowlist；新增 executable TS/TSX ≥80%，`notifications.ts` 新增 critical paths 100%。
 

--- a/specs/GH48/tasks.md
+++ b/specs/GH48/tasks.md
@@ -1,0 +1,27 @@
+# GH-48 Tasks：通知 delivery-first dedupe
+
+## Delivery Contract
+
+- Base: spec 与 implementation PR 分别基于创建时 then-latest `origin/main`。
+- Commit policy: `per_step`。
+- Scope: 只修 notification eligibility/commit/concurrency/outcome/caller visibility。
+- Compatibility: storage JSON、12-hour window、settings、threshold/body 不变。
+
+## Implementation Tasks
+
+- [ ] `SP48-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`, `B-003`. Done when: eligibility read-only；success 后 prune+commit；existing settings/dedupe window/different-body semantics exact。 Verify: notifications + storage read tests。
+- [ ] `SP48-T2` Owner: codex. Dependencies: T1. Covers: `B-002`, `B-006`. Done when: typed sent/skipped/failure；denial、permission/plugin/send/read failure 不 commit且 retry；fixed safe message + on_failure exactly once。 Verify: delivery failure matrix。
+- [ ] `SP48-T3` Owner: codex. Dependencies: T1-T2. Covers: `B-004`, `B-005`. Done when: same-body concurrency one send、different body independent、finally release；post-send write failure returns sent and session-dedupes。 Verify: deferred concurrency + throwing storage tests。
+- [ ] `SP48-T4` Owner: codex. Dependencies: T2. Covers: `B-006`. Done when: service threshold 与 bonus callers 把 failure 固定消息写入 critical event，零 recursive notify；原事件顺序不变。 Verify: exact static gate + outcome callback tests。
+- [ ] `SP48-T5` Owner: codex. Dependencies: T1-T4. Covers: `B-001`~`B-006`. Done when: 8-path allowlist、checker 100%、overall diff ≥80%、notifications critical diff 100%、full frontend/build/Rust pass。 Verify: tech Test Plan。
+
+## Handoff
+
+- [ ] `SP48-T6` Owner: codex. Dependencies: T5. Done when: implementation PR `Closes #48`，正文记录 root cause/state machine/failure semantics/concurrency/coverage/rollback，并通过 implementation-vs-spec、current-head connector/CI/reviewThreads gate。
+
+## Handoff Notes
+
+- Invariants: `{B-001, B-002, B-003, B-004, B-005, B-006}`。
+- Coverage union: `{B-001, B-002, B-003, B-004, B-005, B-006}`。
+- Spec PR 仅三份 GH48 文档；implementation 才修改 allowlist 文件。
+- 禁止 force push、pre-send commit、silent catch、error text leak、test weakening 或范围扩张。

--- a/specs/GH48/tasks.md
+++ b/specs/GH48/tasks.md
@@ -11,8 +11,8 @@
 
 - [ ] `SP48-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`, `B-003`. Done when: eligibility read-only；success 后 prune+commit；existing settings/dedupe window/different-body semantics exact。 Verify: notifications + storage read tests。
 - [ ] `SP48-T2` Owner: codex. Dependencies: T1. Covers: `B-002`, `B-006`. Done when: typed sent/skipped/failure；denial、permission/plugin/send/read failure 不 commit且 retry；fixed safe message + on_failure exactly once。 Verify: delivery failure matrix。
-- [ ] `SP48-T3` Owner: codex. Dependencies: T1-T2. Covers: `B-004`, `B-005`. Done when: same-body concurrency one send、different body independent、finally release；post-send write failure returns sent and session-dedupes。 Verify: deferred concurrency + throwing storage tests。
-- [ ] `SP48-T4` Owner: codex. Dependencies: T2. Covers: `B-006`. Done when: service threshold 与 bonus callers 把 failure 固定消息写入 critical event，零 recursive notify；原事件顺序不变。 Verify: exact static gate + outcome callback tests。
+- [ ] `SP48-T3` Owner: codex. Dependencies: T1-T2. Covers: `B-003`, `B-004`, `B-005`. Done when: same-body concurrency one send；different-body concurrent success 使用 commit-time fresh read/merge，storage 同含 A/B 且随后两者 duplicate；finally release；post-send fresh-read/write failure 均 sent + session-deduped。 Verify: deferred concurrency、A/B lost-update、throwing read/write storage tests。
+- [ ] `SP48-T4` Owner: codex. Dependencies: T2. Covers: `B-006`. Done when: service 80%/95% 与 bonus 三个 callsites 的第三参数均为 tested failure-options helper；callback 只写 fixed critical event、零 recursive notify；原事件顺序不变。 Verify: TypeScript AST exact-callsite/helper gate + outcome callback tests。
 - [ ] `SP48-T5` Owner: codex. Dependencies: T1-T4. Covers: `B-001`~`B-006`. Done when: 8-path allowlist、checker 100%、overall diff ≥80%、notifications critical diff 100%、full frontend/build/Rust pass。 Verify: tech Test Plan。
 
 ## Handoff

--- a/specs/GH48/tech.md
+++ b/specs/GH48/tech.md
@@ -40,6 +40,8 @@ export interface NotificationDeliveryOptions {
 
 `shouldNotify(body, now)` 只读取 typed storage result：failure→false，missing/expired→true，recent→false，零 write。
 
+module-local `delivered_this_session: Map<string, number>` 保存成功 delivery timestamp，并在每次 eligibility/commit 按 12 小时窗口 pruning。eligibility 先检查该 map，再读 persistent/shadow storage。
+
 `notify(title, body, options)`：
 
 1. no backend → skipped/backend_unavailable。
@@ -48,24 +50,26 @@ export interface NotificationDeliveryOptions {
 4. add body to `in_flight`，进入 `try/finally`。
 5. dynamic import；permission check/request。denied → typed failure。
 6. 调用 `sendNotification`；无异常返回才算 delivered。
-7. 写 timestamp + pruning。write 使用 `preserveSessionValue: true, notifyUser: false`；false 表示 persistent write failed but session shadow exists，仍返回 sent。
-8. finally 无条件删除 `in_flight`。
+7. send 成功后立即把 body/commit-time `Date.now()` 写入 session map。
+8. 重新 fresh typed read 当前 persistent/shadow dedupe；不能复用 pre-send eligibility snapshot。read success/missing 时 merge 所有仍在窗口内的 entries + 当前 body 后写入；这段 fresh-read/merge/write 无 `await`，避免不同 body concurrent lost update。
+9. fresh read failure 时不做 persistent overwrite；session map 已保证本 session dedupe，返回 sent。write 使用 `preserveSessionValue: true, notifyUser: false`；false 时 shadow 保存 merged state，仍返回 sent。
+10. finally 无条件删除 `in_flight`。
 
-timestamp 使用 delivery commit 时的 `Date.now()`，不是 eligibility start time。不同 body 独立。send 为同步 API，但 dynamic import/permission awaits 使 concurrent call 必须有 guard。
+timestamp 使用 delivery commit 时的 `Date.now()`，不是 eligibility start time。不同 body 并发测试必须在两次成功后断言 storage 同时包含 A/B，随后 A/B 都 duplicate；post-send fresh-read failure 必须断言 sent + session duplicate。send 为同步 API，但 dynamic import/permission awaits 使 concurrent call 必须有 guard。
 
 ### 3. Callers
 
-`use_service_events.ts` 与 App bonus caller 均传：
+`notifications.ts` 提供 pure `createNotificationFailureOptions(log_event)`；它只返回：
 
 ```ts
-{ on_failure: (message) => logEvent('critical', message) }
+{ on_failure: (message) => log_event('critical', message) }
 ```
 
-callback 只写 event，不调用 notify，不产生 recursion。现有 threshold/bonus event 仍先记录原 warning/critical，再在 delivery failure 时追加 fixed critical event。
+App bonus 与 hook 内 80%/95% 三个 `notify` callsites 的第三参数都必须精确为 `createNotificationFailureOptions(logEvent)`。callback 只写 event，不调用 notify，不产生 recursion。unit test 验证 callback behavior；Test Plan 的 TypeScript AST gate 验证 callsite count/third argument，并检查 helper callback 只有一个 `log_event('critical', message)` CallExpression、零 `notify` identifier。
 
 ### 4. Tests and coverage
 
-新 `tests/notification_delivery_failures.test.ts` mock Tauri plugin/backend marker、fake timers 与 memory/throwing storage，逐项验证 B-001~B-006。现有 `notifications.test.ts` 改为 read-only eligibility assertions；storage read/write suites 更新 dedupe contract，并保留 corrupt/access/write failure regression。
+新 `tests/notification_delivery_failures.test.ts` mock Tauri plugin/backend marker、fake timers 与 memory/throwing storage，逐项验证 B-001~B-006，包括 different-body Promise.all 后 persistent A/B 与 subsequent duplicate、post-send fresh-read failure 的 session dedupe。现有 `notifications.test.ts` 改为 read-only eligibility assertions；storage read/write suites 更新 dedupe contract，并保留 corrupt/access/write failure regression。
 
 diff coverage checker：overall ≥80%，`src/services/notifications.ts=100`。App/hook caller lines通过 source-level exact checks与 integration outcome callback tests；禁止 dummy code。
 
@@ -86,7 +90,8 @@ diff coverage checker：overall ≥80%，`src/services/notifications.ts=100`。A
 | --- | --- |
 | mark-after-send permits concurrent duplicates | module-local same-body in-flight guard + concurrent test。 |
 | guard leaks after denial/error | single try/finally + every terminal-path retry test。 |
-| successful send then storage failure repeats | preserveSessionValue shadow + same-session duplicate test。 |
+| different body concurrent commits overwrite | post-send fresh read/merge/prune without await + A/B storage/subsequent duplicate test。 |
+| successful send then fresh-read/write failure repeats | delivered session timestamp map + shadow where writable + same-session duplicate tests。 |
 | permission denial silently disappears | typed failure + on_failure exact-once event。 |
 | original errors leak | fixed constants + safe callback-error log assertions。 |
 | refactor changes window/pruning | deterministic fake-time boundary/different-body tests。 |
@@ -98,9 +103,9 @@ diff coverage checker：overall ≥80%，`src/services/notifications.ts=100`。A
 | --- | --- |
 | `B-001` read-only eligibility | missing/recent/expired/corrupt/access tests + zero setItem |
 | `B-002` failure retry | denial/permission throw/send throw/plugin failure + retry |
-| `B-003` success commit | sent then duplicate; different body; timestamp at commit |
+| `B-003` success commit | sent then duplicate; concurrent A/B both persisted; timestamp at commit |
 | `B-004` concurrency | deferred permission + Promise.all same/different bodies |
-| `B-005` post-send write failure | sent + session shadow + one send |
+| `B-005` post-send persistence failure | fresh-read failure/write failure both sent + session duplicate |
 | `B-006` visibility/regression | typed outcomes、on_failure、safe messages、coverage/full gates |
 
 ## Test Plan
@@ -118,7 +123,53 @@ git diff --quiet origin/main...HEAD -- . \
   ':(exclude)tests/storage_read_failures.test.ts' \
   ':(exclude)tests/storage_write_failures.test.ts' \
   ':(exclude)specs/GH48/tasks.md'
-rg -n "on_failure.*logEvent\('critical'" src/App.tsx src/hooks/use_service_events.ts
+node --input-type=module -e "
+  import ts from 'typescript';
+  import { readFileSync } from 'node:fs';
+  const parse = (path) => ts.createSourceFile(path, readFileSync(path, 'utf8'), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const notifyCalls = [];
+  for (const path of ['src/App.tsx', 'src/hooks/use_service_events.ts']) {
+    const source = parse(path);
+    const visit = (node) => {
+      if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === 'notify') notifyCalls.push(node);
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  if (notifyCalls.length !== 3) process.exit(1);
+  for (const call of notifyCalls) {
+    const option = call.arguments[2];
+    if (!option || !ts.isCallExpression(option) || !ts.isIdentifier(option.expression) || option.expression.text !== 'createNotificationFailureOptions') process.exit(1);
+    if (option.arguments.length !== 1 || !ts.isIdentifier(option.arguments[0]) || option.arguments[0].text !== 'logEvent') process.exit(1);
+  }
+  const notifications = parse('src/services/notifications.ts');
+  let helper;
+  const find = (node) => {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === 'createNotificationFailureOptions') helper = node;
+    ts.forEachChild(node, find);
+  };
+  find(notifications);
+  if (!helper) process.exit(1);
+  const statements = helper.body?.statements ?? [];
+  if (statements.length !== 1 || !ts.isReturnStatement(statements[0])) process.exit(1);
+  const result = statements[0].expression;
+  if (!result || !ts.isObjectLiteralExpression(result) || result.properties.length !== 1) process.exit(1);
+  const property = result.properties[0];
+  if (!ts.isPropertyAssignment(property) || !ts.isIdentifier(property.name) || property.name.text !== 'on_failure') process.exit(1);
+  const callback = property.initializer;
+  if (!ts.isArrowFunction(callback) || callback.parameters.length !== 1 || callback.parameters[0].name.getText(notifications) !== 'message') process.exit(1);
+  const invocation = callback.body;
+  if (!ts.isCallExpression(invocation) || !ts.isIdentifier(invocation.expression) || invocation.expression.text !== 'log_event') process.exit(1);
+  if (invocation.arguments.length !== 2 || !ts.isStringLiteral(invocation.arguments[0]) || invocation.arguments[0].text !== 'critical') process.exit(1);
+  if (!ts.isIdentifier(invocation.arguments[1]) || invocation.arguments[1].text !== 'message') process.exit(1);
+  let recursive = false;
+  const rejectNotify = (node) => {
+    if (ts.isIdentifier(node) && node.text === 'notify') recursive = true;
+    ts.forEachChild(node, rejectNotify);
+  };
+  rejectNotify(helper);
+  if (recursive) process.exit(1);
+"
 npx vitest run tests/notification_delivery_failures.test.ts tests/notifications.test.ts tests/storage_read_failures.test.ts tests/storage_write_failures.test.ts
 node --experimental-test-coverage \
   --test-coverage-include=scripts/check_ts_diff_coverage.mjs \

--- a/specs/GH48/tech.md
+++ b/specs/GH48/tech.md
@@ -1,0 +1,147 @@
+# GH-48 Tech Spec：delivery-first notification dedupe 状态机
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/48
+- Product spec: `specs/GH48/product.md`
+
+## Root Cause
+
+`shouldNotify` 同时读取 eligibility 与写入 sent timestamp，`notify` 又在任何 `await import`/permission/send 之前调用它。因此 state order 是 `eligible → committed → attempted`。catch 只 console.error，调用方无法区分 sent、duplicate、denied 或 transport failure。
+
+## Preflight Contract
+
+implementation 必须从 spec merge 后 then-latest `origin/main` 创建，并在 edit 前验证：
+
+- `notify` 仍在 permission/plugin/send 前调用 mutating `shouldNotify`。
+- denial 与 send-throw disposable reproduction 均证明 next same-body `shouldNotify=false`。
+- existing notification/storage suites 与 baseline build 全绿。
+
+任一行为漂移必须先更新 GH48 spec。
+
+## Proposed Design
+
+### 1. Typed states
+
+```ts
+export type NotificationDeliveryResult =
+  | { status: 'sent' }
+  | { status: 'skipped'; reason: 'backend_unavailable' | 'duplicate' | 'in_flight' }
+  | { status: 'failure'; message: string };
+
+export interface NotificationDeliveryOptions {
+  on_failure?: (message: string) => void;
+}
+```
+
+固定 messages 区分 dedupe unavailable、permission denied、delivery failed；不得拼接 original error/body/key。failure helper 同时返回 result 并调用 `on_failure` exactly once；callback 自身抛错必须被 fixed safe console error 捕获，不能改变 delivery result。
+
+### 2. State transitions
+
+`shouldNotify(body, now)` 只读取 typed storage result：failure→false，missing/expired→true，recent→false，零 write。
+
+`notify(title, body, options)`：
+
+1. no backend → skipped/backend_unavailable。
+2. body already in module-local `in_flight` → skipped/in_flight。
+3. read eligibility：storage failure → typed failure；recent → skipped/duplicate。
+4. add body to `in_flight`，进入 `try/finally`。
+5. dynamic import；permission check/request。denied → typed failure。
+6. 调用 `sendNotification`；无异常返回才算 delivered。
+7. 写 timestamp + pruning。write 使用 `preserveSessionValue: true, notifyUser: false`；false 表示 persistent write failed but session shadow exists，仍返回 sent。
+8. finally 无条件删除 `in_flight`。
+
+timestamp 使用 delivery commit 时的 `Date.now()`，不是 eligibility start time。不同 body 独立。send 为同步 API，但 dynamic import/permission awaits 使 concurrent call 必须有 guard。
+
+### 3. Callers
+
+`use_service_events.ts` 与 App bonus caller 均传：
+
+```ts
+{ on_failure: (message) => logEvent('critical', message) }
+```
+
+callback 只写 event，不调用 notify，不产生 recursion。现有 threshold/bonus event 仍先记录原 warning/critical，再在 delivery failure 时追加 fixed critical event。
+
+### 4. Tests and coverage
+
+新 `tests/notification_delivery_failures.test.ts` mock Tauri plugin/backend marker、fake timers 与 memory/throwing storage，逐项验证 B-001~B-006。现有 `notifications.test.ts` 改为 read-only eligibility assertions；storage read/write suites 更新 dedupe contract，并保留 corrupt/access/write failure regression。
+
+diff coverage checker：overall ≥80%，`src/services/notifications.ts=100`。App/hook caller lines通过 source-level exact checks与 integration outcome callback tests；禁止 dummy code。
+
+## Affected Files / Allowlist
+
+- `src/services/notifications.ts`
+- `src/hooks/use_service_events.ts`
+- `src/App.tsx`
+- `tests/notifications.test.ts`
+- `tests/notification_delivery_failures.test.ts`
+- `tests/storage_read_failures.test.ts`
+- `tests/storage_write_failures.test.ts`
+- `specs/GH48/tasks.md`
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| mark-after-send permits concurrent duplicates | module-local same-body in-flight guard + concurrent test。 |
+| guard leaks after denial/error | single try/finally + every terminal-path retry test。 |
+| successful send then storage failure repeats | preserveSessionValue shadow + same-session duplicate test。 |
+| permission denial silently disappears | typed failure + on_failure exact-once event。 |
+| original errors leak | fixed constants + safe callback-error log assertions。 |
+| refactor changes window/pruning | deterministic fake-time boundary/different-body tests。 |
+| public contract ambiguity | discriminated union; no void/boolean conflation。 |
+
+## Product-to-Test Mapping
+
+| Invariant | Verification |
+| --- | --- |
+| `B-001` read-only eligibility | missing/recent/expired/corrupt/access tests + zero setItem |
+| `B-002` failure retry | denial/permission throw/send throw/plugin failure + retry |
+| `B-003` success commit | sent then duplicate; different body; timestamp at commit |
+| `B-004` concurrency | deferred permission + Promise.all same/different bodies |
+| `B-005` post-send write failure | sent + session shadow + one send |
+| `B-006` visibility/regression | typed outcomes、on_failure、safe messages、coverage/full gates |
+
+## Test Plan
+
+```bash
+set -euo pipefail
+git fetch origin main:refs/remotes/origin/main
+git merge-base --is-ancestor origin/main HEAD
+git diff --quiet origin/main...HEAD -- . \
+  ':(exclude)src/services/notifications.ts' \
+  ':(exclude)src/hooks/use_service_events.ts' \
+  ':(exclude)src/App.tsx' \
+  ':(exclude)tests/notifications.test.ts' \
+  ':(exclude)tests/notification_delivery_failures.test.ts' \
+  ':(exclude)tests/storage_read_failures.test.ts' \
+  ':(exclude)tests/storage_write_failures.test.ts' \
+  ':(exclude)specs/GH48/tasks.md'
+rg -n "on_failure.*logEvent\('critical'" src/App.tsx src/hooks/use_service_events.ts
+npx vitest run tests/notification_delivery_failures.test.ts tests/notifications.test.ts tests/storage_read_failures.test.ts tests/storage_write_failures.test.ts
+node --experimental-test-coverage \
+  --test-coverage-include=scripts/check_ts_diff_coverage.mjs \
+  --test-coverage-lines=100 \
+  --test-coverage-functions=100 \
+  --test-coverage-branches=100 \
+  --test scripts/check_ts_diff_coverage.test.mjs
+npx vitest run --coverage \
+  --coverage.include='src/**/*.{ts,tsx}' \
+  --coverage.reporter=lcov \
+  --coverage.reporter=text
+node scripts/check_ts_diff_coverage.mjs \
+  --base origin/main \
+  --lcov coverage/lcov.info \
+  --minimum 80 \
+  --critical src/services/notifications.ts=100
+npm test
+npm run build
+cargo fmt --manifest-path src-tauri/Cargo.toml --check
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+## Rollback Plan
+
+回滚 implementation PR，恢复旧 pre-send dedupe。无 schema、window、settings、dependency 或 data migration；已有 dedupe JSON 保持兼容。


### PR DESCRIPTION
Refs #48

## Why

Current notification eligibility mutates the 12-hour dedupe state before permission/plugin/send. Fresh disposable tests proved both permission denial and send failure produce zero delivery while suppressing the next same-body attempt.

## Spec plan

- split read-only eligibility from successful-delivery commit
- use typed `sent | skipped | failure` outcomes and fixed safe messages
- release same-body in-flight reservations on every terminal path
- commit timestamp only after `sendNotification` succeeds
- preserve session shadow if the post-send persistent write fails
- surface failure through existing event logging with no recursive notification
- preserve window, storage JSON, thresholds, body identity, settings, dependencies, and browser behavior

## Verification contract

- deterministic success/duplicate/different-body matrix
- denial, permission API, plugin, send, storage read/decode failures and later retry
- concurrent same/different body behavior
- post-send write failure + session shadow
- 8-path allowlist
- overall executable diff coverage >=80%, notification critical paths 100%
- full frontend/build/Rust, current-head review/CI/reviewThreads gates

## Baseline evidence

- disposable reproduction: 2/2 bug assertions passed
- current baseline: 18 test files / 150 tests passed
- current build passed
- search-first found no existing issue/PR for this defect

## Diff coverage

N/A for this spec-only PR; no executable source is added.