### PR TITLE
fix: prevent stale provider refresh overwrites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,10 @@
         "@tauri-apps/cli": "2.10.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/react-test-renderer": "19.1.0",
         "@vitejs/plugin-react": "^4.6.0",
         "@vitest/coverage-v8": "4.1.6",
+        "react-test-renderer": "19.2.6",
         "typescript": "~5.8.3",
         "vite": "^7.0.4",
         "vitest": "4.1.6"
@@ -1508,6 +1510,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2215,6 +2227,13 @@
         "react": "^19.2.6"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2223,6 +2242,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.6.tgz",
+      "integrity": "sha512-GbS6V23YduFTPiWJ5xICbKEjRcqx1Z90js/V5miqhz7qp/d6xSe9Dd6NjSQODFRdzdsqRMPW82E/sFpPRbY5Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.2.6",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "@tauri-apps/cli": "2.10.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/react-test-renderer": "19.1.0",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/coverage-v8": "4.1.6",
+    "react-test-renderer": "19.2.6",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
     "vitest": "4.1.6"

--- a/scripts/check_latest_request_wiring.mjs
+++ b/scripts/check_latest_request_wiring.mjs
@@ -4,50 +4,62 @@ import ts from 'typescript';
 const owner_configs = [
   {
     path: 'src/App.tsx',
+    component_name: 'App',
     function_name: 'fetchClaudeQuota',
     owner_name: 'claude_request_generation',
     backend_methods: ['getQuota'],
     loading: true,
     loading_setter: 'setClaudeLoading',
+    await_kind: 'direct',
   },
   {
     path: 'src/components/CodexPanel.tsx',
+    component_name: 'CodexPanel',
     function_name: 'fetchData',
     owner_name: 'request_generation',
     backend_methods: ['getCodexInfo', 'getCodexRateLimits', 'getCodexResetCredits'],
     loading: true,
     loading_setter: 'setLoading',
+    await_kind: 'promise_all',
   },
   {
     path: 'src/components/CursorPanel.tsx',
+    component_name: 'CursorPanel',
     function_name: 'fetchData',
     owner_name: 'request_generation',
     backend_methods: ['getCursorInfo'],
     loading: true,
     loading_setter: 'setLoading',
+    await_kind: 'direct',
   },
   {
     path: 'src/components/AntigravityPanel.tsx',
+    component_name: 'AntigravityPanel',
     function_name: 'fetchData',
     owner_name: 'request_generation',
     backend_methods: ['getAntigravityInfo'],
     loading: true,
     loading_setter: 'setLoading',
+    await_kind: 'direct',
   },
   {
     path: 'src/components/CostSummarySection.tsx',
+    component_name: 'CostSummarySection',
     function_name: 'loadCost',
     owner_name: 'overview_generation',
     backend_methods: ['getCostOverview'],
     loading: true,
     loading_setter: 'setLoading',
+    await_kind: 'promise_all',
   },
   {
     path: 'src/components/CostSummarySection.tsx',
+    component_name: 'CostSummarySection',
     function_name: 'loadDaily',
     owner_name: 'daily_generation',
     backend_methods: ['getCostDaily'],
     loading: false,
+    await_kind: 'promise_all',
   },
 ];
 
@@ -141,12 +153,11 @@ function is_generation_start(statement, owner_name) {
     && declaration.initializer.arguments.length === 0;
 }
 
-function backend_methods_in(statement) {
-  const methods = collect_nodes(statement, (node) => {
+function backend_method_calls_in(root) {
+  return collect_nodes(root, (node) => {
     const parts = property_call_parts(node);
     return parts !== null && parts.owner_name === 'backend';
   }).map((node) => property_call_parts(node).method_name);
-  return [...new Set(methods)].sort();
 }
 
 function same_strings(left, right) {
@@ -154,8 +165,29 @@ function same_strings(left, right) {
   return left.every((value, index) => value === right[index]);
 }
 
-function validate_owner(source_file, config) {
-  const declarations = collect_nodes(source_file, (node) => (
+function validate_await_operand(await_expression, await_statement, config) {
+  const expected_methods = [...config.backend_methods].sort();
+  const statement_methods = backend_method_calls_in(await_statement).sort();
+  ensure(same_strings(statement_methods, expected_methods), `${config.path}:${config.function_name} backend call count or placement is wrong`);
+
+  if (config.await_kind === 'direct') {
+    const parts = property_call_parts(await_expression.expression);
+    ensure(parts !== null, `${config.path}:${config.function_name} must directly await its backend call`);
+    ensure(parts.owner_name === 'backend', `${config.path}:${config.function_name} must directly await its backend owner`);
+    ensure(same_strings([parts.method_name], expected_methods), `${config.path}:${config.function_name} direct backend await mapping is wrong`);
+    return;
+  }
+
+  const promise_all = property_call_parts(await_expression.expression);
+  ensure(promise_all !== null, `${config.path}:${config.function_name} must await Promise.all`);
+  ensure(promise_all.owner_name === 'Promise' && promise_all.method_name === 'all', `${config.path}:${config.function_name} must await Promise.all`);
+  ensure(await_expression.expression.arguments.length === 1, `${config.path}:${config.function_name} Promise.all argument count is wrong`);
+  const operand_methods = backend_method_calls_in(await_expression.expression.arguments[0]).sort();
+  ensure(same_strings(operand_methods, expected_methods), `${config.path}:${config.function_name} Promise.all backend dataflow is wrong`);
+}
+
+function validate_owner(component_body, config) {
+  const declarations = collect_nodes(component_body, (node) => (
     ts.isVariableDeclaration(node) && identifier_name(node.name) === config.function_name
   ));
   ensure(declarations.length === 1, `${config.path}:${config.function_name} target count is not one`);
@@ -173,9 +205,10 @@ function validate_owner(source_file, config) {
   }
   ensure(await_indexes.length === 1, `${config.path}:${config.function_name} backend await count is not one`);
   const await_index = await_indexes[0];
-  const actual_methods = backend_methods_in(try_statement.tryBlock.statements[await_index]);
-  const expected_methods = [...config.backend_methods].sort();
-  ensure(same_strings(actual_methods, expected_methods), `${config.path}:${config.function_name} backend await mapping is wrong`);
+  const await_statement = try_statement.tryBlock.statements[await_index];
+  const await_expressions = collect_nodes(await_statement, ts.isAwaitExpression);
+  ensure(await_expressions.length === 1, `${config.path}:${config.function_name} await expression count is not one`);
+  validate_await_operand(await_expressions[0], await_statement, config);
   const success_guard = try_statement.tryBlock.statements[await_index + 1];
   ensure(success_guard !== undefined, `${config.path}:${config.function_name} has no success guard`);
   ensure(is_fail_closed_guard(success_guard, config.owner_name), `${config.path}:${config.function_name} success guard is not fail closed`);
@@ -193,18 +226,33 @@ function validate_owner(source_file, config) {
   }
 }
 
-function validate_hook_bindings(source_file, path, configs) {
-  const hook_calls = collect_nodes(source_file, (node) => is_identifier_call(node, 'useLatestRequestGeneration'));
+function validate_hook_bindings(component_body, path, configs) {
+  const hook_calls = collect_nodes(component_body, (node) => is_identifier_call(node, 'useLatestRequestGeneration'));
   ensure(hook_calls.length === configs.length, `${path} hook call count is wrong`);
   const owner_names = hook_calls.map((call) => {
     ensure(call.arguments.length === 0, `${path} generation hook must have no arguments`);
     const declaration = call.parent;
     ensure(ts.isVariableDeclaration(declaration), `${path} generation hook is not bound by a variable declarator`);
     ensure(declaration.initializer === call, `${path} generation hook is not the declarator initializer`);
+    const variable_statement = declaration.parent.parent;
+    ensure(ts.isVariableStatement(variable_statement), `${path} generation hook is not a variable statement`);
+    ensure(variable_statement.parent === component_body, `${path} generation hook must be bound directly in its owning component`);
     return identifier_name(declaration.name);
   }).sort();
   const expected_names = configs.map((config) => config.owner_name).sort();
   ensure(same_strings(owner_names, expected_names), `${path} generation owner binding is wrong`);
+}
+
+function get_component_body(source_file, path, configs) {
+  const component_name = configs[0].component_name;
+  ensure(configs.every((config) => config.component_name === component_name), `${path} component mapping is inconsistent`);
+  const components = collect_nodes(source_file, (node) => (
+    ts.isFunctionDeclaration(node) && identifier_name(node.name) === component_name
+  ));
+  ensure(components.length === 1, `${path}:${component_name} component count is not one`);
+  ensure(components[0].parent === source_file, `${path}:${component_name} must be declared at module scope`);
+  ensure(components[0].body !== undefined, `${path}:${component_name} has no body`);
+  return components[0].body;
 }
 
 function validate_cost_cleanup(source_file) {
@@ -281,8 +329,9 @@ export function check_latest_request_wiring(sources = read_owner_sources()) {
     ensure(typeof source === 'string', `${path} source is missing`);
     const source_file = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
     source_files.set(path, source_file);
-    validate_hook_bindings(source_file, path, configs);
-    for (const config of configs) validate_owner(source_file, config);
+    const component_body = get_component_body(source_file, path, configs);
+    validate_hook_bindings(component_body, path, configs);
+    for (const config of configs) validate_owner(component_body, config);
   }
 
   validate_cost_cleanup(source_files.get('src/components/CostSummarySection.tsx'));

--- a/scripts/check_latest_request_wiring.mjs
+++ b/scripts/check_latest_request_wiring.mjs
@@ -1,0 +1,292 @@
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+const owner_configs = [
+  {
+    path: 'src/App.tsx',
+    function_name: 'fetchClaudeQuota',
+    owner_name: 'claude_request_generation',
+    backend_methods: ['getQuota'],
+    loading: true,
+    loading_setter: 'setClaudeLoading',
+  },
+  {
+    path: 'src/components/CodexPanel.tsx',
+    function_name: 'fetchData',
+    owner_name: 'request_generation',
+    backend_methods: ['getCodexInfo', 'getCodexRateLimits', 'getCodexResetCredits'],
+    loading: true,
+    loading_setter: 'setLoading',
+  },
+  {
+    path: 'src/components/CursorPanel.tsx',
+    function_name: 'fetchData',
+    owner_name: 'request_generation',
+    backend_methods: ['getCursorInfo'],
+    loading: true,
+    loading_setter: 'setLoading',
+  },
+  {
+    path: 'src/components/AntigravityPanel.tsx',
+    function_name: 'fetchData',
+    owner_name: 'request_generation',
+    backend_methods: ['getAntigravityInfo'],
+    loading: true,
+    loading_setter: 'setLoading',
+  },
+  {
+    path: 'src/components/CostSummarySection.tsx',
+    function_name: 'loadCost',
+    owner_name: 'overview_generation',
+    backend_methods: ['getCostOverview'],
+    loading: true,
+    loading_setter: 'setLoading',
+  },
+  {
+    path: 'src/components/CostSummarySection.tsx',
+    function_name: 'loadDaily',
+    owner_name: 'daily_generation',
+    backend_methods: ['getCostDaily'],
+    loading: false,
+  },
+];
+
+function ensure(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function collect_nodes(root, predicate) {
+  const matches = [];
+  const visit = (node) => {
+    if (predicate(node)) matches.push(node);
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return matches;
+}
+
+function identifier_name(node) {
+  return ts.isIdentifier(node) ? node.text : null;
+}
+
+function is_identifier_call(node, name) {
+  return ts.isCallExpression(node) && identifier_name(node.expression) === name;
+}
+
+function property_call_parts(node) {
+  if (!ts.isCallExpression(node)) return null;
+  if (!ts.isPropertyAccessExpression(node.expression)) return null;
+  const owner_name = identifier_name(node.expression.expression);
+  if (owner_name === null) return null;
+  return { node, owner_name, method_name: node.expression.name.text };
+}
+
+function is_property_call(node, owner_name, method_name, argument_name) {
+  const parts = property_call_parts(node);
+  if (parts === null) return false;
+  if (parts.owner_name !== owner_name || parts.method_name !== method_name) return false;
+  if (argument_name === undefined) return node.arguments.length === 0;
+  if (node.arguments.length !== 1) return false;
+  return identifier_name(node.arguments[0]) === argument_name;
+}
+
+function is_return_statement(node) {
+  if (ts.isReturnStatement(node)) return true;
+  if (!ts.isBlock(node)) return false;
+  return node.statements.length === 1 && ts.isReturnStatement(node.statements[0]);
+}
+
+function is_fail_closed_guard(statement, owner_name) {
+  if (!ts.isIfStatement(statement) || statement.elseStatement !== undefined) return false;
+  if (!ts.isPrefixUnaryExpression(statement.expression)) return false;
+  if (statement.expression.operator !== ts.SyntaxKind.ExclamationToken) return false;
+  if (!is_property_call(statement.expression.operand, owner_name, 'isCurrent', 'generation')) return false;
+  return is_return_statement(statement.thenStatement);
+}
+
+function is_loading_finish_guard(statement, owner_name, loading_setter) {
+  if (!ts.isIfStatement(statement) || statement.elseStatement !== undefined) return false;
+  if (!is_property_call(statement.expression, owner_name, 'isCurrent', 'generation')) return false;
+  if (!ts.isBlock(statement.thenStatement)) return false;
+  if (statement.thenStatement.statements.length !== 1) return false;
+  const loading_statement = statement.thenStatement.statements[0];
+  if (!ts.isExpressionStatement(loading_statement)) return false;
+  return is_identifier_call(loading_statement.expression, loading_setter)
+    && loading_statement.expression.arguments.length === 1
+    && loading_statement.expression.arguments[0].kind === ts.SyntaxKind.FalseKeyword;
+}
+
+function get_function_body(declaration, config) {
+  let initializer = declaration.initializer;
+  ensure(initializer !== undefined, `${config.path}:${config.function_name} has no initializer`);
+  if (is_identifier_call(initializer, 'useCallback')) {
+    ensure(initializer.arguments.length > 0, `${config.path}:${config.function_name} useCallback has no function`);
+    initializer = initializer.arguments[0];
+  }
+  ensure(ts.isArrowFunction(initializer), `${config.path}:${config.function_name} is not an arrow function`);
+  ensure(initializer.modifiers !== undefined, `${config.path}:${config.function_name} is not async`);
+  ensure(initializer.modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword), `${config.path}:${config.function_name} is not async`);
+  ensure(ts.isBlock(initializer.body), `${config.path}:${config.function_name} has no block body`);
+  return initializer.body;
+}
+
+function is_generation_start(statement, owner_name) {
+  if (!ts.isVariableStatement(statement)) return false;
+  if ((statement.declarationList.flags & ts.NodeFlags.Const) === 0) return false;
+  if (statement.declarationList.declarations.length !== 1) return false;
+  const declaration = statement.declarationList.declarations[0];
+  if (identifier_name(declaration.name) !== 'generation') return false;
+  if (declaration.initializer === undefined) return false;
+  return is_property_call(declaration.initializer, owner_name, 'begin', undefined)
+    && declaration.initializer.arguments.length === 0;
+}
+
+function backend_methods_in(statement) {
+  const methods = collect_nodes(statement, (node) => {
+    const parts = property_call_parts(node);
+    return parts !== null && parts.owner_name === 'backend';
+  }).map((node) => property_call_parts(node).method_name);
+  return [...new Set(methods)].sort();
+}
+
+function same_strings(left, right) {
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
+function validate_owner(source_file, config) {
+  const declarations = collect_nodes(source_file, (node) => (
+    ts.isVariableDeclaration(node) && identifier_name(node.name) === config.function_name
+  ));
+  ensure(declarations.length === 1, `${config.path}:${config.function_name} target count is not one`);
+  const body = get_function_body(declarations[0], config);
+  ensure(body.statements.length > 1, `${config.path}:${config.function_name} body is incomplete`);
+  ensure(is_generation_start(body.statements[0], config.owner_name), `${config.path}:${config.function_name} must begin with its generation token`);
+
+  const try_statements = body.statements.filter(ts.isTryStatement);
+  ensure(try_statements.length === 1, `${config.path}:${config.function_name} try count is not one`);
+  const try_statement = try_statements[0];
+  const await_indexes = [];
+  for (let index = 0; index < try_statement.tryBlock.statements.length; index += 1) {
+    const awaits = collect_nodes(try_statement.tryBlock.statements[index], ts.isAwaitExpression);
+    if (awaits.length > 0) await_indexes.push(index);
+  }
+  ensure(await_indexes.length === 1, `${config.path}:${config.function_name} backend await count is not one`);
+  const await_index = await_indexes[0];
+  const actual_methods = backend_methods_in(try_statement.tryBlock.statements[await_index]);
+  const expected_methods = [...config.backend_methods].sort();
+  ensure(same_strings(actual_methods, expected_methods), `${config.path}:${config.function_name} backend await mapping is wrong`);
+  const success_guard = try_statement.tryBlock.statements[await_index + 1];
+  ensure(success_guard !== undefined, `${config.path}:${config.function_name} has no success guard`);
+  ensure(is_fail_closed_guard(success_guard, config.owner_name), `${config.path}:${config.function_name} success guard is not fail closed`);
+
+  ensure(try_statement.catchClause !== undefined, `${config.path}:${config.function_name} has no catch`);
+  const catch_statements = try_statement.catchClause.block.statements;
+  ensure(catch_statements.length > 0, `${config.path}:${config.function_name} catch is empty`);
+  ensure(is_fail_closed_guard(catch_statements[0], config.owner_name), `${config.path}:${config.function_name} catch guard is not fail closed`);
+
+  if (config.loading) {
+    ensure(try_statement.finallyBlock !== undefined, `${config.path}:${config.function_name} has no finally`);
+    const finally_statements = try_statement.finallyBlock.statements;
+    ensure(finally_statements.length === 1, `${config.path}:${config.function_name} finally must contain one current guard`);
+    ensure(is_loading_finish_guard(finally_statements[0], config.owner_name, config.loading_setter), `${config.path}:${config.function_name} finally loading guard is wrong`);
+  }
+}
+
+function validate_hook_bindings(source_file, path, configs) {
+  const hook_calls = collect_nodes(source_file, (node) => is_identifier_call(node, 'useLatestRequestGeneration'));
+  ensure(hook_calls.length === configs.length, `${path} hook call count is wrong`);
+  const owner_names = hook_calls.map((call) => {
+    ensure(call.arguments.length === 0, `${path} generation hook must have no arguments`);
+    const declaration = call.parent;
+    ensure(ts.isVariableDeclaration(declaration), `${path} generation hook is not bound by a variable declarator`);
+    ensure(declaration.initializer === call, `${path} generation hook is not the declarator initializer`);
+    return identifier_name(declaration.name);
+  }).sort();
+  const expected_names = configs.map((config) => config.owner_name).sort();
+  ensure(same_strings(owner_names, expected_names), `${path} generation owner binding is wrong`);
+}
+
+function validate_cost_cleanup(source_file) {
+  const effects = collect_nodes(source_file, (node) => {
+    if (!is_identifier_call(node, 'useEffect')) return false;
+    return collect_nodes(node, (child) => (
+      ts.isVariableDeclaration(child)
+      && (identifier_name(child.name) === 'loadCost' || identifier_name(child.name) === 'loadDaily')
+    )).length === 2;
+  });
+  ensure(effects.length === 1, 'CostSummarySection owning effect count is wrong');
+  const effect_function = effects[0].arguments[0];
+  ensure(ts.isArrowFunction(effect_function), 'CostSummarySection owning effect is not an arrow function');
+  ensure(ts.isBlock(effect_function.body), 'CostSummarySection owning effect has no block body');
+  const returns = effect_function.body.statements.filter(ts.isReturnStatement);
+  ensure(returns.length === 1, 'CostSummarySection owning effect cleanup count is wrong');
+  const cleanup = returns[0].expression;
+  ensure(cleanup !== undefined && ts.isArrowFunction(cleanup), 'CostSummarySection cleanup is not an arrow function');
+  ensure(ts.isBlock(cleanup.body), 'CostSummarySection cleanup has no block body');
+  const invalidated = cleanup.body.statements.flatMap((statement) => {
+    if (!ts.isExpressionStatement(statement)) return [];
+    const parts = property_call_parts(statement.expression);
+    if (parts === null || parts.method_name !== 'invalidate') return [];
+    return [parts.owner_name];
+  }).sort();
+  ensure(same_strings(invalidated, ['daily_generation', 'overview_generation']), 'CostSummarySection cleanup must invalidate both lanes exactly');
+}
+
+function validate_antigravity_pause(source_file) {
+  const effects = collect_nodes(source_file, (node) => {
+    if (!is_identifier_call(node, 'useEffect')) return false;
+    const has_fetch = collect_nodes(node, (child) => is_identifier_call(child, 'fetchData')).length > 0;
+    const has_interval = collect_nodes(node, (child) => is_identifier_call(child, 'setInterval')).length > 0;
+    return has_fetch && has_interval;
+  });
+  ensure(effects.length === 1, 'Antigravity polling effect count is wrong');
+  const effect_function = effects[0].arguments[0];
+  ensure(ts.isArrowFunction(effect_function) && ts.isBlock(effect_function.body), 'Antigravity polling effect has no block body');
+  const statements = effect_function.body.statements;
+  const pause_index = statements.findIndex((statement) => {
+    if (!ts.isIfStatement(statement) || !ts.isBinaryExpression(statement.expression)) return false;
+    const expression = statement.expression;
+    return identifier_name(expression.left) === 'autoRefreshIntervalMs'
+      && expression.operatorToken.kind === ts.SyntaxKind.LessThanEqualsToken
+      && ts.isNumericLiteral(expression.right)
+      && expression.right.text === '0'
+      && is_return_statement(statement.thenStatement);
+  });
+  const interval_index = statements.findIndex((statement) => (
+    collect_nodes(statement, (node) => is_identifier_call(node, 'setInterval')).length > 0
+  ));
+  ensure(pause_index >= 0 && pause_index < interval_index, 'Antigravity interval zero guard must precede setInterval');
+}
+
+export function read_owner_sources() {
+  const sources = new Map();
+  for (const config of owner_configs) {
+    if (!sources.has(config.path)) sources.set(config.path, readFileSync(config.path, 'utf8'));
+  }
+  return sources;
+}
+
+export function check_latest_request_wiring(sources = read_owner_sources()) {
+  const configs_by_path = new Map();
+  for (const config of owner_configs) {
+    const configs = configs_by_path.get(config.path) ?? [];
+    configs.push(config);
+    configs_by_path.set(config.path, configs);
+  }
+
+  const source_files = new Map();
+  for (const [path, configs] of configs_by_path) {
+    const source = sources.get(path);
+    ensure(typeof source === 'string', `${path} source is missing`);
+    const source_file = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+    source_files.set(path, source_file);
+    validate_hook_bindings(source_file, path, configs);
+    for (const config of configs) validate_owner(source_file, config);
+  }
+
+  validate_cost_cleanup(source_files.get('src/components/CostSummarySection.tsx'));
+  validate_antigravity_pause(source_files.get('src/components/AntigravityPanel.tsx'));
+}
+
+check_latest_request_wiring();

--- a/scripts/check_latest_request_wiring.mjs
+++ b/scripts/check_latest_request_wiring.mjs
@@ -21,6 +21,7 @@ const owner_configs = [
     loading: true,
     loading_setter: 'setLoading',
     await_kind: 'promise_all',
+    promise_all_kind: 'array',
   },
   {
     path: 'src/components/CursorPanel.tsx',
@@ -51,6 +52,7 @@ const owner_configs = [
     loading: true,
     loading_setter: 'setLoading',
     await_kind: 'promise_all',
+    promise_all_kind: 'map',
   },
   {
     path: 'src/components/CostSummarySection.tsx',
@@ -60,6 +62,7 @@ const owner_configs = [
     backend_methods: ['getCostDaily'],
     loading: false,
     await_kind: 'promise_all',
+    promise_all_kind: 'map',
   },
 ];
 
@@ -182,8 +185,28 @@ function validate_await_operand(await_expression, await_statement, config) {
   ensure(promise_all !== null, `${config.path}:${config.function_name} must await Promise.all`);
   ensure(promise_all.owner_name === 'Promise' && promise_all.method_name === 'all', `${config.path}:${config.function_name} must await Promise.all`);
   ensure(await_expression.expression.arguments.length === 1, `${config.path}:${config.function_name} Promise.all argument count is wrong`);
-  const operand_methods = backend_method_calls_in(await_expression.expression.arguments[0]).sort();
-  ensure(same_strings(operand_methods, expected_methods), `${config.path}:${config.function_name} Promise.all backend dataflow is wrong`);
+  const promise_all_argument = await_expression.expression.arguments[0];
+
+  if (config.promise_all_kind === 'array') {
+    ensure(ts.isArrayLiteralExpression(promise_all_argument), `${config.path}:${config.function_name} Promise.all must receive a direct array`);
+    const element_methods = promise_all_argument.elements.map((element) => {
+      const parts = property_call_parts(element);
+      ensure(parts !== null && parts.owner_name === 'backend', `${config.path}:${config.function_name} Promise.all array elements must be direct backend calls`);
+      return parts.method_name;
+    }).sort();
+    ensure(same_strings(element_methods, expected_methods), `${config.path}:${config.function_name} Promise.all array dataflow is wrong`);
+    return;
+  }
+
+  const map_call = property_call_parts(promise_all_argument);
+  ensure(map_call !== null, `${config.path}:${config.function_name} Promise.all must receive sources.map`);
+  ensure(map_call.owner_name === 'sources' && map_call.method_name === 'map', `${config.path}:${config.function_name} Promise.all must receive sources.map`);
+  ensure(promise_all_argument.arguments.length === 1, `${config.path}:${config.function_name} sources.map callback count is wrong`);
+  const callback = promise_all_argument.arguments[0];
+  ensure(ts.isArrowFunction(callback), `${config.path}:${config.function_name} sources.map callback must be an arrow function`);
+  const callback_call = property_call_parts(callback.body);
+  ensure(callback_call !== null && callback_call.owner_name === 'backend', `${config.path}:${config.function_name} sources.map callback must directly return a backend call`);
+  ensure(same_strings([callback_call.method_name], expected_methods), `${config.path}:${config.function_name} sources.map backend dataflow is wrong`);
 }
 
 function validate_owner(component_body, config) {

--- a/scripts/check_latest_request_wiring.mjs
+++ b/scripts/check_latest_request_wiring.mjs
@@ -11,6 +11,8 @@ const owner_configs = [
     loading: true,
     loading_setter: 'setClaudeLoading',
     await_kind: 'direct',
+    target_scope: 'component',
+    backend_arguments: { getQuota: [] },
   },
   {
     path: 'src/components/CodexPanel.tsx',
@@ -22,6 +24,12 @@ const owner_configs = [
     loading_setter: 'setLoading',
     await_kind: 'promise_all',
     promise_all_kind: 'array',
+    target_scope: 'component',
+    backend_arguments: {
+      getCodexInfo: [],
+      getCodexRateLimits: [],
+      getCodexResetCredits: [],
+    },
   },
   {
     path: 'src/components/CursorPanel.tsx',
@@ -32,6 +40,8 @@ const owner_configs = [
     loading: true,
     loading_setter: 'setLoading',
     await_kind: 'direct',
+    target_scope: 'component',
+    backend_arguments: { getCursorInfo: [] },
   },
   {
     path: 'src/components/AntigravityPanel.tsx',
@@ -42,6 +52,8 @@ const owner_configs = [
     loading: true,
     loading_setter: 'setLoading',
     await_kind: 'direct',
+    target_scope: 'component',
+    backend_arguments: { getAntigravityInfo: [] },
   },
   {
     path: 'src/components/CostSummarySection.tsx',
@@ -53,6 +65,8 @@ const owner_configs = [
     loading_setter: 'setLoading',
     await_kind: 'promise_all',
     promise_all_kind: 'map',
+    target_scope: 'cost_effect',
+    backend_arguments: { getCostOverview: ['item', 'force'] },
   },
   {
     path: 'src/components/CostSummarySection.tsx',
@@ -63,6 +77,8 @@ const owner_configs = [
     loading: false,
     await_kind: 'promise_all',
     promise_all_kind: 'map',
+    target_scope: 'cost_effect',
+    backend_arguments: { getCostDaily: ['item', 'DAILY_SERIES_DAYS', 'force'] },
   },
 ];
 
@@ -168,16 +184,28 @@ function same_strings(left, right) {
   return left.every((value, index) => value === right[index]);
 }
 
+function call_argument_names(call) {
+  return call.arguments.map(identifier_name);
+}
+
+function validate_backend_call(call, method_name, config) {
+  const parts = property_call_parts(call);
+  ensure(parts !== null && parts.owner_name === 'backend', `${config.path}:${config.function_name} backend call owner is wrong`);
+  ensure(parts.method_name === method_name, `${config.path}:${config.function_name} backend call method is wrong`);
+  ensure(
+    same_strings(call_argument_names(call), config.backend_arguments[method_name]),
+    `${config.path}:${config.function_name} backend call arguments are wrong`,
+  );
+}
+
 function validate_await_operand(await_expression, await_statement, config) {
   const expected_methods = [...config.backend_methods].sort();
   const statement_methods = backend_method_calls_in(await_statement).sort();
   ensure(same_strings(statement_methods, expected_methods), `${config.path}:${config.function_name} backend call count or placement is wrong`);
 
   if (config.await_kind === 'direct') {
-    const parts = property_call_parts(await_expression.expression);
-    ensure(parts !== null, `${config.path}:${config.function_name} must directly await its backend call`);
-    ensure(parts.owner_name === 'backend', `${config.path}:${config.function_name} must directly await its backend owner`);
-    ensure(same_strings([parts.method_name], expected_methods), `${config.path}:${config.function_name} direct backend await mapping is wrong`);
+    ensure(ts.isCallExpression(await_expression.expression), `${config.path}:${config.function_name} must directly await its backend call`);
+    validate_backend_call(await_expression.expression, expected_methods[0], config);
     return;
   }
 
@@ -192,6 +220,7 @@ function validate_await_operand(await_expression, await_statement, config) {
     const element_methods = promise_all_argument.elements.map((element) => {
       const parts = property_call_parts(element);
       ensure(parts !== null && parts.owner_name === 'backend', `${config.path}:${config.function_name} Promise.all array elements must be direct backend calls`);
+      validate_backend_call(element, parts.method_name, config);
       return parts.method_name;
     }).sort();
     ensure(same_strings(element_methods, expected_methods), `${config.path}:${config.function_name} Promise.all array dataflow is wrong`);
@@ -204,15 +233,22 @@ function validate_await_operand(await_expression, await_statement, config) {
   ensure(promise_all_argument.arguments.length === 1, `${config.path}:${config.function_name} sources.map callback count is wrong`);
   const callback = promise_all_argument.arguments[0];
   ensure(ts.isArrowFunction(callback), `${config.path}:${config.function_name} sources.map callback must be an arrow function`);
+  ensure(callback.parameters.length === 1 && identifier_name(callback.parameters[0].name) === 'item', `${config.path}:${config.function_name} sources.map callback parameter is wrong`);
   const callback_call = property_call_parts(callback.body);
   ensure(callback_call !== null && callback_call.owner_name === 'backend', `${config.path}:${config.function_name} sources.map callback must directly return a backend call`);
   ensure(same_strings([callback_call.method_name], expected_methods), `${config.path}:${config.function_name} sources.map backend dataflow is wrong`);
+  validate_backend_call(callback.body, callback_call.method_name, config);
 }
 
-function validate_owner(component_body, config) {
-  const declarations = collect_nodes(component_body, (node) => (
-    ts.isVariableDeclaration(node) && identifier_name(node.name) === config.function_name
-  ));
+function direct_variable_declarations(block, name) {
+  return block.statements.flatMap((statement) => {
+    if (!ts.isVariableStatement(statement)) return [];
+    return statement.declarationList.declarations.filter((declaration) => identifier_name(declaration.name) === name);
+  });
+}
+
+function validate_owner(target_body, config) {
+  const declarations = direct_variable_declarations(target_body, config.function_name);
   ensure(declarations.length === 1, `${config.path}:${config.function_name} target count is not one`);
   const body = get_function_body(declarations[0], config);
   ensure(body.statements.length > 1, `${config.path}:${config.function_name} body is incomplete`);
@@ -249,6 +285,86 @@ function validate_owner(component_body, config) {
   }
 }
 
+function named_import_bindings(source_file) {
+  return source_file.statements.flatMap((statement) => {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) return [];
+    const named_bindings = statement.importClause?.namedBindings;
+    if (!named_bindings || !ts.isNamedImports(named_bindings)) return [];
+    return named_bindings.elements.map((element) => ({
+      module_name: statement.moduleSpecifier.text,
+      imported_name: identifier_name(element.propertyName ?? element.name),
+      local_name: identifier_name(element.name),
+    }));
+  });
+}
+
+function validate_named_import(source_file, path, module_name, binding_name) {
+  const relevant = named_import_bindings(source_file).filter((binding) => (
+    binding.imported_name === binding_name || binding.local_name === binding_name
+  ));
+  ensure(relevant.length === 1, `${path} ${binding_name} import binding count is wrong`);
+  const binding = relevant[0];
+  ensure(
+    binding.module_name === module_name
+      && binding.imported_name === binding_name
+      && binding.local_name === binding_name,
+    `${path} ${binding_name} import provenance is wrong`,
+  );
+}
+
+function is_value_binding_identifier(node) {
+  if (!ts.isIdentifier(node)) return false;
+  const parent = node.parent;
+  if (ts.isVariableDeclaration(parent) || ts.isParameter(parent) || ts.isBindingElement(parent)) return parent.name === node;
+  if (ts.isFunctionDeclaration(parent) || ts.isFunctionExpression(parent)) return parent.name === node;
+  if (ts.isClassDeclaration(parent) || ts.isClassExpression(parent) || ts.isEnumDeclaration(parent)) return parent.name === node;
+  return false;
+}
+
+function validate_no_shadowing(source_file, component_body, path) {
+  const component_protected = new Set(['backend', 'useLatestRequestGeneration', 'useEffect', 'useCallback']);
+  const component_shadows = collect_nodes(component_body, is_value_binding_identifier)
+    .map(identifier_name)
+    .filter((name) => component_protected.has(name));
+  ensure(component_shadows.length === 0, `${path} protected component binding is shadowed`);
+
+  const promise_shadows = collect_nodes(source_file, is_value_binding_identifier)
+    .map(identifier_name)
+    .filter((name) => name === 'Promise');
+  ensure(promise_shadows.length === 0, `${path} global Promise binding is shadowed`);
+}
+
+function direct_hook_blocks(component_body, hook_name) {
+  return component_body.statements.flatMap((statement) => {
+    if (!ts.isExpressionStatement(statement) || !is_identifier_call(statement.expression, hook_name)) return [];
+    const callback = statement.expression.arguments[0];
+    ensure(callback && ts.isArrowFunction(callback) && ts.isBlock(callback.body), `${hook_name} callback must be a block arrow function`);
+    return [callback.body];
+  });
+}
+
+function get_target_body(component_body, path, configs) {
+  if (configs.every((config) => config.target_scope === 'component')) return component_body;
+  ensure(configs.every((config) => config.target_scope === 'cost_effect'), `${path} target scope mapping is inconsistent`);
+  const candidates = direct_hook_blocks(component_body, 'useEffect').filter((block) => (
+    configs.every((config) => direct_variable_declarations(block, config.function_name).length === 1)
+  ));
+  ensure(candidates.length === 1, `${path} owning effect count is wrong`);
+  return candidates[0];
+}
+
+function validate_expected_backend_method_ownership(component_body, path, configs) {
+  for (const config of configs) {
+    for (const method_name of config.backend_methods) {
+      const calls = collect_nodes(component_body, (node) => {
+        const parts = property_call_parts(node);
+        return parts !== null && parts.owner_name === 'backend' && parts.method_name === method_name;
+      });
+      ensure(calls.length === 1, `${path} ${method_name} component call count is wrong`);
+    }
+  }
+}
+
 function validate_hook_bindings(component_body, path, configs) {
   const hook_calls = collect_nodes(component_body, (node) => is_identifier_call(node, 'useLatestRequestGeneration'));
   ensure(hook_calls.length === configs.length, `${path} hook call count is wrong`);
@@ -278,19 +394,8 @@ function get_component_body(source_file, path, configs) {
   return components[0].body;
 }
 
-function validate_cost_cleanup(source_file) {
-  const effects = collect_nodes(source_file, (node) => {
-    if (!is_identifier_call(node, 'useEffect')) return false;
-    return collect_nodes(node, (child) => (
-      ts.isVariableDeclaration(child)
-      && (identifier_name(child.name) === 'loadCost' || identifier_name(child.name) === 'loadDaily')
-    )).length === 2;
-  });
-  ensure(effects.length === 1, 'CostSummarySection owning effect count is wrong');
-  const effect_function = effects[0].arguments[0];
-  ensure(ts.isArrowFunction(effect_function), 'CostSummarySection owning effect is not an arrow function');
-  ensure(ts.isBlock(effect_function.body), 'CostSummarySection owning effect has no block body');
-  const returns = effect_function.body.statements.filter(ts.isReturnStatement);
+function validate_cost_cleanup(target_body) {
+  const returns = target_body.statements.filter(ts.isReturnStatement);
   ensure(returns.length === 1, 'CostSummarySection owning effect cleanup count is wrong');
   const cleanup = returns[0].expression;
   ensure(cleanup !== undefined && ts.isArrowFunction(cleanup), 'CostSummarySection cleanup is not an arrow function');
@@ -304,17 +409,18 @@ function validate_cost_cleanup(source_file) {
   ensure(same_strings(invalidated, ['daily_generation', 'overview_generation']), 'CostSummarySection cleanup must invalidate both lanes exactly');
 }
 
-function validate_antigravity_pause(source_file) {
-  const effects = collect_nodes(source_file, (node) => {
-    if (!is_identifier_call(node, 'useEffect')) return false;
-    const has_fetch = collect_nodes(node, (child) => is_identifier_call(child, 'fetchData')).length > 0;
-    const has_interval = collect_nodes(node, (child) => is_identifier_call(child, 'setInterval')).length > 0;
+function validate_antigravity_pause(component_body) {
+  const effects = direct_hook_blocks(component_body, 'useEffect').filter((block) => {
+    const has_fetch = block.statements.some((statement) => (
+      ts.isExpressionStatement(statement) && is_identifier_call(statement.expression, 'fetchData')
+    ));
+    const has_interval = block.statements.some((statement) => (
+      collect_nodes(statement, (node) => is_identifier_call(node, 'setInterval')).length > 0
+    ));
     return has_fetch && has_interval;
   });
   ensure(effects.length === 1, 'Antigravity polling effect count is wrong');
-  const effect_function = effects[0].arguments[0];
-  ensure(ts.isArrowFunction(effect_function) && ts.isBlock(effect_function.body), 'Antigravity polling effect has no block body');
-  const statements = effect_function.body.statements;
+  const statements = effects[0].statements;
   const pause_index = statements.findIndex((statement) => {
     if (!ts.isIfStatement(statement) || !ts.isBinaryExpression(statement.expression)) return false;
     const expression = statement.expression;
@@ -346,19 +452,27 @@ export function check_latest_request_wiring(sources = read_owner_sources()) {
     configs_by_path.set(config.path, configs);
   }
 
-  const source_files = new Map();
   for (const [path, configs] of configs_by_path) {
     const source = sources.get(path);
     ensure(typeof source === 'string', `${path} source is missing`);
     const source_file = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-    source_files.set(path, source_file);
+    ensure(source_file.parseDiagnostics.length === 0, `${path} source has parse errors`);
     const component_body = get_component_body(source_file, path, configs);
+    const component_prefix = path === 'src/App.tsx' ? '.' : '..';
+    validate_named_import(source_file, path, `${component_prefix}/services/backend`, 'backend');
+    validate_named_import(source_file, path, `${component_prefix}/hooks/use_latest_request_generation`, 'useLatestRequestGeneration');
+    validate_named_import(source_file, path, 'react', 'useEffect');
+    if (configs.some((config) => config.target_scope === 'component')) {
+      validate_named_import(source_file, path, 'react', 'useCallback');
+    }
+    validate_no_shadowing(source_file, component_body, path);
     validate_hook_bindings(component_body, path, configs);
-    for (const config of configs) validate_owner(component_body, config);
+    const target_body = get_target_body(component_body, path, configs);
+    for (const config of configs) validate_owner(target_body, config);
+    validate_expected_backend_method_ownership(component_body, path, configs);
+    if (path === 'src/components/CostSummarySection.tsx') validate_cost_cleanup(target_body);
+    if (path === 'src/components/AntigravityPanel.tsx') validate_antigravity_pause(component_body);
   }
-
-  validate_cost_cleanup(source_files.get('src/components/CostSummarySection.tsx'));
-  validate_antigravity_pause(source_files.get('src/components/AntigravityPanel.tsx'));
 }
 
 check_latest_request_wiring();

--- a/scripts/check_latest_request_wiring.mjs
+++ b/scripts/check_latest_request_wiring.mjs
@@ -321,17 +321,12 @@ function is_value_binding_identifier(node) {
   return false;
 }
 
-function validate_no_shadowing(source_file, component_body, path) {
-  const component_protected = new Set(['backend', 'useLatestRequestGeneration', 'useEffect', 'useCallback']);
-  const component_shadows = collect_nodes(component_body, is_value_binding_identifier)
+function validate_no_shadowing(source_file, path) {
+  const protected_names = new Set(['backend', 'useLatestRequestGeneration', 'useEffect', 'useCallback', 'Promise']);
+  const shadows = collect_nodes(source_file, is_value_binding_identifier)
     .map(identifier_name)
-    .filter((name) => component_protected.has(name));
-  ensure(component_shadows.length === 0, `${path} protected component binding is shadowed`);
-
-  const promise_shadows = collect_nodes(source_file, is_value_binding_identifier)
-    .map(identifier_name)
-    .filter((name) => name === 'Promise');
-  ensure(promise_shadows.length === 0, `${path} global Promise binding is shadowed`);
+    .filter((name) => protected_names.has(name));
+  ensure(shadows.length === 0, `${path} protected binding is shadowed`);
 }
 
 function direct_hook_blocks(component_body, hook_name) {
@@ -465,7 +460,7 @@ export function check_latest_request_wiring(sources = read_owner_sources()) {
     if (configs.some((config) => config.target_scope === 'component')) {
       validate_named_import(source_file, path, 'react', 'useCallback');
     }
-    validate_no_shadowing(source_file, component_body, path);
+    validate_no_shadowing(source_file, path);
     validate_hook_bindings(component_body, path, configs);
     const target_body = get_target_body(component_body, path, configs);
     for (const config of configs) validate_owner(target_body, config);

--- a/scripts/check_latest_request_wiring.test.mjs
+++ b/scripts/check_latest_request_wiring.test.mjs
@@ -71,6 +71,21 @@ test('rejects a wrong generation owner binding', () => {
   );
 });
 
+test('rejects a generation hook moved outside its owning component', () => {
+  const sources = read_owner_sources();
+  const original = sources.get(paths.cursor);
+  assert.equal(typeof original, 'string');
+  const without_binding = original.replace('  const request_generation = useLatestRequestGeneration();\n', '');
+  assert.notEqual(without_binding, original);
+  const moved_binding = without_binding.replace(
+    "import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';",
+    "import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';\nconst request_generation = useLatestRequestGeneration();",
+  );
+  assert.notEqual(moved_binding, without_binding);
+  sources.set(paths.cursor, moved_binding);
+  assert.throws(() => check_latest_request_wiring(sources), /hook call count|owning component/);
+});
+
 test('rejects a wrong token in a terminal guard', () => {
   rejects_change(
     paths.cursor,
@@ -204,7 +219,25 @@ for (const [name, replacement] of malformed_start_fixtures) {
 }
 
 test('rejects a wrong backend await mapping', () => {
-  rejects_change(paths.cursor, 'backend.getCursorInfo()', 'backend.getQuota()', /backend await mapping/);
+  rejects_change(paths.cursor, 'backend.getCursorInfo()', 'backend.getQuota()', /backend call count|await mapping/);
+});
+
+test('rejects an expected backend call that is not awaited', () => {
+  rejects_change(
+    paths.cursor,
+    'const data = await backend.getCursorInfo();',
+    'const data = (backend.getCursorInfo(), await Promise.resolve({ connected: true }));',
+    /directly await/,
+  );
+});
+
+test('rejects an expected backend call discarded inside the await operand', () => {
+  rejects_change(
+    paths.cursor,
+    'const data = await backend.getCursorInfo();',
+    'const data = await (backend.getCursorInfo(), Promise.resolve({ connected: true }));',
+    /directly await/,
+  );
 });
 
 test('rejects a missing Cost lane invalidation', () => {

--- a/scripts/check_latest_request_wiring.test.mjs
+++ b/scripts/check_latest_request_wiring.test.mjs
@@ -1,0 +1,242 @@
+import assert from 'node:assert/strict';
+import {
+  check_latest_request_wiring,
+  read_owner_sources,
+} from './check_latest_request_wiring.mjs';
+
+const { it: test } = process.env.VITEST
+  ? await import('vitest')
+  : await import('node:test');
+
+const paths = {
+  app: 'src/App.tsx',
+  codex: 'src/components/CodexPanel.tsx',
+  cursor: 'src/components/CursorPanel.tsx',
+  antigravity: 'src/components/AntigravityPanel.tsx',
+  cost: 'src/components/CostSummarySection.tsx',
+};
+
+function changed_source(path, from, to) {
+  const sources = read_owner_sources();
+  const original = sources.get(path);
+  assert.equal(typeof original, 'string');
+  const parts = original.split(from);
+  assert.equal(parts.length, 2, `fixture mutation must match once: ${from}`);
+  sources.set(path, `${parts[0]}${to}${parts[1]}`);
+  return sources;
+}
+
+function rejects_change(path, from, to, message) {
+  assert.throws(() => check_latest_request_wiring(changed_source(path, from, to)), message);
+}
+
+function accepts_change(path, from, to) {
+  assert.doesNotThrow(() => check_latest_request_wiring(changed_source(path, from, to)));
+}
+
+test('accepts the exact real owner wiring', () => {
+  assert.doesNotThrow(() => check_latest_request_wiring(read_owner_sources()));
+});
+
+test('rejects a missing owner source', () => {
+  const sources = read_owner_sources();
+  sources.delete(paths.app);
+  assert.throws(() => check_latest_request_wiring(sources), /source is missing/);
+});
+
+test('rejects a dummy hook and fake generation object', () => {
+  rejects_change(
+    paths.cursor,
+    '  const request_generation = useLatestRequestGeneration();',
+    '  const request_generation = useLatestRequestGeneration();\n  const fake_generation = useLatestRequestGeneration();',
+    /hook call count/,
+  );
+});
+
+test('rejects a hook that is not the exact declarator initializer', () => {
+  rejects_change(
+    paths.cursor,
+    'const request_generation = useLatestRequestGeneration();',
+    'const request_generation = true ? useLatestRequestGeneration() : useLatestRequestGeneration();',
+    /hook call count/,
+  );
+});
+
+test('rejects a wrong generation owner binding', () => {
+  rejects_change(
+    paths.cursor,
+    'const request_generation = useLatestRequestGeneration();',
+    'const wrong_generation = useLatestRequestGeneration();',
+    /owner binding/,
+  );
+});
+
+test('rejects a wrong token in a terminal guard', () => {
+  rejects_change(
+    paths.cursor,
+    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(wrong_generation)) return;',
+    /success guard/,
+  );
+});
+
+test('rejects a guard moved outside the real backend fetch', () => {
+  rejects_change(
+    paths.cursor,
+    '      if (!request_generation.isCurrent(generation)) return;\n      setCursorData(data);',
+    '      setCursorData(data);\n      if (!request_generation.isCurrent(generation)) return;',
+    /success guard/,
+  );
+});
+
+test('rejects a wrong owner in the real backend fetch', () => {
+  rejects_change(
+    paths.app,
+    '      const data = await backend.getQuota();\n      if (!claude_request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getQuota();\n      if (!request_generation.isCurrent(generation)) return;',
+    /success guard/,
+  );
+});
+
+test('rejects a dead-code terminal guard', () => {
+  rejects_change(
+    paths.antigravity,
+    '      if (!request_generation.isCurrent(generation)) return;\n      setData(info);',
+    '      if (false) { if (!request_generation.isCurrent(generation)) return; }\n      setData(info);',
+    /success guard/,
+  );
+});
+
+test('rejects a current check that does not return', () => {
+  rejects_change(
+    paths.cursor,
+    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) console.error(generation);',
+    /success guard/,
+  );
+});
+
+test('accepts a fail-closed guard with a one-return block', () => {
+  accepts_change(
+    paths.cursor,
+    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) { return; }',
+  );
+});
+
+test('rejects a terminal guard with the wrong prefix operator', () => {
+  rejects_change(
+    paths.cursor,
+    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo();\n      if (+request_generation.isCurrent(generation)) return;',
+    /success guard/,
+  );
+});
+
+test('rejects a terminal guard with extra token arguments', () => {
+  rejects_change(
+    paths.cursor,
+    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation, generation)) return;',
+    /success guard/,
+  );
+});
+
+test('rejects a catch whose first statement is not the current-token guard', () => {
+  rejects_change(
+    paths.codex,
+    '    } catch (err) {\n      if (!request_generation.isCurrent(generation)) return;',
+    '    } catch (err) {\n      console.error(err);\n      if (!request_generation.isCurrent(generation)) return;',
+    /catch guard/,
+  );
+});
+
+test('rejects a missing current finally guard', () => {
+  rejects_change(
+    paths.codex,
+    '    } finally {\n      if (request_generation.isCurrent(generation)) {',
+    '    } finally {\n      setLoading(false);\n      if (request_generation.isCurrent(generation)) {',
+    /finally must contain one current guard/,
+  );
+});
+
+const malformed_finally_fixtures = [
+  ['guard with else', '      if (request_generation.isCurrent(generation)) { setLoading(false); } else { setLoading(false); }'],
+  ['wrong current owner', '      if (wrong_generation.isCurrent(generation)) { setLoading(false); }'],
+  ['non-block body', '      if (request_generation.isCurrent(generation)) setLoading(false);'],
+  ['multiple body statements', '      if (request_generation.isCurrent(generation)) { setLoading(false); setLoading(false); }'],
+  ['non-expression body', '      if (request_generation.isCurrent(generation)) { return; }'],
+  ['wrong setter', '      if (request_generation.isCurrent(generation)) { setOtherLoading(false); }'],
+  ['missing argument', '      if (request_generation.isCurrent(generation)) { setLoading(); }'],
+  ['wrong argument', '      if (request_generation.isCurrent(generation)) { setLoading(true); }'],
+];
+for (const [name, replacement] of malformed_finally_fixtures) {
+  test(`rejects malformed finally loading guard: ${name}`, () => {
+    rejects_change(
+      paths.codex,
+      '      if (request_generation.isCurrent(generation)) {\n        setLoading(false);\n      }',
+      replacement,
+      /finally loading guard/,
+    );
+  });
+}
+
+const malformed_start_fixtures = [
+  ['not a declaration', '    request_generation.begin();'],
+  ['not const', '    let generation = request_generation.begin();'],
+  ['multiple declarations', '    const generation = request_generation.begin(), extra = 0;'],
+  ['wrong token name', '    const wrong_generation = request_generation.begin();'],
+  ['missing initializer', '    const generation;'],
+  ['identifier call', '    const generation = begin();'],
+  ['non-identifier owner', '    const generation = getGeneration().begin();'],
+  ['wrong owner', '    const generation = wrong_generation.begin();'],
+  ['begin with argument', '    const generation = request_generation.begin(1);'],
+];
+for (const [name, replacement] of malformed_start_fixtures) {
+  test(`rejects malformed generation start: ${name}`, () => {
+    rejects_change(
+      paths.cursor,
+      '    const generation = request_generation.begin();',
+      replacement,
+      /must begin/,
+    );
+  });
+}
+
+test('rejects a wrong backend await mapping', () => {
+  rejects_change(paths.cursor, 'backend.getCursorInfo()', 'backend.getQuota()', /backend await mapping/);
+});
+
+test('rejects a missing Cost lane invalidation', () => {
+  rejects_change(paths.cost, '      daily_generation.invalidate();\n', '', /invalidate both lanes/);
+});
+
+test('rejects a Cost invalidation outside the owning cleanup', () => {
+  rejects_change(
+    paths.cost,
+    '      daily_generation.invalidate();',
+    '      if (false) daily_generation.invalidate();',
+    /invalidate both lanes/,
+  );
+});
+
+test('accepts unrelated direct cleanup work without counting it as invalidation', () => {
+  accepts_change(
+    paths.cost,
+    '      daily_generation.invalidate();\n      if (interval !== undefined) {',
+    '      daily_generation.invalidate();\n      clearInterval(0);\n      if (interval !== undefined) {',
+  );
+});
+
+test('rejects a missing Antigravity interval zero branch', () => {
+  rejects_change(paths.antigravity, '    if (autoRefreshIntervalMs <= 0) return;\n', '', /interval zero guard/);
+});
+
+test('rejects an Antigravity interval zero branch after setInterval', () => {
+  rejects_change(
+    paths.antigravity,
+    '    if (autoRefreshIntervalMs <= 0) return;\n    const interval = setInterval(fetchData, autoRefreshIntervalMs);',
+    '    const interval = setInterval(fetchData, autoRefreshIntervalMs);\n    if (autoRefreshIntervalMs <= 0) return;',
+    /interval zero guard/,
+  );
+});

--- a/scripts/check_latest_request_wiring.test.mjs
+++ b/scripts/check_latest_request_wiring.test.mjs
@@ -240,6 +240,24 @@ test('rejects an expected backend call discarded inside the await operand', () =
   );
 });
 
+test('rejects a Codex backend call discarded inside a Promise.all array element', () => {
+  rejects_change(
+    paths.codex,
+    '        backend.getCodexInfo(),',
+    '        (backend.getCodexInfo(), Promise.resolve({ connected: true })),',
+    /array elements must be direct backend calls/,
+  );
+});
+
+test('rejects a Cost backend call discarded inside the sources.map callback', () => {
+  rejects_change(
+    paths.cost,
+    'sources.map((item) => backend.getCostOverview(item, force))',
+    'sources.map((item) => (backend.getCostOverview(item, force), Promise.resolve(null)))',
+    /map callback must directly return a backend call/,
+  );
+});
+
 test('rejects a missing Cost lane invalidation', () => {
   rejects_change(paths.cost, '      daily_generation.invalidate();\n', '', /invalidate both lanes/);
 });

--- a/scripts/check_latest_request_wiring.test.mjs
+++ b/scripts/check_latest_request_wiring.test.mjs
@@ -110,7 +110,7 @@ for (const [name, declaration] of protected_shadow_fixtures) {
       paths.cursor,
       '  const request_generation = useLatestRequestGeneration();',
       `${declaration}\n  const request_generation = useLatestRequestGeneration();`,
-      /protected component binding is shadowed/,
+      /protected binding is shadowed/,
     );
   });
 }
@@ -120,7 +120,7 @@ test('rejects a shadowed global Promise binding', () => {
     paths.codex,
     '  const request_generation = useLatestRequestGeneration();',
     '  const Promise = fake_promise;\n  const request_generation = useLatestRequestGeneration();',
-    /global Promise binding is shadowed/,
+    /protected binding is shadowed/,
   );
 });
 
@@ -129,9 +129,24 @@ test('rejects a module-scope global Promise binding', () => {
     paths.codex,
     "import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';",
     "import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';\nfunction Promise() {}",
-    /global Promise binding is shadowed/,
+    /protected binding is shadowed/,
   );
 });
+
+const module_shadow_fixtures = [
+  ['backend', 'const backend = fake_backend;'],
+  ['generation hook', 'function useLatestRequestGeneration() { return fake_generation; }'],
+];
+for (const [name, declaration] of module_shadow_fixtures) {
+  test(`rejects a module-scope ${name} shadow beside the real import`, () => {
+    rejects_change(
+      paths.cursor,
+      "import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';",
+      `import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';\n${declaration}`,
+      /protected binding is shadowed/,
+    );
+  });
+}
 
 test('rejects a dummy hook and fake generation object', () => {
   rejects_change(

--- a/scripts/check_latest_request_wiring.test.mjs
+++ b/scripts/check_latest_request_wiring.test.mjs
@@ -44,6 +44,95 @@ test('rejects a missing owner source', () => {
   assert.throws(() => check_latest_request_wiring(sources), /source is missing/);
 });
 
+test('rejects malformed owner source before structural checks', () => {
+  rejects_change(paths.cursor, 'export default function CursorPanel({', 'export default function CursorPanel((', /parse errors/);
+});
+
+const import_provenance_fixtures = [
+  [
+    'fake backend definition',
+    "import { backend } from '../services/backend';",
+    'const backend = fake_backend;',
+    /backend import binding count/,
+  ],
+  [
+    'wrong backend module',
+    "import { backend } from '../services/backend';",
+    "import { backend } from '../services/fake_backend';",
+    /backend import provenance/,
+  ],
+  [
+    'aliased backend import',
+    "import { backend } from '../services/backend';",
+    "import { backend as backend_alias } from '../services/backend';",
+    /backend import provenance/,
+  ],
+  [
+    'fake generation hook definition',
+    "import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';",
+    'const useLatestRequestGeneration = fake_hook;',
+    /useLatestRequestGeneration import binding count/,
+  ],
+  [
+    'wrong generation hook module',
+    "import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';",
+    "import { useLatestRequestGeneration } from '../hooks/fake_generation';",
+    /useLatestRequestGeneration import provenance/,
+  ],
+  [
+    'wrong React hook module',
+    "import { useEffect, useState, useCallback } from 'react';",
+    "import { useEffect, useState, useCallback } from 'fake-react';",
+    /useEffect import provenance/,
+  ],
+];
+for (const [name, from, to, message] of import_provenance_fixtures) {
+  test(`rejects import provenance bypass: ${name}`, () => {
+    rejects_change(paths.cursor, from, to, message);
+  });
+}
+
+const protected_shadow_fixtures = [
+  ['backend variable', '  const backend = fake_backend;'],
+  ['generation hook variable', '  const useLatestRequestGeneration = fake_hook;'],
+  ['React effect variable', '  const useEffect = fake_effect;'],
+  ['React callback parameter', '  function shadow(useCallback) { return useCallback; }'],
+  ['backend destructuring binding', '  const { backend } = fake_bindings;'],
+  ['generation hook function', '  function useLatestRequestGeneration() { return fake_generation; }'],
+  ['React effect named function expression', '  const shadow_holder = function useEffect() {};'],
+  ['backend class', '  class backend {}'],
+  ['backend named class expression', '  const shadow_holder = class backend {};'],
+  ['React effect enum', '  enum useEffect { fake }'],
+];
+for (const [name, declaration] of protected_shadow_fixtures) {
+  test(`rejects protected component shadow: ${name}`, () => {
+    rejects_change(
+      paths.cursor,
+      '  const request_generation = useLatestRequestGeneration();',
+      `${declaration}\n  const request_generation = useLatestRequestGeneration();`,
+      /protected component binding is shadowed/,
+    );
+  });
+}
+
+test('rejects a shadowed global Promise binding', () => {
+  rejects_change(
+    paths.codex,
+    '  const request_generation = useLatestRequestGeneration();',
+    '  const Promise = fake_promise;\n  const request_generation = useLatestRequestGeneration();',
+    /global Promise binding is shadowed/,
+  );
+});
+
+test('rejects a module-scope global Promise binding', () => {
+  rejects_change(
+    paths.codex,
+    "import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';",
+    "import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';\nfunction Promise() {}",
+    /global Promise binding is shadowed/,
+  );
+});
+
 test('rejects a dummy hook and fake generation object', () => {
   rejects_change(
     paths.cursor,
@@ -222,12 +311,98 @@ test('rejects a wrong backend await mapping', () => {
   rejects_change(paths.cursor, 'backend.getCursorInfo()', 'backend.getQuota()', /backend call count|await mapping/);
 });
 
+const attached_alias_call_fixtures = [
+  [
+    'direct',
+    paths.cursor,
+    'backend.getCursorInfo()',
+    'backend.getCursorInfo(backend_alias.getCursorInfo())',
+  ],
+  [
+    'Promise.all array',
+    paths.codex,
+    'backend.getCodexInfo()',
+    'backend.getCodexInfo(backend_alias.getCodexInfo())',
+  ],
+  [
+    'sources.map callback',
+    paths.cost,
+    'backend.getCostOverview(item, force)',
+    'backend.getCostOverview(item, force, backend_alias.getCostOverview(item, force))',
+  ],
+];
+for (const [name, path, from, to] of attached_alias_call_fixtures) {
+  test(`rejects an attached backend alias call in ${name}`, () => {
+    rejects_change(path, from, to, /backend call arguments/);
+  });
+}
+
+test('rejects a wrong sources.map callback parameter', () => {
+  rejects_change(
+    paths.cost,
+    'sources.map((item) => backend.getCostOverview(item, force))',
+    'sources.map((wrong_item) => backend.getCostOverview(item, force))',
+    /callback parameter/,
+  );
+});
+
+test('rejects a malformed direct effect callback', () => {
+  rejects_change(
+    paths.cost,
+    '  useEffect(() => {',
+    '  useEffect(not_a_callback);\n  useEffect(() => {',
+    /callback must be a block arrow function/,
+  );
+});
+
+test('rejects a duplicate expected backend method outside the owner target', () => {
+  rejects_change(
+    paths.cursor,
+    '  const request_generation = useLatestRequestGeneration();',
+    '  void backend.getCursorInfo();\n  const request_generation = useLatestRequestGeneration();',
+    /component call count/,
+  );
+});
+
+test('rejects a nested dead compliant target in place of the direct owner target', () => {
+  rejects_change(
+    paths.cursor,
+    '  const fetchData = useCallback(async () => {',
+    `  if (false) {
+    const fetchData = useCallback(async () => {
+      const generation = request_generation.begin();
+      try {
+        const data = await backend.getCursorInfo();
+        if (!request_generation.isCurrent(generation)) return;
+        void data;
+      } catch (err) {
+        if (!request_generation.isCurrent(generation)) return;
+        void err;
+      } finally {
+        if (request_generation.isCurrent(generation)) { setLoading(false); }
+      }
+    }, []);
+  }
+  const unsafeFetchData = useCallback(async () => {`,
+    /target count is not one/,
+  );
+});
+
 test('rejects an expected backend call that is not awaited', () => {
   rejects_change(
     paths.cursor,
     'const data = await backend.getCursorInfo();',
     'const data = (backend.getCursorInfo(), await Promise.resolve({ connected: true }));',
-    /directly await/,
+    /backend call owner/,
+  );
+});
+
+test('rejects an identifier await operand with an attached backend call', () => {
+  rejects_change(
+    paths.cursor,
+    'const data = await backend.getCursorInfo();',
+    'const data = await getData(backend.getCursorInfo());',
+    /backend call owner/,
   );
 });
 

--- a/specs/GH52/tasks.md
+++ b/specs/GH52/tasks.md
@@ -9,10 +9,10 @@
 
 ## Implementation Tasks
 
-- [ ] `SP52-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`, `B-003`, `B-004`. Done when: stable monotonic generation hook、unmount invalidate、current success/failure/finally contract、critical 100%。 Verify: latest-request unit/hook tests。
-- [ ] `SP52-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-006`. Done when: Claude/Codex/Cursor/Antigravity 全部接入 owner-shared guard；Codex bundle atomic；每个 owner 的 success/failure/finally/unmount parameterized matrix 通过；三 bundle members current/stale rejection 通过；Antigravity interval 0 pauses；fail-closed wiring checker 拒绝所有 adversarial fixtures。 Verify: provider deferred real-effect matrix + wiring checker 100%。
-- [ ] `SP52-T3` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-005`. Done when: Cost overview/daily 独立 generations；两 lane 的 success/failure/cleanup full matrix 通过；overview stale finally 与 cross-lane identity exact。 Verify: cost parameterized deferred tests。
-- [ ] `SP52-T4` Owner: codex. Dependencies: T1-T3. Covers: `B-007`. Done when: dev-only renderer 与 resolved React exact version；13-path allowlist；overall diff ≥80%；wiring checker、coordinator 与五个 owner 新增 stale terminal paths critical 100%；full frontend/build/Rust pass。 Verify: tech Test Plan。
+- [x] `SP52-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`, `B-003`, `B-004`. Done when: stable monotonic generation hook、unmount invalidate、current success/failure/finally contract、critical 100%。 Verify: latest-request unit/hook tests。
+- [x] `SP52-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-006`. Done when: Claude/Codex/Cursor/Antigravity 全部接入 owner-shared guard；Codex bundle atomic；每个 owner 的 success/failure/finally/unmount parameterized matrix 通过；三 bundle members current/stale rejection 通过；Antigravity interval 0 pauses；fail-closed wiring checker 拒绝所有 adversarial fixtures。 Verify: provider deferred real-effect matrix + wiring checker 100%。
+- [x] `SP52-T3` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-005`. Done when: Cost overview/daily 独立 generations；两 lane 的 success/failure/cleanup full matrix 通过；overview stale finally 与 cross-lane identity exact。 Verify: cost parameterized deferred tests。
+- [x] `SP52-T4` Owner: codex. Dependencies: T1-T3. Covers: `B-007`. Done when: dev-only renderer 与 resolved React exact version；13-path allowlist；overall diff ≥80%；wiring checker、coordinator 与五个 owner 新增 stale terminal paths critical 100%；full frontend/build/Rust pass。 Verify: tech Test Plan。
 
 ## Handoff
 

--- a/specs/GH52/tasks.md
+++ b/specs/GH52/tasks.md
@@ -16,7 +16,7 @@
 
 ## Handoff
 
-- [ ] `SP52-T5` Owner: codex. Dependencies: T4. Done when: implementation PR `Closes #52`，正文记录 reproduction、lane model、stale terminal semantics、dependency boundary、coverage、rollback，并通过 implementation-vs-spec、current-head connector/CI/reviewThreads gate。
+- [x] `SP52-T5` Owner: codex. Dependencies: T4. Done when: implementation PR `Closes #52`，正文记录 reproduction、lane model、stale terminal semantics、dependency boundary、coverage、rollback，并通过 implementation-vs-spec、current-head connector/CI/reviewThreads gate。
 
 ## Handoff Notes
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,7 @@ import {
 } from './services/storage';
 import { useServiceEvents } from './hooks/use_service_events';
 import { usePopoverWindow } from './hooks/use_popover_window';
+import { useLatestRequestGeneration } from './hooks/use_latest_request_generation';
 
 // Re-exported for existing tests/importers.
 export {
@@ -128,6 +129,7 @@ export default function App() {
   const [claudeError, setClaudeError] = useState<string | null>(null);
   const [claudeCostRefreshNonce, setClaudeCostRefreshNonce] = useState(0);
   const claudeIntervalRef = useRef(AUTO_REFRESH_INTERVAL_MS);
+  const claude_request_generation = useLatestRequestGeneration();
 
   // Per-service connection + usage state (set via Panel callbacks)
   const [connected, setConnected] = useState<ServiceMap<boolean>>(() => defaultServiceMap(false));
@@ -262,10 +264,12 @@ export default function App() {
 
   // Fetch Claude quota for startup/manual/background refresh.
   const fetchClaudeQuota = useCallback(async () => {
+    const generation = claude_request_generation.begin();
     try {
       setClaudeLoading(true);
       setClaudeError(null);
       const data = await backend.getQuota();
+      if (!claude_request_generation.isCurrent(generation)) return;
 
       if (data.error) {
         setClaudeError(data.error);
@@ -280,14 +284,17 @@ export default function App() {
       }
       setServiceConnected('claude', data.connected);
     } catch (err) {
+      if (!claude_request_generation.isCurrent(generation)) return;
       const message = err instanceof Error ? err.message : 'Unknown error';
       setClaudeError(message);
       claudeIntervalRef.current = getClaudeRefreshIntervalMs(message);
       setServiceConnected('claude', false);
     } finally {
-      setClaudeLoading(false);
+      if (claude_request_generation.isCurrent(generation)) {
+        setClaudeLoading(false);
+      }
     }
-  }, [setServiceConnected]);
+  }, [claude_request_generation, setServiceConnected]);
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | null = null;

--- a/src/components/AntigravityPanel.tsx
+++ b/src/components/AntigravityPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { backend } from '../services/backend';
 import type { AntigravityData } from '../types/models';
 import ProviderDetailHeader from './ProviderDetailHeader';
+import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';
 
 interface AntigravityPanelProps {
   onConnectionChange?: (connected: boolean) => void;
@@ -18,24 +19,31 @@ export default function AntigravityPanel({
 }: AntigravityPanelProps) {
   const [data, setData] = useState<AntigravityData | null>(null);
   const [loading, setLoading] = useState(true);
+  const request_generation = useLatestRequestGeneration();
 
   const fetchData = useCallback(async () => {
+    const generation = request_generation.begin();
     try {
       setLoading(true);
       const info = await backend.getAntigravityInfo();
+      if (!request_generation.isCurrent(generation)) return;
       setData(info);
       onConnectionChange?.(info.connected);
     } catch (err) {
+      if (!request_generation.isCurrent(generation)) return;
       const message = err instanceof Error ? err.message : 'Failed to load Antigravity status';
       setData({ connected: false, status: 'error', error: message });
       onConnectionChange?.(false);
     } finally {
-      setLoading(false);
+      if (request_generation.isCurrent(generation)) {
+        setLoading(false);
+      }
     }
-  }, [onConnectionChange]);
+  }, [onConnectionChange, request_generation]);
 
   useEffect(() => {
     fetchData();
+    if (autoRefreshIntervalMs <= 0) return;
     const interval = setInterval(fetchData, autoRefreshIntervalMs);
     return () => clearInterval(interval);
   }, [fetchData, autoRefreshIntervalMs]);

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -14,6 +14,7 @@ import { buildCodexQuotaWindows, sortMostConstrained, type QuotaWindowSummary } 
 import { getAvailableResetCredits, getHighUsageTip } from '../services/detail_helpers';
 import { formatPaceText, formatPlanType, formatResetTime, getProgressStyle } from '../utils/quota_format';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
+import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';
 
 interface CodexPanelProps {
   onConnectionChange?: (connected: boolean) => void;
@@ -149,8 +150,10 @@ export default function CodexPanel({
   const [resetCredits, setResetCredits] = useState<CodexResetCredits | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const request_generation = useLatestRequestGeneration();
 
   const fetchData = useCallback(async () => {
+    const generation = request_generation.begin();
     try {
       setLoading(true);
       setError(null);
@@ -160,6 +163,7 @@ export default function CodexPanel({
         backend.getCodexRateLimits(),
         backend.getCodexResetCredits(),
       ]);
+      if (!request_generation.isCurrent(generation)) return;
 
       setCodexData(info);
       setRateLimits(limits);
@@ -179,14 +183,17 @@ export default function CodexPanel({
       // Use weekly usage for tray when available (secondary window).
       onUsageChange?.(getTrayUsedPercent(limits));
     } catch (err) {
+      if (!request_generation.isCurrent(generation)) return;
       setError(err instanceof Error ? err.message : 'Failed to fetch Codex data');
       onConnectionChange?.(false);
       onUsageChange?.(null);
       onQuotaWindowsChange?.([]);
     } finally {
-      setLoading(false);
+      if (request_generation.isCurrent(generation)) {
+        setLoading(false);
+      }
     }
-  }, [onConnectionChange, onQuotaWindowsChange, onUsageChange]);
+  }, [onConnectionChange, onQuotaWindowsChange, onUsageChange, request_generation]);
 
   useEffect(() => {
     fetchData();

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -3,6 +3,7 @@ import { backend } from '../services/backend';
 import { getBudgetForSources, getSavedMonthlyBudgets } from '../services/budget';
 import type { CostDailyPoint, CostDailySeries, CostOverview, CostRangeSummary, CostSource } from '../types/models';
 import { getProgressStyle } from '../utils/quota_format';
+import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';
 
 interface CostSummarySectionProps {
   source: CostSource | readonly CostSource[];
@@ -212,47 +213,46 @@ export default function CostSummarySection({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const sourceKey = Array.isArray(source) ? source.join(',') : source;
+  const overview_generation = useLatestRequestGeneration();
+  const daily_generation = useLatestRequestGeneration();
 
   useEffect(() => {
-    let cancelled = false;
     let interval: number | undefined;
 
     const loadCost = async (force: boolean) => {
+      const generation = overview_generation.begin();
       try {
         setLoading(true);
         setError(null);
         const sources = Array.isArray(source) ? source : [source];
         const overviews = await Promise.all(sources.map((item) => backend.getCostOverview(item, force)));
+        if (!overview_generation.isCurrent(generation)) return;
         const data = mergeCostOverviews(overviews);
-        if (!cancelled) {
-          setOverview(data);
-        }
+        setOverview(data);
       } catch (err) {
-        if (!cancelled) {
-          setError(getCostSummaryErrorMessage(err));
-        }
+        if (!overview_generation.isCurrent(generation)) return;
+        setError(getCostSummaryErrorMessage(err));
       } finally {
-        if (!cancelled) {
+        if (overview_generation.isCurrent(generation)) {
           setLoading(false);
         }
       }
     };
 
     const loadDaily = async (force: boolean) => {
+      const generation = daily_generation.begin();
       try {
         const sources = Array.isArray(source) ? source : [source];
         const seriesList = await Promise.all(
           sources.map((item) => backend.getCostDaily(item, DAILY_SERIES_DAYS, force)),
         );
-        if (!cancelled) {
-          setDaily(mergeDailySeries(seriesList));
-        }
+        if (!daily_generation.isCurrent(generation)) return;
+        setDaily(mergeDailySeries(seriesList));
       } catch (err) {
+        if (!daily_generation.isCurrent(generation)) return;
         // The trend falls back to per-model bars; surface why in the console.
         console.error('Failed to load daily cost series:', err);
-        if (!cancelled) {
-          setDaily(null);
-        }
+        setDaily(null);
       }
     };
 
@@ -264,12 +264,13 @@ export default function CostSummarySection({
     });
 
     return () => {
-      cancelled = true;
+      overview_generation.invalidate();
+      daily_generation.invalidate();
       if (interval !== undefined) {
         clearInterval(interval);
       }
     };
-  }, [sourceKey, refreshKey, autoRefreshIntervalMs]);
+  }, [sourceKey, refreshKey, autoRefreshIntervalMs, overview_generation, daily_generation]);
 
   const primaryRange = useMemo(() => pickPrimaryRange(overview), [overview]);
   const topModels = primaryRange?.models.slice(0, 3) ?? [];

--- a/src/components/CursorPanel.tsx
+++ b/src/components/CursorPanel.tsx
@@ -9,6 +9,7 @@ import { buildCursorQuotaWindows, sortMostConstrained, type QuotaWindowSummary }
 import { getHighUsageTip } from '../services/detail_helpers';
 import { formatPlanType, getProgressStyle } from '../utils/quota_format';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
+import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';
 
 interface CursorPanelProps {
   onConnectionChange?: (connected: boolean) => void;
@@ -51,12 +52,15 @@ export default function CursorPanel({
   const [cursorData, setCursorData] = useState<CursorData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const request_generation = useLatestRequestGeneration();
 
   const fetchData = useCallback(async () => {
+    const generation = request_generation.begin();
     try {
       setLoading(true);
       setError(null);
       const data = await backend.getCursorInfo();
+      if (!request_generation.isCurrent(generation)) return;
       setCursorData(data);
       if (data.error) {
         setError(data.error);
@@ -65,15 +69,18 @@ export default function CursorPanel({
       onUsageChange?.(data.percentage ?? null);
       onQuotaWindowsChange?.(buildCursorQuotaWindows(data));
     } catch (err) {
+      if (!request_generation.isCurrent(generation)) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch Cursor data';
       setError(message);
       onConnectionChange?.(false);
       onUsageChange?.(null);
       onQuotaWindowsChange?.([]);
     } finally {
-      setLoading(false);
+      if (request_generation.isCurrent(generation)) {
+        setLoading(false);
+      }
     }
-  }, [onConnectionChange, onQuotaWindowsChange, onUsageChange]);
+  }, [onConnectionChange, onQuotaWindowsChange, onUsageChange, request_generation]);
 
   useEffect(() => {
     fetchData();

--- a/src/hooks/use_latest_request_generation.ts
+++ b/src/hooks/use_latest_request_generation.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+export interface LatestRequestGeneration {
+  begin(): number;
+  isCurrent(generation: number): boolean;
+  invalidate(): void;
+}
+
+export function createLatestRequestGeneration(): LatestRequestGeneration {
+  let current_generation = 0;
+
+  return {
+    begin() {
+      current_generation += 1;
+      return current_generation;
+    },
+    isCurrent(generation) {
+      return generation === current_generation;
+    },
+    invalidate() {
+      current_generation += 1;
+    },
+  };
+}
+
+export function useLatestRequestGeneration(): LatestRequestGeneration {
+  const [request_generation] = useState(createLatestRequestGeneration);
+
+  useEffect(() => () => request_generation.invalidate(), [request_generation]);
+
+  return request_generation;
+}

--- a/tests/latest_request_generation.test.ts
+++ b/tests/latest_request_generation.test.ts
@@ -1,0 +1,62 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  createLatestRequestGeneration,
+  type LatestRequestGeneration,
+  useLatestRequestGeneration,
+} from '../src/hooks/use_latest_request_generation';
+
+function GenerationProbe({ onGeneration }: { onGeneration(generation: LatestRequestGeneration): void }) {
+  onGeneration(useLatestRequestGeneration());
+  return null;
+}
+
+describe('latest request generation', () => {
+  beforeAll(() => {
+    (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('replaces the current token monotonically and invalidates explicitly', () => {
+    const request_generation = createLatestRequestGeneration();
+
+    const first = request_generation.begin();
+    expect(first).toBe(1);
+    expect(request_generation.isCurrent(first)).toBe(true);
+
+    const second = request_generation.begin();
+    expect(second).toBe(2);
+    expect(request_generation.isCurrent(first)).toBe(false);
+    expect(request_generation.isCurrent(second)).toBe(true);
+
+    request_generation.invalidate();
+    expect(request_generation.isCurrent(second)).toBe(false);
+  });
+
+  it('keeps one coordinator across renders and invalidates it on unmount', async () => {
+    const observed: LatestRequestGeneration[] = [];
+    const on_generation = (generation: LatestRequestGeneration) => observed.push(generation);
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(createElement(GenerationProbe, { onGeneration: on_generation }));
+    });
+    await act(async () => {
+      renderer.update(createElement(GenerationProbe, { onGeneration: on_generation }));
+    });
+
+    expect(observed).toHaveLength(2);
+    expect(observed[1]).toBe(observed[0]);
+    const generation = observed[0].begin();
+    expect(observed[0].isCurrent(generation)).toBe(true);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+    expect(observed[0].isCurrent(generation)).toBe(false);
+  });
+});

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -1,0 +1,555 @@
+import { createElement, type ReactElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import App from '../src/App';
+import AntigravityPanel from '../src/components/AntigravityPanel';
+import CodexPanel from '../src/components/CodexPanel';
+import CostSummarySection from '../src/components/CostSummarySection';
+import CursorPanel from '../src/components/CursorPanel';
+import { backend } from '../src/services/backend';
+import type {
+  AntigravityData,
+  CodexData,
+  CodexRateLimits,
+  CodexResetCredits,
+  CostDailySeries,
+  CostOverview,
+  CursorData,
+  QuotaData,
+} from '../src/types/models';
+
+vi.mock('../src/hooks/use_popover_window', () => ({
+  usePopoverWindow: () => false,
+}));
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject(reason: unknown): void;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let reject!: (reason: unknown) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolve_promise, reject_promise) => {
+    resolve = resolve_promise;
+    reject = reject_promise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function settle(action: () => void): Promise<void> {
+  await act(async () => {
+    action();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function unmount(renderer: ReactTestRenderer): Promise<void> {
+  await act(async () => renderer.unmount());
+}
+
+function rendered_text(renderer: ReactTestRenderer): string {
+  return JSON.stringify(renderer.toJSON());
+}
+
+interface PanelCallbacks {
+  connection: Mock;
+  loading: Mock;
+  quota_windows: Mock;
+  usage: Mock;
+}
+
+function panel_callbacks(): PanelCallbacks {
+  return {
+    connection: vi.fn(),
+    loading: vi.fn(),
+    quota_windows: vi.fn(),
+    usage: vi.fn(),
+  };
+}
+
+interface PanelRequests {
+  reject(index: number, reason: unknown): void;
+  resolve(index: number, marker: number): void;
+}
+
+interface PanelDriver {
+  expected_failure_marker: boolean | null;
+  marker(callbacks: PanelCallbacks): Array<boolean | number | null>;
+  name: string;
+  render(nonce: number, callbacks: PanelCallbacks): ReactElement;
+  requests(): PanelRequests;
+}
+
+function cursor_requests(): PanelRequests {
+  const active: Deferred<CursorData>[] = [];
+  vi.spyOn(backend, 'getCursorInfo').mockImplementation(() => {
+    const request = deferred<CursorData>();
+    active.push(request);
+    return request.promise;
+  });
+  return {
+    reject: (index, reason) => active[index].reject(reason),
+    resolve: (index, marker) => active[index].resolve({ connected: true, percentage: marker }),
+  };
+}
+
+interface CodexBundle {
+  credits: Deferred<CodexResetCredits>;
+  info: Deferred<CodexData>;
+  limits: Deferred<CodexRateLimits>;
+}
+
+function codex_requests(): PanelRequests & { reject_member(index: number, member: keyof CodexBundle, reason: unknown): void } {
+  const bundles: CodexBundle[] = [];
+  const get_bundle = (index: number) => {
+    while (bundles.length <= index) {
+      bundles.push({
+        credits: deferred<CodexResetCredits>(),
+        info: deferred<CodexData>(),
+        limits: deferred<CodexRateLimits>(),
+      });
+    }
+    return bundles[index];
+  };
+  let info_index = 0;
+  let limits_index = 0;
+  let credits_index = 0;
+  vi.spyOn(backend, 'getCodexInfo').mockImplementation(() => get_bundle(info_index++).info.promise);
+  vi.spyOn(backend, 'getCodexRateLimits').mockImplementation(() => get_bundle(limits_index++).limits.promise);
+  vi.spyOn(backend, 'getCodexResetCredits').mockImplementation(() => get_bundle(credits_index++).credits.promise);
+  return {
+    reject: (index, reason) => get_bundle(index).info.reject(reason),
+    reject_member: (index, member, reason) => get_bundle(index)[member].reject(reason),
+    resolve: (index, marker) => {
+      const bundle = get_bundle(index);
+      bundle.info.resolve({ connected: true });
+      bundle.limits.resolve({ connected: true, secondary: { usedPercent: marker } });
+      bundle.credits.resolve({ connected: true, availableCount: 0, credits: [] });
+    },
+  };
+}
+
+function antigravity_requests(): PanelRequests {
+  const active: Array<Deferred<AntigravityData>> = [];
+  vi.spyOn(backend, 'getAntigravityInfo').mockImplementation(() => {
+    const request = deferred<AntigravityData>();
+    active.push(request);
+    return request.promise;
+  });
+  return {
+    reject: (index, reason) => active[index].reject(reason),
+    resolve: (index, marker) => active[index].resolve({ connected: marker === 20, status: `status-${marker}` }),
+  };
+}
+
+const panel_drivers: PanelDriver[] = [
+  {
+    name: 'Codex',
+    expected_failure_marker: null,
+    requests: codex_requests,
+    marker: (callbacks) => callbacks.usage.mock.calls.map(([value]) => value),
+    render: (nonce, callbacks) => createElement(CodexPanel, {
+      autoRefreshIntervalMs: 0,
+      manualRefreshNonce: nonce,
+      onConnectionChange: callbacks.connection,
+      onLoadingChange: callbacks.loading,
+      onQuotaWindowsChange: callbacks.quota_windows,
+      onUsageChange: callbacks.usage,
+      showCostSummary: false,
+    }),
+  },
+  {
+    name: 'Cursor',
+    expected_failure_marker: null,
+    requests: cursor_requests,
+    marker: (callbacks) => callbacks.usage.mock.calls.map(([value]) => value),
+    render: (nonce, callbacks) => createElement(CursorPanel, {
+      autoRefreshIntervalMs: 0,
+      manualRefreshNonce: nonce,
+      onConnectionChange: callbacks.connection,
+      onLoadingChange: callbacks.loading,
+      onQuotaWindowsChange: callbacks.quota_windows,
+      onUsageChange: callbacks.usage,
+      showCostSummary: false,
+    }),
+  },
+  {
+    name: 'Antigravity',
+    expected_failure_marker: false,
+    requests: antigravity_requests,
+    marker: (callbacks) => callbacks.connection.mock.calls.map(([value]) => value),
+    render: (nonce, callbacks) => createElement(AntigravityPanel, {
+      autoRefreshIntervalMs: 0,
+      manualRefreshNonce: nonce,
+      onConnectionChange: callbacks.connection,
+      onLoadingChange: callbacks.loading,
+    }),
+  },
+];
+
+async function start_panel_race(driver: PanelDriver) {
+  const requests = driver.requests();
+  const callbacks = panel_callbacks();
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(driver.render(0, callbacks));
+  });
+  await act(async () => {
+    renderer.update(driver.render(1, callbacks));
+  });
+  return { callbacks, renderer, requests };
+}
+
+describe.each(panel_drivers)('$name latest request wins', (driver) => {
+  it('keeps new success after old success', async () => {
+    const race = await start_panel_race(driver);
+    await settle(() => race.requests.resolve(1, 20));
+    await settle(() => race.requests.resolve(0, 90));
+    expect(driver.marker(race.callbacks)).toEqual([driver.name === 'Antigravity' ? true : 20]);
+    expect(race.callbacks.loading.mock.calls.at(-1)?.[0]).toBe(false);
+    await unmount(race.renderer);
+  });
+
+  it('keeps new success after old failure', async () => {
+    const race = await start_panel_race(driver);
+    await settle(() => race.requests.resolve(1, 20));
+    await settle(() => race.requests.reject(0, new Error('old failure')));
+    expect(driver.marker(race.callbacks)).toEqual([driver.name === 'Antigravity' ? true : 20]);
+    expect(rendered_text(race.renderer)).not.toContain('old failure');
+    await unmount(race.renderer);
+  });
+
+  it('keeps new failure after old success', async () => {
+    const race = await start_panel_race(driver);
+    await settle(() => race.requests.reject(1, new Error('new failure')));
+    await settle(() => race.requests.resolve(0, 90));
+    expect(driver.marker(race.callbacks)).toEqual([driver.expected_failure_marker]);
+    expect(rendered_text(race.renderer)).toContain('new failure');
+    await unmount(race.renderer);
+  });
+
+  it('does not let stale finally finish current loading', async () => {
+    const race = await start_panel_race(driver);
+    await settle(() => race.requests.resolve(0, 90));
+    expect(race.callbacks.loading.mock.calls.at(-1)?.[0]).toBe(true);
+    expect(driver.marker(race.callbacks)).toEqual([]);
+    await settle(() => race.requests.resolve(1, 20));
+    expect(race.callbacks.loading.mock.calls.at(-1)?.[0]).toBe(false);
+    await unmount(race.renderer);
+  });
+
+  it('suppresses completion after unmount', async () => {
+    const requests = driver.requests();
+    const callbacks = panel_callbacks();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(driver.render(0, callbacks));
+    });
+    await unmount(renderer);
+    await settle(() => requests.resolve(0, 90));
+    expect(driver.marker(callbacks)).toEqual([]);
+  });
+});
+
+describe('Codex atomic bundle failures', () => {
+  for (const member of ['info', 'limits', 'credits'] as const) {
+    it(`surfaces current ${member} rejection`, async () => {
+      const requests = codex_requests();
+      const callbacks = panel_callbacks();
+      let renderer!: ReactTestRenderer;
+      await act(async () => {
+        renderer = create(panel_drivers[0].render(0, callbacks));
+      });
+      await settle(() => requests.reject_member(0, member, new Error(`current ${member} failure`)));
+      expect(callbacks.usage).toHaveBeenCalledWith(null);
+      expect(callbacks.connection).toHaveBeenCalledWith(false);
+      expect(callbacks.quota_windows).toHaveBeenCalledWith([]);
+      expect(rendered_text(renderer)).toContain(`current ${member} failure`);
+      await unmount(renderer);
+    });
+
+    it(`suppresses stale ${member} rejection`, async () => {
+      const race = await start_panel_race(panel_drivers[0]);
+      const requests = race.requests as ReturnType<typeof codex_requests>;
+      await settle(() => requests.resolve(1, 20));
+      await settle(() => requests.reject_member(0, member, new Error(`old ${member} failure`)));
+      expect(race.callbacks.usage.mock.calls.map(([value]) => value)).toEqual([20]);
+      expect(rendered_text(race.renderer)).not.toContain(`old ${member} failure`);
+      await unmount(race.renderer);
+    });
+  }
+});
+
+function install_app_backend(quota_requests: Array<Deferred<QuotaData>>): void {
+  vi.spyOn(backend, 'getQuota').mockImplementation(() => quota_requests.shift()!.promise);
+  vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({ connected: true, availableCount: 0, credits: [] });
+  vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getAntigravityInfo').mockResolvedValue({ connected: false, status: 'pending' });
+  vi.spyOn(backend, 'setDockVisibility').mockResolvedValue(undefined);
+  vi.spyOn(backend, 'updateTrayIcon').mockResolvedValue(undefined);
+}
+
+function quota(marker: number): QuotaData {
+  return {
+    connected: true,
+    weeklyTotal: { used: marker, limit: 100, percentage: marker },
+  };
+}
+
+async function start_claude_race() {
+  vi.useFakeTimers();
+  const old_request = deferred<QuotaData>();
+  const new_request = deferred<QuotaData>();
+  install_app_backend([old_request, new_request]);
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(createElement(App));
+    await Promise.resolve();
+  });
+  const refresh = renderer.root.findByProps({ 'aria-label': 'Refresh current provider' });
+  await act(async () => refresh.props.onClick());
+  return { new_request, old_request, renderer };
+}
+
+describe('Claude latest request wins', () => {
+  it('keeps new success after old success', async () => {
+    const race = await start_claude_race();
+    await settle(() => race.new_request.resolve(quota(20)));
+    await settle(() => race.old_request.resolve(quota(90)));
+    expect(rendered_text(race.renderer)).toContain('20%');
+    expect(rendered_text(race.renderer)).not.toContain('90%');
+    await unmount(race.renderer);
+  });
+
+  it('keeps new success after old failure', async () => {
+    const race = await start_claude_race();
+    await settle(() => race.new_request.resolve(quota(20)));
+    await settle(() => race.old_request.reject(new Error('old Claude failure')));
+    expect(rendered_text(race.renderer)).toContain('20%');
+    expect(rendered_text(race.renderer)).not.toContain('old Claude failure');
+    await unmount(race.renderer);
+  });
+
+  it('keeps new failure after old success', async () => {
+    const race = await start_claude_race();
+    await settle(() => race.new_request.reject(new Error('new Claude failure')));
+    await settle(() => race.old_request.resolve(quota(90)));
+    expect(rendered_text(race.renderer)).toContain('new Claude failure');
+    expect(rendered_text(race.renderer)).not.toContain('90%');
+    await unmount(race.renderer);
+  });
+
+  it('does not let stale finally finish current loading', async () => {
+    const race = await start_claude_race();
+    await settle(() => race.old_request.resolve(quota(90)));
+    expect(rendered_text(race.renderer)).toContain('Loading Claude quota');
+    await settle(() => race.new_request.resolve(quota(20)));
+    expect(rendered_text(race.renderer)).toContain('20%');
+    await unmount(race.renderer);
+  });
+
+  it('invalidates a startup request on unmount', async () => {
+    vi.useFakeTimers();
+    const request = deferred<QuotaData>();
+    install_app_backend([request]);
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(App));
+      await Promise.resolve();
+    });
+    await unmount(renderer);
+    await settle(() => request.resolve(quota(90)));
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+function cost_overview(marker: number): CostOverview {
+  return {
+    source: 'claude',
+    displayName: 'Claude',
+    currency: 'USD',
+    generatedAt: '2026-07-16T00:00:00Z',
+    cached: false,
+    ranges: [{
+      range: 'today',
+      label: 'Today',
+      currency: 'USD',
+      cost: marker,
+      costUsd: marker,
+      tokens: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: marker },
+      models: [],
+      validEntries: 1,
+      skippedEntries: 0,
+      elapsedMs: 1,
+    }],
+  };
+}
+
+function cost_daily(marker: number): CostDailySeries {
+  return {
+    source: 'claude',
+    currency: 'USD',
+    generatedAt: '2026-07-16T00:00:00Z',
+    cached: false,
+    days: [{ date: '2026-07-16', cost: marker, costUsd: marker, totalTokens: marker }],
+  };
+}
+
+function cost_requests() {
+  const overviews: Array<Deferred<CostOverview>> = [];
+  const dailies: Array<Deferred<CostDailySeries>> = [];
+  vi.spyOn(backend, 'getCostOverview').mockImplementation(() => {
+    const request = deferred<CostOverview>();
+    overviews.push(request);
+    return request.promise;
+  });
+  vi.spyOn(backend, 'getCostDaily').mockImplementation(() => {
+    const request = deferred<CostDailySeries>();
+    dailies.push(request);
+    return request.promise;
+  });
+  return { dailies, overviews };
+}
+
+async function start_cost_race() {
+  vi.useFakeTimers();
+  const requests = cost_requests();
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(createElement(CostSummarySection, { source: 'claude', autoRefreshIntervalMs: 1000 }));
+  });
+  await act(async () => vi.advanceTimersByTime(1000));
+  expect(requests.overviews).toHaveLength(2);
+  expect(requests.dailies).toHaveLength(2);
+  return { renderer, requests };
+}
+
+describe('Cost lane latest request wins', () => {
+  it('keeps overview new success after old success and failure', async () => {
+    for (const old_terminal of ['success', 'failure'] as const) {
+      const race = await start_cost_race();
+      await settle(() => race.requests.overviews[1].resolve(cost_overview(20)));
+      if (old_terminal === 'success') await settle(() => race.requests.overviews[0].resolve(cost_overview(90)));
+      else await settle(() => race.requests.overviews[0].reject(new Error('old overview failure')));
+      expect(rendered_text(race.renderer)).toContain('$20.00');
+      expect(rendered_text(race.renderer)).not.toContain('$90.00');
+      await unmount(race.renderer);
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps overview new failure after old success', async () => {
+    const race = await start_cost_race();
+    await settle(() => race.requests.overviews[1].reject(new Error('new overview failure')));
+    await settle(() => race.requests.overviews[0].resolve(cost_overview(90)));
+    expect(rendered_text(race.renderer)).toContain('new overview failure');
+    expect(rendered_text(race.renderer)).not.toContain('$90.00');
+    await unmount(race.renderer);
+  });
+
+  it('does not let overview stale finally finish current loading', async () => {
+    const race = await start_cost_race();
+    await settle(() => race.requests.overviews[0].resolve(cost_overview(90)));
+    expect(rendered_text(race.renderer)).toContain('Loading cost');
+    await settle(() => race.requests.overviews[1].resolve(cost_overview(20)));
+    expect(rendered_text(race.renderer)).toContain('$20.00');
+    await unmount(race.renderer);
+  });
+
+  it('keeps daily new success after old success and failure', async () => {
+    for (const old_terminal of ['success', 'failure'] as const) {
+      const race = await start_cost_race();
+      await settle(() => race.requests.overviews[1].resolve(cost_overview(20)));
+      await settle(() => race.requests.dailies[1].resolve(cost_daily(2)));
+      const console_error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      if (old_terminal === 'success') await settle(() => race.requests.dailies[0].resolve(cost_daily(9)));
+      else await settle(() => race.requests.dailies[0].reject(new Error('old daily failure')));
+      expect(rendered_text(race.renderer)).toContain('Past 7 days · $2.00');
+      expect(rendered_text(race.renderer)).not.toContain('$9.00');
+      expect(console_error).not.toHaveBeenCalled();
+      await unmount(race.renderer);
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('keeps daily new failure after old success', async () => {
+    const race = await start_cost_race();
+    await settle(() => race.requests.overviews[1].resolve(cost_overview(20)));
+    const console_error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await settle(() => race.requests.dailies[1].reject(new Error('new daily failure')));
+    await settle(() => race.requests.dailies[0].resolve(cost_daily(9)));
+    expect(console_error).toHaveBeenCalledWith('Failed to load daily cost series:', expect.any(Error));
+    expect(rendered_text(race.renderer)).not.toContain('Past 7 days');
+    await unmount(race.renderer);
+  });
+
+  it('commits overview and daily current requests independently', async () => {
+    const race = await start_cost_race();
+    await settle(() => race.requests.overviews[1].resolve(cost_overview(20)));
+    await settle(() => race.requests.dailies[1].resolve(cost_daily(2)));
+    expect(rendered_text(race.renderer)).toContain('$20.00');
+    expect(rendered_text(race.renderer)).toContain('Past 7 days · $2.00');
+    await unmount(race.renderer);
+  });
+
+  it('suppresses both lane completions after cleanup', async () => {
+    vi.useFakeTimers();
+    const requests = cost_requests();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CostSummarySection, { source: 'claude', autoRefreshIntervalMs: 0 }));
+    });
+    await unmount(renderer);
+    const console_error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await settle(() => requests.overviews[0].resolve(cost_overview(90)));
+    await settle(() => requests.dailies[0].reject(new Error('cleanup daily failure')));
+    expect(console_error).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('Antigravity polling pause', () => {
+  it('does not register a timer when interval is zero', async () => {
+    vi.useFakeTimers();
+    const requests = antigravity_requests();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(AntigravityPanel, { autoRefreshIntervalMs: 0 }));
+    });
+    expect(vi.getTimerCount()).toBe(0);
+    await unmount(renderer);
+    await settle(() => requests.resolve(0, 20));
+  });
+});
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+beforeEach(() => {
+  const values = new Map<string, string>();
+  (globalThis as Record<string, unknown>).localStorage = {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() { return values.size; },
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete (globalThis as Record<string, unknown>).localStorage;
+});
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+});


### PR DESCRIPTION
## Why

Overlapping startup, manual, and interval reads could commit out of order. A deferred real-React reproduction showed a newer Codex refresh publish 20%, then an older startup request overwrite it with stale 90%. The same unconditional terminal writes existed in Claude, Cursor, Antigravity, and Cost.

## Implementation

- add one stable monotonic request-generation coordinator with unmount invalidation
- make Claude, Codex, Cursor, and Antigravity success/failure/finally commits latest-wins
- keep the Codex info/limits/credits bundle atomic
- give Cost overview and daily independent generation lanes and invalidate both on effect cleanup
- pause Antigravity polling when autoRefreshIntervalMs <= 0
- enforce real backend, generation-hook, and React import provenance; reject protected lexical shadows including global Promise across the entire source
- bind provider targets directly to the owner component and Cost targets directly to the one owning effect, rejecting nested/dead compliant decoys and duplicate expected backend calls
- require exact direct/Promise.all array/map backend methods and arguments, rejecting comma-discard, dummy-promise, alias-attached, extra, missing, duplicate, and wrong-receiver cases
- add deterministic real-React deferred coverage for every provider/lane terminal order, every Codex bundle member rejection, unmount/cleanup, loading ownership, and Cost cross-lane independence

## Scope and dependencies

- exact 13-path SpecRail allowlist
- react-test-renderer@19.2.6 and its types are dev-only; resolved renderer exactly matches React 19.2.6
- no backend API, payload, cache, cadence, UI wording, runtime dependency, or tray-write serialization change

## Verification

- fail-closed wiring checker: 72 adversarial/valid cases; line/function/branch 100%
- latest-generation + real-React race matrix: 36/36 passed
- full frontend: 22 files / 274 tests passed
- TypeScript diff coverage: 49/49 measurable changed lines = 100%; coordinator and App/Codex/Cursor/Antigravity/Cost critical paths all 100%
- npm run build: passed
- cargo fmt --check, cargo check, cargo test: passed (29 passed, 2 ignored)
- 13-path allowlist and git diff --check: passed

## Rollback

Revert this PR. There are no backend, schema, payload, persistence, cache, cadence, or runtime dependency migrations.

Closes #52