### PR TITLE
spec: make fatal frontend diagnostics safe and observable

### DIFF
--- a/specs/GH58/product.md
+++ b/specs/GH58/product.md
@@ -1,0 +1,67 @@
+# GH-58 Product Spec：fatal frontend diagnostics 安全、可见且单实例
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/58
+- `complexity: medium`
+
+## Problem
+
+`src/main.tsx` 把 window error、unhandled rejection 与 React uncaught error 的任意 payload 原样传给 `console.error`，并把 `Error.message` / `Error.stack` 或 `String(payload)` 写进透明 popover DOM。OAuth 片段、本地路径、响应内容等敏感上下文因此可能进入日志与截图；异常 `toString` 还可能让 fatal reporter 自身抛错。DOM fallback 的空 `catch {}` 会吞掉 create/update/append failure，使 blank-panel 症状继续无独立 reporter 信号。重复 fatal channel 还会追加多个全屏 `<pre>`。
+
+`origin/main@db883cd42eb466fd41f84e920cf6b4579ec94ef1` 的 disposable entry-module reproduction 已确认：带 `oauth_token=private-fatal-payload` 与 private stack marker 的 Error 同时出现在 console arguments 和 `<pre>.textContent`；`appendChild` 抛错后 handler 静默返回，且没有固定 reporter-failure message。临时测试已删除，audit worktree 恢复干净。
+
+## Goals
+
+- 三个 fatal channel 只输出固定安全诊断，不读取、转换、序列化或转发 raw payload。
+- 透明 popover 继续绘制明确、通用的重启提示，并保留安全的内部 source 标识。
+- 所有 fatal channel 复用一个固定 ID 的 surface，不追加重复 overlay。
+- fatal surface 的 lookup/create/update/append failure 使用固定安全 secondary diagnostic，可观察且不泄漏 raw 值。
+- 保持 React root、window listeners 与正常 App render wiring 不变。
+
+## Non-Goals
+
+- 不新增 telemetry、remote reporting、crash persistence、user notification 或 error details UI。
+- 不改 App、backend、Tauri API、provider、storage、polling、notification 或 styling system。
+- 不展示 stack、error message、本地路径、payload 摘要或 debug token。
+- 不新增 runtime/dev dependency。
+
+## Behavior Invariants
+
+1. `B-001` module startup 精确注册一次 window `error` listener、一次 `unhandledrejection` listener，并以 React 19 `onUncaughtError` 创建与 render 现有 root/App。
+2. `B-002` 每次 window、promise 或 React fatal event 精确记录一次 source-specific fixed primary string；console arguments 不含 raw identity、message、stack、getter/toString result 或任意 payload。
+3. `B-003` 每次 fatal event 尝试把固定 generic restart instruction 与内部 source 写入固定 ID surface；DOM text 不含 raw 数据。
+4. `B-004` 首次成功创建并 append 一个 `<pre>`；后续 fatal event 复用并更新同一 surface，append count 保持一次。
+5. `B-005` surface lookup、create、safe-field update 或 append 任一失败时，handler 不传播该 DOM failure，精确记录一次固定 secondary string，且不传递 caught value。
+6. `B-006` raw payload 永不被属性读取、字符串转换或序列化；带 throwing getter/toString 的 Error-like/object payload 也不能影响 reporter terminal。
+7. `B-007` surface 只使用 `textContent`；不得出现 `innerHTML`、HTML parsing、raw error logging、empty catch 或 duplicate fatal node。
+8. `B-008` deterministic entry-module matrix、diff coverage、full frontend/build/Rust 与 current-head PR gates 全部通过，implementation 无 allowlist 外 scope。
+
+## Acceptance Criteria
+
+- entry-module tests 捕获真实注册的 window error、unhandled rejection 与 React `onUncaughtError` callbacks，不测试复制 helper。
+- 三个 channel 分别传入含 private marker 的 Error、非 Error object 与 throwing getter/toString payload；handler 不抛错，primary log 与 DOM text 仅为固定安全值。
+- fixed strings 为 `Quotabar encountered an unexpected interface error. Restart the app.` 与 `Failed to display fatal frontend error.`；source 仅为 `window`、`promise`、`react`。
+- 首次 fatal event 创建固定 ID `quotabar-fatal-error` 的 `<pre>`；连续三个 channel 只 append 一次，复用 surface 并更新为最后 source。
+- deterministic failure matrix 覆盖 `getElementById`、`createElement`、surface id/style/text update 与 `body.appendChild` failure；每个 terminal primary/secondary 各一次、零 raw data、零 throw。
+- fake surface 对 `innerHTML` write fail closed；throwing raw getters/toString 与实际 callback capture 直接证明 production path 不读取 raw event fields 或 payload。
+- root lookup、`createRoot` options、`render(<StrictMode><App /></StrictMode>)` 与两个 listener registrations 精确断言。
+- implementation 仅含 tech spec allowlist；executable TS/TSX diff line coverage ≥80%，`src/main.tsx` measurable changed lines critical 100%。
+
+## Boundary Checklist
+
+| Boundary | Expected result |
+| --- | --- |
+| Window Error with secret Error | fixed window log + fixed window surface；零 raw。 |
+| Promise rejection object | fixed promise log + reused fixed surface；零 object access/coercion。 |
+| React uncaught error | fixed react log + reused fixed surface；root wiring unchanged。 |
+| Throwing getter/toString payload | handler terminal 不受影响；零 payload evaluation。 |
+| First fatal event | create/initialize/append fixed-ID `<pre>` exactly once。 |
+| Repeated channels | reuse same node；append count remains one。 |
+| Existing fatal surface | update safe text only；不创建新 node。 |
+| DOM operation failure | fixed secondary log once；零 raw/caught value；handler 不 throw。 |
+| HTML injection marker | textContent exact literal；零 innerHTML。 |
+
+## Open Questions
+
+- 无。安全 strings、source union、single-surface ownership、DOM failure terminal 与测试边界均已定义。

--- a/specs/GH58/product.md
+++ b/specs/GH58/product.md
@@ -13,7 +13,7 @@
 
 ## Goals
 
-- 三个 fatal channel 只输出固定安全诊断，不读取、转换、序列化或转发 raw payload。
+- 三个 fatal channel 只输出固定安全诊断，不读取、转换、序列化或转发 raw payload；window/promise events 还必须取消可能泄漏 raw 数据的平台默认报告。
 - 透明 popover 继续绘制明确、通用的重启提示，并保留安全的内部 source 标识。
 - 所有 fatal channel 复用一个固定 ID 的 surface，不追加重复 overlay。
 - fatal surface 的 lookup/create/update/append failure 使用固定安全 secondary diagnostic，可观察且不泄漏 raw 值。
@@ -29,18 +29,18 @@
 ## Behavior Invariants
 
 1. `B-001` module startup 精确注册一次 window `error` listener、一次 `unhandledrejection` listener，并以 React 19 `onUncaughtError` 创建与 render 现有 root/App。
-2. `B-002` 每次 window、promise 或 React fatal event 精确记录一次 source-specific fixed primary string；console arguments 不含 raw identity、message、stack、getter/toString result 或任意 payload。
+2. `B-002` 每次 window、promise 或 React fatal event 精确记录一次 source-specific fixed primary string；window/promise listener 分别调用 event wrapper 的 `preventDefault()` exactly once，阻止平台默认 raw console report；所有 console arguments 不含 raw identity、message、stack、getter/toString result 或任意 payload。
 3. `B-003` 每次 fatal event 尝试把固定 generic restart instruction 与内部 source 写入固定 ID surface；DOM text 不含 raw 数据。
 4. `B-004` 首次成功创建并 append 一个 `<pre>`；后续 fatal event 复用并更新同一 surface，append count 保持一次。
 5. `B-005` surface lookup、create、safe-field update 或 append 任一失败时，handler 不传播该 DOM failure，精确记录一次固定 secondary string，且不传递 caught value。
-6. `B-006` raw payload 永不被属性读取、字符串转换或序列化；带 throwing getter/toString 的 Error-like/object payload 也不能影响 reporter terminal。
+6. `B-006` 除 event wrapper 的 `preventDefault()` control method 外，raw payload/event data 永不被属性读取、字符串转换或序列化；带 throwing error/message/reason getter 或 toString 的 payload 也不能影响 reporter terminal。
 7. `B-007` surface 只使用 `textContent`；不得出现 `innerHTML`、HTML parsing、raw error logging、empty catch 或 duplicate fatal node。
 8. `B-008` deterministic entry-module matrix、diff coverage、full frontend/build/Rust 与 current-head PR gates 全部通过，implementation 无 allowlist 外 scope。
 
 ## Acceptance Criteria
 
-- entry-module tests 捕获真实注册的 window error、unhandled rejection 与 React `onUncaughtError` callbacks，不测试复制 helper。
-- 三个 channel 分别传入含 private marker 的 Error、非 Error object 与 throwing getter/toString payload；handler 不抛错，primary log 与 DOM text 仅为固定安全值。
+- entry-module tests 捕获真实注册的 window error、unhandled rejection 与 React `onUncaughtError` callbacks，不测试复制 helper；两个 global events 的 `preventDefault()` 各自 exactly once，React path 不存在 event cancellation。
+- 三个 channel 分别传入含 private marker 的 Error、非 Error object 与 throwing getter/toString payload；window/promise wrapper 只允许读取 `preventDefault`，不得触发 error/message/reason getter；handler 不抛错，primary log 与 DOM text 仅为固定安全值。
 - fixed strings 为 `Quotabar encountered an unexpected interface error. Restart the app.` 与 `Failed to display fatal frontend error.`；source 仅为 `window`、`promise`、`react`。
 - 首次 fatal event 创建固定 ID `quotabar-fatal-error` 的 `<pre>`；连续三个 channel 只 append 一次，复用 surface 并更新为最后 source。
 - deterministic failure matrix 覆盖 `getElementById`、`createElement`、surface id/style/text update 与 `body.appendChild` failure；每个 terminal primary/secondary 各一次、零 raw data、零 throw。
@@ -52,8 +52,8 @@
 
 | Boundary | Expected result |
 | --- | --- |
-| Window Error with secret Error | fixed window log + fixed window surface；零 raw。 |
-| Promise rejection object | fixed promise log + reused fixed surface；零 object access/coercion。 |
+| Window Error with secret Error | preventDefault once + fixed window log/surface；零 raw getter/default report。 |
+| Promise rejection object | preventDefault once + fixed promise log/reused surface；零 reason access/coercion/default report。 |
 | React uncaught error | fixed react log + reused fixed surface；root wiring unchanged。 |
 | Throwing getter/toString payload | handler terminal 不受影响；零 payload evaluation。 |
 | First fatal event | create/initialize/append fixed-ID `<pre>` exactly once。 |

--- a/specs/GH58/tasks.md
+++ b/specs/GH58/tasks.md
@@ -1,0 +1,25 @@
+# GH-58 Tasks：safe fatal frontend reporting
+
+## Delivery Contract
+
+- Base: spec 与 implementation PR 分别基于创建时 then-latest `origin/main`。
+- Commit policy: `per_step`。
+- Scope: 仅修入口 fatal diagnostics 的 raw-data boundary、single-surface ownership 与 reporter failure observability。
+- Compatibility: React root、App render、window listeners、backend/Tauri/provider/storage/dependencies 不变。
+
+## Implementation Tasks
+
+- [ ] `SP58-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`~`B-007`. Done when: closed source union、fixed safe primary/secondary strings、argument-discarding callbacks、fixed-ID single surface 与 observable DOM failure 接入真实 entry module；零 raw access/coercion/log/DOM。 Verify: targeted real-entry tests。
+- [ ] `SP58-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-007`. Done when: wiring、三 channel、hostile payload、first/existing/repeated ownership、六类 DOM failure 与 innerHTML runtime trap deterministic matrix 全部通过；无 wall-clock/jsdom/copied helper。 Verify: `tests/fatal_error_reporting.test.tsx`。
+- [ ] `SP58-T3` Owner: codex. Dependencies: T1-T2. Covers: `B-008`. Done when: exact 3-path allowlist；overall executable diff ≥80%；`src/main.tsx` critical changed lines 100%；full frontend/build/Rust pass。 Verify: tech Test Plan。
+
+## Handoff
+
+- [ ] `SP58-T4` Owner: codex. Dependencies: T3. Done when: implementation PR `Closes #58`，正文记录 reproduction、threat boundary、fixed diagnostics、single-surface ownership、DOM terminal matrix、coverage、dependency boundary 与 rollback，并通过 implementation-vs-spec、current-head connector/CI/reviewThreads gate。
+
+## Handoff Notes
+
+- Invariants: `{B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008}`。
+- Coverage union: `{B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008}`。
+- Spec PR 仅三份 GH58 文档；implementation 才修改 entry、tests 与本 tasks ledger。
+- 禁止 force push、raw fatal payload exposure、empty catch、innerHTML、duplicate fatal surface、test weakening 或 allowlist 外 scope。

--- a/specs/GH58/tasks.md
+++ b/specs/GH58/tasks.md
@@ -9,8 +9,8 @@
 
 ## Implementation Tasks
 
-- [ ] `SP58-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`~`B-007`. Done when: closed source union、fixed safe primary/secondary strings、argument-discarding callbacks、fixed-ID single surface 与 observable DOM failure 接入真实 entry module；零 raw access/coercion/log/DOM。 Verify: targeted real-entry tests。
-- [ ] `SP58-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-007`. Done when: wiring、三 channel、hostile payload、first/existing/repeated ownership、六类 DOM failure 与 innerHTML runtime trap deterministic matrix 全部通过；无 wall-clock/jsdom/copied helper。 Verify: `tests/fatal_error_reporting.test.tsx`。
+- [ ] `SP58-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`~`B-007`. Done when: closed source union、fixed safe primary/secondary strings、global preventDefault exact-once、argument-discarding React callback、fixed-ID single surface 与 observable DOM failure 接入真实 entry module；零 raw access/coercion/log/DOM/default report。 Verify: targeted real-entry tests。
+- [ ] `SP58-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-007`. Done when: wiring、三 channel、global preventDefault、throwing error/message/reason getters与toString、first/existing/repeated ownership、六类 DOM failure 与 innerHTML runtime trap deterministic matrix 全部通过；无 wall-clock/jsdom/copied helper。 Verify: `tests/fatal_error_reporting.test.tsx`。
 - [ ] `SP58-T3` Owner: codex. Dependencies: T1-T2. Covers: `B-008`. Done when: exact 3-path allowlist；overall executable diff ≥80%；`src/main.tsx` critical changed lines 100%；full frontend/build/Rust pass。 Verify: tech Test Plan。
 
 ## Handoff

--- a/specs/GH58/tech.md
+++ b/specs/GH58/tech.md
@@ -1,0 +1,156 @@
+# GH-58 Tech Spec：fail-safe fatal frontend reporter
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/58
+- Product spec: `specs/GH58/product.md`
+
+## Root Cause
+
+入口 module 的 `reportFatalError(source, error)` 在任何保护逻辑前读取/转换 raw error，随后把 raw identity 交给 `console.error`，把 message/stack 写入 DOM。三类 callbacks 还主动读取 `event.error`、`event.message` 与 `event.reason`。DOM mutation 使用每次新建/append node 的无所有权模型，且 empty catch 吞掉 reporter failure。因此 confidentiality、reporter liveness、single-surface ownership 与 failure observability 同时缺失。
+
+## Preflight Contract
+
+implementation 必须从 spec merge 后 then-latest `origin/main` 创建，并在 edit 前验证：
+
+- disposable entry-module reproduction 仍证明 private marker 进入 console/DOM，append failure 无 fixed secondary diagnostic。
+- `src/main.tsx` 仍读取/转换 raw payload、每次 append 新 `<pre>` 且存在 empty catch。
+- search-first 无同类 issue/PR，baseline frontend/build/Rust 全绿。
+
+任一行为漂移必须先更新 GH58 spec。
+
+## Proposed Design
+
+### 1. Closed source and fixed messages
+
+module-local contract：
+
+```ts
+type FatalErrorSource = 'window' | 'promise' | 'react';
+
+const FATAL_ERROR_MESSAGE =
+  'Quotabar encountered an unexpected interface error. Restart the app.';
+const FATAL_SURFACE_ERROR_MESSAGE = 'Failed to display fatal frontend error.';
+const FATAL_SURFACE_ID = 'quotabar-fatal-error';
+```
+
+`report_fatal_error(source: FatalErrorSource): void` 不接收 raw value。三个 callbacks 都忽略全部 callback arguments，只传 literal source；禁止读取 `event.error`、`event.message`、`event.reason`，禁止 Error narrowing、`String`、JSON serialization 或 raw console argument。
+
+每次调用先执行一次下列 primary diagnostic；只有一个 string argument：
+
+```ts
+console.error(`[fatal:${source}] ${FATAL_ERROR_MESSAGE}`);
+```
+
+### 2. Single owned surface
+
+在一个 `try/catch` 内：
+
+- 用 `document.getElementById(FATAL_SURFACE_ID)` 查找已有 surface。
+- 没有时创建 `pre`，设置 fixed ID 与既有 fixed safe CSS，使用 `textContent` 写 fixed `[source] message`，再 append 到 `document.body`。
+- 已存在时只更新 `textContent` 为最新 fixed source/message；不得创建或 append 新 node。
+- 不使用 module cache 作为 DOM ownership truth，避免 node 被外部移除后持有 stale reference；每次以 fixed ID lookup 为准。
+
+surface 允许 `HTMLElement`，但创建路径必须为 `<pre>`。禁止 `innerHTML`、insertAdjacentHTML 或 raw interpolation。
+
+### 3. Observable reporter failure
+
+lookup/create/id/style/text/append 任一同步 throw 进入唯一 catch。catch 不绑定 caught value，固定执行一次：
+
+```ts
+console.error(FATAL_SURFACE_ERROR_MESSAGE);
+```
+
+不得传递 DOM exception。primary log 已在 try 外完成，因此每次 DOM failure 恰有 primary safe log once + secondary safe log once。console API 自身 failure 与浏览器全局事件递归策略不在本 issue scope。
+
+### 4. Entry wiring
+
+- `window.addEventListener('error', () => report_fatal_error('window'))`
+- `window.addEventListener('unhandledrejection', () => report_fatal_error('promise'))`
+- React root option `onUncaughtError: () => report_fatal_error('react')`
+
+root element lookup、StrictMode、App 与 render count 不变。函数与常量保持 module-local，不新增 public API。
+
+### 5. Deterministic entry-module tests
+
+新增 `tests/fatal_error_reporting.test.tsx`。mock React root/App boundary，真实 import `src/main.tsx`，捕获真实 listeners、root options、render call；fake document/surface 提供可控 getter/setter/operation failures。
+
+| Case group | Required cases |
+| --- | --- |
+| Wiring | 两个 window listeners exactly once；root element/options/render exactly once |
+| Channels | window Error、promise object、React Error；fixed source-specific log/text |
+| Raw safety | raw identity/message/stack/nested marker absent；throwing getters/toString never evaluated |
+| Ownership | first create/append once；three channels reuse one ID surface；existing surface path zero create/append |
+| DOM terminals | lookup、create、id、style、text、append 各自 throw；primary/secondary exact counts、zero throw/raw |
+| Injection | HTML-like marker absent；innerHTML setter never called；actual callbacks never access raw getters |
+
+使用 `vi.resetModules()`、deferred-free synchronous callbacks 与 explicit stubs；不依赖 jsdom、wall-clock sleep 或 copied reporter helper。
+
+## Affected Files / Allowlist
+
+- `src/main.tsx`
+- `tests/fatal_error_reporting.test.tsx`
+- `specs/GH58/tasks.md`
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Sanitization removes debugging detail | fixed source keeps channel attribution；安全优先，不显示 raw。 |
+| duplicate fatal events create overlays | fixed-ID DOM lookup ownership + multi-channel reuse test。 |
+| reporter crashes on hostile payload | callbacks discard arguments；throwing getter/toString test。 |
+| DOM stub passes while real wiring drifts | import real entry module and capture actual registered callbacks/root options。 |
+| innerHTML introduces injection | textContent exact assertion + innerHTML runtime trap。 |
+| DOM failure becomes silent | fixed secondary diagnostic exact-count matrix。 |
+| scope expands into global error UI | exact 3-path allowlist。 |
+
+## Product-to-Test Mapping
+
+| Invariant | Verification |
+| --- | --- |
+| `B-001` | entry wiring/root render exact-count tests |
+| `B-002` | three channel safe primary logs + raw negative assertions |
+| `B-003` | exact fixed surface text per source |
+| `B-004` | first/existing/repeated single-surface matrix |
+| `B-005` | six DOM operation failure terminals |
+| `B-006` | throwing getter/toString payload cases |
+| `B-007` | innerHTML trap + DOM failure observability + no empty catch |
+| `B-008` | allowlist、coverage、full local/CI/current-head review |
+
+## Test Plan
+
+```bash
+set -euo pipefail
+git fetch origin main:refs/remotes/origin/main
+git merge-base --is-ancestor origin/main HEAD
+git diff --quiet origin/main...HEAD -- . \
+  ':(exclude)src/main.tsx' \
+  ':(exclude)tests/fatal_error_reporting.test.tsx' \
+  ':(exclude)specs/GH58/tasks.md'
+npx vitest run tests/fatal_error_reporting.test.tsx
+node --experimental-test-coverage \
+  --test-coverage-include=scripts/check_ts_diff_coverage.mjs \
+  --test-coverage-lines=100 \
+  --test-coverage-functions=100 \
+  --test-coverage-branches=100 \
+  --test scripts/check_ts_diff_coverage.test.mjs
+npx vitest run --coverage \
+  --coverage.include='src/**/*.{ts,tsx}' \
+  --coverage.reporter=lcov \
+  --coverage.reporter=text
+node scripts/check_ts_diff_coverage.mjs \
+  --base origin/main \
+  --lcov coverage/lcov.info \
+  --minimum 80 \
+  --critical src/main.tsx=100
+npm test
+npm run build
+cargo fmt --manifest-path src-tauri/Cargo.toml --check
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+git diff --check origin/main...HEAD
+```
+
+## Rollback Plan
+
+回滚 implementation PR。无 backend、schema、payload、persistence、interval、cache、dependency 或 migration；旧行为将恢复为 raw fatal data 写 console/DOM、duplicate surfaces 与 silent reporter failure。

--- a/specs/GH58/tech.md
+++ b/specs/GH58/tech.md
@@ -7,7 +7,7 @@
 
 ## Root Cause
 
-入口 module 的 `reportFatalError(source, error)` 在任何保护逻辑前读取/转换 raw error，随后把 raw identity 交给 `console.error`，把 message/stack 写入 DOM。三类 callbacks 还主动读取 `event.error`、`event.message` 与 `event.reason`。DOM mutation 使用每次新建/append node 的无所有权模型，且 empty catch 吞掉 reporter failure。因此 confidentiality、reporter liveness、single-surface ownership 与 failure observability 同时缺失。
+入口 module 的 `reportFatalError(source, error)` 在任何保护逻辑前读取/转换 raw error，随后把 raw identity 交给 `console.error`，把 message/stack 写入 DOM。三类 callbacks 还主动读取 `event.error`、`event.message` 与 `event.reason`；两个 cancelable global events 未调用 `preventDefault()`，平台默认处理仍可能把 raw Error/reason 输出到 WebView console。DOM mutation 使用每次新建/append node 的无所有权模型，且 empty catch 吞掉 reporter failure。因此 confidentiality、reporter liveness、single-surface ownership 与 failure observability 同时缺失。
 
 ## Preflight Contract
 
@@ -34,7 +34,7 @@ const FATAL_SURFACE_ERROR_MESSAGE = 'Failed to display fatal frontend error.';
 const FATAL_SURFACE_ID = 'quotabar-fatal-error';
 ```
 
-`report_fatal_error(source: FatalErrorSource): void` 不接收 raw value。三个 callbacks 都忽略全部 callback arguments，只传 literal source；禁止读取 `event.error`、`event.message`、`event.reason`，禁止 Error narrowing、`String`、JSON serialization 或 raw console argument。
+`report_fatal_error(source: FatalErrorSource): void` 不接收 raw value。React callback 忽略全部 callback arguments，只传 literal source。window/promise callbacks 接收 event wrapper，但只允许调用 `event.preventDefault()` exactly once 后传 literal source；禁止读取 `event.error`、`event.message`、`event.reason`，禁止 Error narrowing、`String`、JSON serialization 或 raw console argument。取消默认动作属于 confidentiality contract，不能省略或延后到可能失败的 reporter DOM path。
 
 每次调用先执行一次下列 primary diagnostic；只有一个 string argument：
 
@@ -65,8 +65,8 @@ console.error(FATAL_SURFACE_ERROR_MESSAGE);
 
 ### 4. Entry wiring
 
-- `window.addEventListener('error', () => report_fatal_error('window'))`
-- `window.addEventListener('unhandledrejection', () => report_fatal_error('promise'))`
+- `window.addEventListener('error', (event) => { event.preventDefault(); report_fatal_error('window'); })`
+- `window.addEventListener('unhandledrejection', (event) => { event.preventDefault(); report_fatal_error('promise'); })`
 - React root option `onUncaughtError: () => report_fatal_error('react')`
 
 root element lookup、StrictMode、App 与 render count 不变。函数与常量保持 module-local，不新增 public API。
@@ -77,9 +77,9 @@ root element lookup、StrictMode、App 与 render count 不变。函数与常量
 
 | Case group | Required cases |
 | --- | --- |
-| Wiring | 两个 window listeners exactly once；root element/options/render exactly once |
-| Channels | window Error、promise object、React Error；fixed source-specific log/text |
-| Raw safety | raw identity/message/stack/nested marker absent；throwing getters/toString never evaluated |
+| Wiring | 两个 window listeners exactly once；global preventDefault each exactly once；root element/options/render exactly once |
+| Channels | window Error、promise object、React Error；fixed source-specific log/text；global default reports canceled |
+| Raw safety | raw identity/message/stack/nested marker absent；throwing error/message/reason getters与toString never evaluated |
 | Ownership | first create/append once；three channels reuse one ID surface；existing surface path zero create/append |
 | DOM terminals | lookup、create、id、style、text、append 各自 throw；primary/secondary exact counts、zero throw/raw |
 | Injection | HTML-like marker absent；innerHTML setter never called；actual callbacks never access raw getters |
@@ -101,6 +101,7 @@ root element lookup、StrictMode、App 与 render count 不变。函数与常量
 | reporter crashes on hostile payload | callbacks discard arguments；throwing getter/toString test。 |
 | DOM stub passes while real wiring drifts | import real entry module and capture actual registered callbacks/root options。 |
 | innerHTML introduces injection | textContent exact assertion + innerHTML runtime trap。 |
+| platform default action leaks raw fatal data | real global callbacks assert preventDefault exactly once before fixed reporting。 |
 | DOM failure becomes silent | fixed secondary diagnostic exact-count matrix。 |
 | scope expands into global error UI | exact 3-path allowlist。 |
 
@@ -109,11 +110,11 @@ root element lookup、StrictMode、App 与 render count 不变。函数与常量
 | Invariant | Verification |
 | --- | --- |
 | `B-001` | entry wiring/root render exact-count tests |
-| `B-002` | three channel safe primary logs + raw negative assertions |
+| `B-002` | three channel safe primary logs + two preventDefault exact-once + raw negative assertions |
 | `B-003` | exact fixed surface text per source |
 | `B-004` | first/existing/repeated single-surface matrix |
 | `B-005` | six DOM operation failure terminals |
-| `B-006` | throwing getter/toString payload cases |
+| `B-006` | throwing error/message/reason getter and toString payload cases |
 | `B-007` | innerHTML trap + DOM failure observability + no empty catch |
 | `B-008` | allowlist、coverage、full local/CI/current-head review |
 


### PR DESCRIPTION
Spec for #58.

## Why

The entry reporter currently copies arbitrary fatal Error/rejection data into console arguments and screenshot-visible DOM, evaluates hostile payload coercion, silently swallows reporter DOM failures, and appends duplicate fullscreen surfaces. A disposable test on `origin/main@db883cd` reproduced raw OAuth-like markers and stack text in both sinks plus an unobservable append failure.

## Plan

- Use a closed `window | promise | react` source union and fixed primary/secondary strings.
- Discard callback payloads before any property access, coercion, serialization, log, or DOM write.
- Reuse one fixed-ID `<pre>` using DOM lookup ownership and `textContent` only.
- Surface lookup/create/id/style/text/append failures with one fixed safe secondary diagnostic.
- Verify real entry listeners, React root wiring, hostile payloads, repeated channels, six DOM terminals, innerHTML trap, exact three-path scope, coverage, and full gates.

## Scope

Spec-only: `specs/GH58/product.md`, `tech.md`, and `tasks.md`. Implementation is a separate PR after this spec merges. No backend, Tauri, App, persistence, provider, notification, styling-system, or dependency changes.

## Baseline verification

- Frontend: 23 files / 311 tests.
- `npm run build`.
- Rust fmt/check/test: 29 passed / 2 ignored.
- Test Plan shell syntax and `git diff --check`.