### PR TITLE
docs: specify switcher visibility transactions

### DIFF
--- a/specs/GH61/product.md
+++ b/specs/GH61/product.md
@@ -17,7 +17,8 @@
 
 - 从当前已渲染 switcher visibility snapshot 同步决定 blocked 或 accepted terminal，不依赖 updater 何时执行。
 - 关闭最后一个可见 provider 时保持所有 visibility 值不变、零 persistence，并精确显示一次固定 guard toast 与一次清理 timer。
-- accepted enable/disable 只翻转目标 provider，其他 provider 不变，并在真实 StrictMode contract 下以 exact next snapshot 持久化一次。
+- 连续 blocked 用户事件由 latest event 拥有 timer：取消旧 timer、重新获得完整展示时长，并在 unmount 释放 timer ownership。
+- 四个 provider 的 accepted enable/disable 均只翻转目标 provider，其他 provider 不变，并在真实 StrictMode contract 下以 exact next snapshot 持久化一次。
 - 保持 SettingsView callback、switcher storage schema、active-tab fallback 与 provider refresh wiring 不变。
 
 ## Non-Goals
@@ -31,8 +32,8 @@
 
 1. `B-001` `SettingsView.onSwitcherToggle` 继续接收真实 `handleSwitcherToggle`，四个 `TrayServiceName` 均使用当前 render 的 `switcherVisibility` 做一次 closed transition decision。
 2. `B-002` 当目标当前为 visible 且其他三个均 hidden 时，transition 为 blocked：四个值全部保持、`saveSwitcherVisibility` 零次、fixed guard toast 精确出现一次。
-3. `B-003` blocked toast 文本固定为 `At least one provider must stay in the switcher`，使用 `TRAY_GUARD_TOAST_MS` 精确安排一次 clear；到期前保留，到期后清除。
-4. `B-004` accepted hidden→visible 与 visible→hidden transition 只翻转目标 service，提交 exact next snapshot，并调用 `saveSwitcherVisibility(next)` exactly once；StrictMode 不增加 persistence 次数。
+3. `B-003` blocked toast 文本固定为 `At least one provider must stay in the switcher`，使用 `TRAY_GUARD_TOAST_MS`；latest blocked event 取消前一个 owned timer 并重新安排一次 clear，获得完整展示时长；timer 只清除仍为该 guard 的 toast，unmount 取消 pending timer 且零 post-unmount state write。
+4. `B-004` 四个 service 各自的 accepted hidden→visible 与 visible-with-peer→hidden transition 只翻转目标 service，提交 exact next snapshot，并调用 `saveSwitcherVisibility(next)` exactly once；共 8 个 terminal，StrictMode 不增加 persistence 次数。
 5. `B-005` state updater 保持纯净：persistence、toast 与 timer side effect 不得从 functional updater、state initializer 或 render evaluation 触发。
 6. `B-006` active provider 隐藏后回退 Overview、其他 App state/effects、SettingsView props 与 switcher storage failure notification 继续使用既有契约。
 7. `B-007` deterministic real-App matrix、executable diff coverage、full frontend/build/Rust 与 current-head PR gates 全部通过，implementation 无 allowlist 外 scope。
@@ -41,8 +42,9 @@
 
 - 测试挂载真实 `<StrictMode><App /></StrictMode>`，从真实 `SettingsView` instance 捕获 `onSwitcherToggle`；不得测试复制 helper 或跳过 App state。
 - 参数化四个 service 的 only-visible blocked terminal：callback 不抛、visibility snapshot 完全不变、persistence 零次、fixed toast 一次。
-- fake timers 直接证明 blocked terminal 新增一个 `TRAY_GUARD_TOAST_MS` clear：到期前 toast 仍可见，到期后为空；不依赖 wall-clock sleep。
-- 参数化 accepted hidden→visible 与“至少另一个可见”的 visible→hidden terminal：只有目标 bit 变化，`saveSwitcherVisibility` 对 exact next object 精确一次。
+- fake timers 直接证明首个 blocked terminal 安排一个 `TRAY_GUARD_TOAST_MS` clear；第二个正常用户 blocked event 在旧 timer 到期前发生时取消旧 timer、重新安排一个完整 delay，旧 expiry 后 toast 仍存在、新 expiry 后才清除；不依赖 wall-clock sleep。
+- timer callback 只清除仍为 switcher guard 的 toast；unmount 取消 pending owned timer，之后 advance timers 不产生 state write。
+- 参数化四个 service 各自的 accepted hidden→visible 与“至少另一个可见”的 visible→hidden terminal，共 8 例：只有目标 bit 变化，`saveSwitcherVisibility` 对 exact next object 精确一次。
 - accepted matrix 在 StrictMode 下运行；当前重复 updater-side-effect 实现必须因 persistence count 2 而失败。
 - blocked 与 accepted callback 均来自最新 committed render；tests 不建立同一 render callback 的 programmatic reentrant API。
 - active provider hidden 后的既有 Overview fallback 至少有一例回归断言；storage/backend/provider contract 不变。
@@ -54,10 +56,12 @@
 | --- | --- |
 | only Claude visible → disable Claude | state unchanged；zero save；guard toast once；one clear timer。 |
 | each other service only-visible | 与 Claude 相同 blocked terminal。 |
-| hidden service → enable | target true；others unchanged；exact next snapshot saved once。 |
-| visible service with another visible → disable | target false；others unchanged；exact next snapshot saved once。 |
+| each hidden service → enable | 四例 target true；others unchanged；exact next snapshot saved once。 |
+| each visible service with another visible → disable | 四例 target false；others unchanged；exact next snapshot saved once。 |
 | StrictMode updater purity probe | accepted event 仍仅一次 save，无 render/updater side effect。 |
 | guard toast before/at expiry | expiry 前存在，`TRAY_GUARD_TOAST_MS` 到期后清除。 |
+| two blocked user events | old timer canceled；latest event owns full delay；old expiry 不清 latest toast。 |
+| unmount with owned timer | timer canceled；advance 后零 state write。 |
 | active provider becomes hidden | existing effect falls back to Overview。 |
 
 ## Open Questions

--- a/specs/GH61/product.md
+++ b/specs/GH61/product.md
@@ -1,0 +1,65 @@
+# GH-61 Product Spec：switcher visibility transition 可观察且单次提交
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/61
+- `complexity: medium`
+
+## Problem
+
+`App.handleSwitcherToggle` 把 `blocked` 赋值放在 functional state updater 内，却在 `setSwitcherVisibility` 返回后立即读取该局部变量。React 可以延后执行 updater，因此“关闭最后一个可见 provider”虽然保持了 visibility state，却丢失固定 guard toast，用户看到点击无响应且不知道约束原因。
+
+同一 updater 还执行 `saveSwitcherVisibility(next)`。真实入口使用 React `StrictMode`，开发模式会重复求值 updater 以检查纯度，导致一次 accepted toggle 写 storage 两次，并可能重复 storage failure signal。
+
+`origin/main@896a3f7bd24035a614952ba1b0b1dd2caf60d211` 的 disposable real-App reproduction 已确认：`<StrictMode><App /></StrictMode>` 捕获真实 `SettingsView.onSwitcherToggle` 后，only-Claude 的 blocked toggle 保持 state 但不显示 `At least one provider must stay in the switcher`；enable Codex 更新 state 却调用 `saveSwitcherVisibility` 两次。两例 2/2 通过后临时测试已删除，audit worktree 恢复干净。
+
+## Goals
+
+- 从当前已渲染 switcher visibility snapshot 同步决定 blocked 或 accepted terminal，不依赖 updater 何时执行。
+- 关闭最后一个可见 provider 时保持所有 visibility 值不变、零 persistence，并精确显示一次固定 guard toast 与一次清理 timer。
+- accepted enable/disable 只翻转目标 provider，其他 provider 不变，并在真实 StrictMode contract 下以 exact next snapshot 持久化一次。
+- 保持 SettingsView callback、switcher storage schema、active-tab fallback 与 provider refresh wiring 不变。
+
+## Non-Goals
+
+- 不改 tray toggle、tray guard、Settings UI、provider list 或 accessibility layout。
+- 不改 storage implementation/schema、failure listener、shadow value 或 error strings。
+- 不改 backend、Tauri、provider、polling、notification、cost 或 dependency。
+- 不做 broad App decomposition 或 reentrant/programmatic same-render callback API。
+
+## Behavior Invariants
+
+1. `B-001` `SettingsView.onSwitcherToggle` 继续接收真实 `handleSwitcherToggle`，四个 `TrayServiceName` 均使用当前 render 的 `switcherVisibility` 做一次 closed transition decision。
+2. `B-002` 当目标当前为 visible 且其他三个均 hidden 时，transition 为 blocked：四个值全部保持、`saveSwitcherVisibility` 零次、fixed guard toast 精确出现一次。
+3. `B-003` blocked toast 文本固定为 `At least one provider must stay in the switcher`，使用 `TRAY_GUARD_TOAST_MS` 精确安排一次 clear；到期前保留，到期后清除。
+4. `B-004` accepted hidden→visible 与 visible→hidden transition 只翻转目标 service，提交 exact next snapshot，并调用 `saveSwitcherVisibility(next)` exactly once；StrictMode 不增加 persistence 次数。
+5. `B-005` state updater 保持纯净：persistence、toast 与 timer side effect 不得从 functional updater、state initializer 或 render evaluation 触发。
+6. `B-006` active provider 隐藏后回退 Overview、其他 App state/effects、SettingsView props 与 switcher storage failure notification 继续使用既有契约。
+7. `B-007` deterministic real-App matrix、executable diff coverage、full frontend/build/Rust 与 current-head PR gates 全部通过，implementation 无 allowlist 外 scope。
+
+## Acceptance Criteria
+
+- 测试挂载真实 `<StrictMode><App /></StrictMode>`，从真实 `SettingsView` instance 捕获 `onSwitcherToggle`；不得测试复制 helper 或跳过 App state。
+- 参数化四个 service 的 only-visible blocked terminal：callback 不抛、visibility snapshot 完全不变、persistence 零次、fixed toast 一次。
+- fake timers 直接证明 blocked terminal 新增一个 `TRAY_GUARD_TOAST_MS` clear：到期前 toast 仍可见，到期后为空；不依赖 wall-clock sleep。
+- 参数化 accepted hidden→visible 与“至少另一个可见”的 visible→hidden terminal：只有目标 bit 变化，`saveSwitcherVisibility` 对 exact next object 精确一次。
+- accepted matrix 在 StrictMode 下运行；当前重复 updater-side-effect 实现必须因 persistence count 2 而失败。
+- blocked 与 accepted callback 均来自最新 committed render；tests 不建立同一 render callback 的 programmatic reentrant API。
+- active provider hidden 后的既有 Overview fallback 至少有一例回归断言；storage/backend/provider contract 不变。
+- implementation 仅含 tech spec allowlist；executable TS/TSX diff line coverage ≥80%，`src/App.tsx` measurable changed lines critical 100%。
+
+## Boundary Checklist
+
+| Boundary | Expected result |
+| --- | --- |
+| only Claude visible → disable Claude | state unchanged；zero save；guard toast once；one clear timer。 |
+| each other service only-visible | 与 Claude 相同 blocked terminal。 |
+| hidden service → enable | target true；others unchanged；exact next snapshot saved once。 |
+| visible service with another visible → disable | target false；others unchanged；exact next snapshot saved once。 |
+| StrictMode updater purity probe | accepted event 仍仅一次 save，无 render/updater side effect。 |
+| guard toast before/at expiry | expiry 前存在，`TRAY_GUARD_TOAST_MS` 到期后清除。 |
+| active provider becomes hidden | existing effect falls back to Overview。 |
+
+## Open Questions
+
+- 无。transition snapshot、fixed toast、persistence cardinality、StrictMode boundary 与测试范围均已定义。

--- a/specs/GH61/tasks.md
+++ b/specs/GH61/tasks.md
@@ -9,8 +9,8 @@
 
 ## Implementation Tasks
 
-- [ ] `SP61-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`~`B-006`. Done when: `handleSwitcherToggle` 从 current render snapshot 同步决定 terminal；blocked 零 state/save 且 fixed toast/timer once；accepted exact next state/save once；functional updater 无 side effect。 Verify: targeted real-App tests。
-- [ ] `SP61-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-006`. Done when: StrictMode real App/SettingsView callback、四 service blocked matrix、accepted enable/disable、peer preservation、exact saver、toast lifecycle 与 Overview fallback deterministic 通过；无 copied helper/wall-clock/DOM dependency。 Verify: `tests/switcher_visibility_transactions.test.tsx`。
+- [ ] `SP61-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`~`B-006`. Done when: `handleSwitcherToggle` 从 current render snapshot 同步决定 terminal；blocked 零 state/save、latest-event owned timer、conditional clear 与 unmount cleanup；四 service accepted exact next state/save once；functional updater 无 side effect。 Verify: targeted real-App tests。
+- [ ] `SP61-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-006`. Done when: StrictMode real App/SettingsView callback、四 service blocked matrix、四 enable + 四 disable accepted terminals、peer preservation、exact saver、two-event timer ownership、non-guard preservation、unmount cleanup、toast lifecycle 与 Overview fallback deterministic 通过；无 copied helper/wall-clock/DOM dependency。 Verify: `tests/switcher_visibility_transactions.test.tsx`。
 - [ ] `SP61-T3` Owner: codex. Dependencies: T1-T2. Covers: `B-007`. Done when: exact 3-path allowlist；overall executable diff ≥80%；`src/App.tsx` critical changed lines 100%；full frontend/build/Rust pass。 Verify: tech Test Plan。
 
 ## Handoff

--- a/specs/GH61/tasks.md
+++ b/specs/GH61/tasks.md
@@ -1,0 +1,25 @@
+# GH-61 Tasks：switcher visibility transaction
+
+## Delivery Contract
+
+- Base: spec 与 implementation PR 分别基于创建时 then-latest `origin/main`。
+- Commit policy: `per_step`。
+- Scope: 仅修 switcher visibility transition 的 guard observability 与 persistence cardinality。
+- Compatibility: SettingsView/storage schema、active-tab fallback、tray/backend/provider/dependencies 不变。
+
+## Implementation Tasks
+
+- [ ] `SP61-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`~`B-006`. Done when: `handleSwitcherToggle` 从 current render snapshot 同步决定 terminal；blocked 零 state/save 且 fixed toast/timer once；accepted exact next state/save once；functional updater 无 side effect。 Verify: targeted real-App tests。
+- [ ] `SP61-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-006`. Done when: StrictMode real App/SettingsView callback、四 service blocked matrix、accepted enable/disable、peer preservation、exact saver、toast lifecycle 与 Overview fallback deterministic 通过；无 copied helper/wall-clock/DOM dependency。 Verify: `tests/switcher_visibility_transactions.test.tsx`。
+- [ ] `SP61-T3` Owner: codex. Dependencies: T1-T2. Covers: `B-007`. Done when: exact 3-path allowlist；overall executable diff ≥80%；`src/App.tsx` critical changed lines 100%；full frontend/build/Rust pass。 Verify: tech Test Plan。
+
+## Handoff
+
+- [ ] `SP61-T4` Owner: codex. Dependencies: T3. Done when: implementation PR `Closes #61`，正文记录 reproduction、transaction boundary、StrictMode cardinality、test matrix、coverage、dependency boundary 与 rollback，并通过 implementation-vs-spec、current-head connector/CI/reviewThreads gate。
+
+## Handoff Notes
+
+- Invariants: `{B-001, B-002, B-003, B-004, B-005, B-006, B-007}`。
+- Coverage union: `{B-001, B-002, B-003, B-004, B-005, B-006, B-007}`。
+- Spec PR 仅三份 GH61 文档；implementation 才修改 App、tests 与本 tasks ledger。
+- 禁止 force push、functional-updater side effect、duplicate persistence、silent blocked terminal、test weakening 或 allowlist 外 scope。

--- a/specs/GH61/tech.md
+++ b/specs/GH61/tech.md
@@ -49,11 +49,14 @@ const wouldHideLast = !nextValue
 
 `wouldHideLast` 时立即：
 
+- 通过 module-local fixed message 与 `switcherGuardTimerRef` 清除前一个 owned timer（若存在）；
 - `setToast('At least one provider must stay in the switcher')` exactly once；
-- `setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS)` exactly once；
+- 创建一个新的 `TRAY_GUARD_TOAST_MS` timer 并保存 ownership；
 - return，不调用 state setter 或 persistence。
 
-state 因未提交 transition 而保持完整 snapshot。不得把 toast/timer 放回 state updater 或 render path。
+timer callback 只在当前 toast 仍等于 fixed switcher guard 时清空，不能覆盖后来出现的 storage/其他 toast；随后释放 ref ownership。component unmount cleanup 取消 pending owned timer 并清空 ref，保证零 post-unmount state write。
+
+连续 blocked user events 的 latest event 必须拥有 timer：第二次事件 clear 第一次 timer 并从第二次事件起获得完整 delay。state 因未提交 transition 而保持完整 snapshot。不得把 toast/timer 放回 state updater 或 render path。
 
 ### 3. Accepted terminal
 
@@ -80,9 +83,9 @@ handler dependency 必须包含 `switcherVisibility`，确保每次 committed re
 - mock popover/backend 与初始 saved visibility，但 import/mount 真实 App、SettingsView 和 StrictMode；
 - 从 rendered `SettingsView` props 调用真实 callback，每次 accepted transition 后重新获取 latest instance/callback；
 - 参数化四个 only-visible blocked states；
-- 参数化 hidden→visible 与 visible-with-peer→hidden accepted states；
+- 参数化四个 service 的 hidden→visible 与 visible-with-peer→hidden accepted states，共 8 terminals；
 - spy `saveSwitcherVisibility` exact calls/arguments；
-- fake timer + timeout spy 验证 fixed delay 和 toast lifecycle；
+- fake timer + timeout/clearTimeout spy 验证 fixed delay、two-event latest ownership、non-guard preservation、unmount cleanup 与 toast lifecycle；
 - 至少一例 active hidden 后 Overview fallback。
 
 不复制 production decision helper，不依赖 wall-clock、DOM environment 或 AST-only evidence。
@@ -99,8 +102,11 @@ handler dependency 必须包含 `switcherVisibility`，确保每次 committed re
 | --- | --- |
 | callback closure becomes stale | dependency includes full visibility snapshot；每次 accepted event 后测试重新获取 committed callback。 |
 | guard only works for Claude | four-service parameterized only-visible matrix。 |
+| accepted target-specific bug escapes tests | four-service enable + four-service disable 共 8 terminal matrix。 |
 | StrictMode still duplicates storage | actual StrictMode mount + exact save count。 |
 | accepted transition mutates peers | exact full-object argument/state assertions。 |
+| earlier timer clears latest/other toast | owned timer replacement + conditional clear + two-event/non-guard tests。 |
+| timer writes after unmount | cleanup cancels owned timer + post-unmount advance assertion。 |
 | toast timer becomes flaky | fake timers + fixed delay spy，无 sleep。 |
 | storage failure routing changes | saver return contract untouched；existing global subscriber remains owner。 |
 | App scope expands | exact 3-path allowlist；不改 tray/storage/backend。 |
@@ -111,8 +117,8 @@ handler dependency 必须包含 `switcherVisibility`，确保每次 committed re
 | --- | --- |
 | `B-001` | real App/SettingsView callback capture + four service matrix |
 | `B-002` | only-visible blocked state/save/toast assertions |
-| `B-003` | timeout delay/count + pre/post-expiry toast assertions |
-| `B-004` | StrictMode accepted enable/disable state and exact saver argument/count |
+| `B-003` | timeout/clear count + two-event ownership + non-guard preservation + unmount + pre/post-expiry assertions |
+| `B-004` | StrictMode four-service enable/disable 8-terminal state and exact saver argument/count |
 | `B-005` | current implementation fails save count 2；fixed behavior exact once/zero |
 | `B-006` | active-hidden Overview fallback + unchanged boundary checks |
 | `B-007` | allowlist、coverage、full local/CI/current-head review |

--- a/specs/GH61/tech.md
+++ b/specs/GH61/tech.md
@@ -1,0 +1,156 @@
+# GH-61 Tech Spec：pure switcher visibility transaction
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/61
+- Product spec: `specs/GH61/product.md`
+
+## Root Cause
+
+当前 handler 把 decision、state transition 与 persistence 混在 React functional updater 中：
+
+```ts
+let blocked = false;
+setSwitcherVisibility((prev) => {
+  // assigns blocked and persists here
+});
+if (blocked) {
+  // may run before updater assignment
+}
+```
+
+`blocked` 的可见性依赖 React updater scheduling，而 updater 内 persistence 又违反 updater purity。结果是 deferred evaluation 丢失 blocked feedback，StrictMode repeated evaluation 重复写入。根因不是 toast renderer、storage API 或 SettingsView control，而是 event transaction boundary 错置。
+
+## Preflight Contract
+
+implementation 必须从 spec merge 后 then-latest `origin/main` 创建，并在 edit 前验证：
+
+- disposable real-App StrictMode reproduction 仍证明 blocked toast 缺失与 accepted persistence count 2。
+- `handleSwitcherToggle` 仍在 functional updater 内设置 blocked/persist，并在 updater 外同步读取 blocked。
+- search-first 无同类 issue/PR，baseline frontend/build/Rust 全绿。
+
+任一行为漂移必须先更新 GH61 spec。
+
+## Proposed Design
+
+### 1. Render-snapshot decision
+
+`handleSwitcherToggle` 直接读取 callback closure 对应的 current committed `switcherVisibility`：
+
+```ts
+const nextValue = !switcherVisibility[service];
+const wouldHideLast = !nextValue
+  && !SERVICES.some((other) => other !== service && switcherVisibility[other]);
+```
+
+真实 SettingsView user event 使用最新 committed callback；不为同一 callback 的 reentrant programmatic calls 引入额外 ref/reducer API。
+
+### 2. Blocked terminal
+
+`wouldHideLast` 时立即：
+
+- `setToast('At least one provider must stay in the switcher')` exactly once；
+- `setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS)` exactly once；
+- return，不调用 state setter 或 persistence。
+
+state 因未提交 transition 而保持完整 snapshot。不得把 toast/timer 放回 state updater 或 render path。
+
+### 3. Accepted terminal
+
+accepted 时构造一次 exact next snapshot：
+
+```ts
+const next = { ...switcherVisibility, [service]: nextValue };
+setSwitcherVisibility(next);
+saveSwitcherVisibility(next);
+```
+
+两项 event side effects 各执行一次。不得传 functional updater，避免 StrictMode purity probe 重放 persistence。继续忽略 saver boolean，因为既有 storage failure listener 负责用户提示；本 issue 不改变 failure routing。
+
+handler dependency 必须包含 `switcherVisibility`，确保每次 committed render 生成对应 snapshot 的 callback。
+
+### 4. Existing fallback
+
+保留现有 effect：当 active provider 变 hidden 时调用 `setAndPersistTab('all')`。不改变 SettingsView props、storage schema 或 provider refresh flow。
+
+### 5. Deterministic real-App tests
+
+新增 `tests/switcher_visibility_transactions.test.tsx`：
+
+- mock popover/backend 与初始 saved visibility，但 import/mount 真实 App、SettingsView 和 StrictMode；
+- 从 rendered `SettingsView` props 调用真实 callback，每次 accepted transition 后重新获取 latest instance/callback；
+- 参数化四个 only-visible blocked states；
+- 参数化 hidden→visible 与 visible-with-peer→hidden accepted states；
+- spy `saveSwitcherVisibility` exact calls/arguments；
+- fake timer + timeout spy 验证 fixed delay 和 toast lifecycle；
+- 至少一例 active hidden 后 Overview fallback。
+
+不复制 production decision helper，不依赖 wall-clock、DOM environment 或 AST-only evidence。
+
+## Affected Files / Allowlist
+
+- `src/App.tsx`
+- `tests/switcher_visibility_transactions.test.tsx`
+- `specs/GH61/tasks.md`
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| callback closure becomes stale | dependency includes full visibility snapshot；每次 accepted event 后测试重新获取 committed callback。 |
+| guard only works for Claude | four-service parameterized only-visible matrix。 |
+| StrictMode still duplicates storage | actual StrictMode mount + exact save count。 |
+| accepted transition mutates peers | exact full-object argument/state assertions。 |
+| toast timer becomes flaky | fake timers + fixed delay spy，无 sleep。 |
+| storage failure routing changes | saver return contract untouched；existing global subscriber remains owner。 |
+| App scope expands | exact 3-path allowlist；不改 tray/storage/backend。 |
+
+## Product-to-Test Mapping
+
+| Invariant | Verification |
+| --- | --- |
+| `B-001` | real App/SettingsView callback capture + four service matrix |
+| `B-002` | only-visible blocked state/save/toast assertions |
+| `B-003` | timeout delay/count + pre/post-expiry toast assertions |
+| `B-004` | StrictMode accepted enable/disable state and exact saver argument/count |
+| `B-005` | current implementation fails save count 2；fixed behavior exact once/zero |
+| `B-006` | active-hidden Overview fallback + unchanged boundary checks |
+| `B-007` | allowlist、coverage、full local/CI/current-head review |
+
+## Test Plan
+
+```bash
+set -euo pipefail
+git fetch origin main:refs/remotes/origin/main
+git merge-base --is-ancestor origin/main HEAD
+git diff --quiet origin/main...HEAD -- . \
+  ':(exclude)src/App.tsx' \
+  ':(exclude)tests/switcher_visibility_transactions.test.tsx' \
+  ':(exclude)specs/GH61/tasks.md'
+npx vitest run tests/switcher_visibility_transactions.test.tsx
+node --experimental-test-coverage \
+  --test-coverage-include=scripts/check_ts_diff_coverage.mjs \
+  --test-coverage-lines=100 \
+  --test-coverage-functions=100 \
+  --test-coverage-branches=100 \
+  --test scripts/check_ts_diff_coverage.test.mjs
+npx vitest run --coverage \
+  --coverage.include='src/**/*.{ts,tsx}' \
+  --coverage.reporter=lcov \
+  --coverage.reporter=text
+node scripts/check_ts_diff_coverage.mjs \
+  --base origin/main \
+  --lcov coverage/lcov.info \
+  --minimum 80 \
+  --critical src/App.tsx=100
+npm test
+npm run build
+cargo fmt --manifest-path src-tauri/Cargo.toml --check
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+git diff --check origin/main...HEAD
+```
+
+## Rollback Plan
+
+回滚 implementation PR。无 backend、schema、payload、persistence format、dependency 或 migration；旧 behavior 将恢复为 blocked feedback scheduling-dependent 与 StrictMode duplicate persistence。


### PR DESCRIPTION
Relates to #61

## Why

The current switcher handler reads a mutable guard flag before React is required to evaluate the functional updater that assigns it, so a blocked last-provider transition can lose its explanation. Persistence also runs inside that updater, and the real StrictMode entry contract evaluates it twice, producing duplicate writes and potentially duplicate failure signals.

## Spec plan

- define current-render snapshot decision semantics for all four providers
- separate blocked and accepted terminals with exact state, toast, timer, and persistence cardinality
- require real `<StrictMode><App /></StrictMode>` tests using the actual `SettingsView.onSwitcherToggle` callback
- parameterize four only-visible blocked states and accepted enable/disable transitions
- preserve storage schema, active-provider fallback, SettingsView, tray, backend, provider, and dependency boundaries
- require exact 3-path implementation allowlist, diff coverage, full frontend/build/Rust, and current-head PR gates

## Reproduction and baseline

A disposable real-App test on `origin/main@896a3f7` reproduced missing guard feedback and two persistence calls for one accepted StrictMode event; 2/2 cases passed and the temporary test was deleted. Search-first found no duplicate issue or PR. Baseline frontend passed 24 files/320 tests, build passed, and Rust fmt/check/test passed with 29 tests and 2 ignored.

## Scope

This PR contains only `specs/GH61/product.md`, `tech.md`, and `tasks.md`. It does not implement #61.

Rollback is this documentation-only PR.