### PR TITLE
fix: make switcher visibility transitions observable and single-shot

### DIFF
--- a/specs/GH61/tasks.md
+++ b/specs/GH61/tasks.md
@@ -9,9 +9,9 @@
 
 ## Implementation Tasks
 
-- [ ] `SP61-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`~`B-006`. Done when: `handleSwitcherToggle` 从 current render snapshot 同步决定 terminal；blocked 零 state/save、latest-event owned timer、conditional clear 与 unmount cleanup；四 service accepted exact next state/save once；functional updater 无 side effect。 Verify: targeted real-App tests。
-- [ ] `SP61-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-006`. Done when: StrictMode real App/SettingsView callback、四 service blocked matrix、四 enable + 四 disable accepted terminals、peer preservation、exact saver、two-event timer ownership、non-guard preservation、unmount cleanup、toast lifecycle 与 Overview fallback deterministic 通过；无 copied helper/wall-clock/DOM dependency。 Verify: `tests/switcher_visibility_transactions.test.tsx`。
-- [ ] `SP61-T3` Owner: codex. Dependencies: T1-T2. Covers: `B-007`. Done when: exact 3-path allowlist；overall executable diff ≥80%；`src/App.tsx` critical changed lines 100%；full frontend/build/Rust pass。 Verify: tech Test Plan。
+- [x] `SP61-T1` Owner: codex. Dependencies: merged spec. Covers: `B-001`~`B-006`. Done when: `handleSwitcherToggle` 从 current render snapshot 同步决定 terminal；blocked 零 state/save、latest-event owned timer、conditional clear 与 unmount cleanup；四 service accepted exact next state/save once；functional updater 无 side effect。 Verify: targeted real-App tests。
+- [x] `SP61-T2` Owner: codex. Dependencies: T1. Covers: `B-001`~`B-006`. Done when: StrictMode real App/SettingsView callback、四 service blocked matrix、四 enable + 四 disable accepted terminals、peer preservation、exact saver、two-event timer ownership、non-guard preservation、unmount cleanup、toast lifecycle 与 Overview fallback deterministic 通过；无 copied helper/wall-clock/DOM dependency。 Verify: `tests/switcher_visibility_transactions.test.tsx`。
+- [x] `SP61-T3` Owner: codex. Dependencies: T1-T2. Covers: `B-007`. Done when: exact 3-path allowlist；overall executable diff ≥80%；`src/App.tsx` critical changed lines 100%；full frontend/build/Rust pass。 Verify: tech Test Plan。
 
 ## Handoff
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -220,16 +220,22 @@ export default function App() {
 
   const showStorageWriteFailure = useCallback(() => {
     setToast(STORAGE_WRITE_FAILURE_MESSAGE);
-    setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS);
+    setTimeout(() => setToast((current) => current === STORAGE_WRITE_FAILURE_MESSAGE ? null : current), TRAY_GUARD_TOAST_MS);
   }, []);
 
   useEffect(() => {
     return subscribeStorageWriteFailures(showStorageWriteFailure);
   }, [showStorageWriteFailure]);
 
-  useEffect(() => {
-    return subscribeStorageReadFailureToast(setToast);
+  const setStorageReadToast = useCallback<ToastSetter>((message) => {
+    if (message !== null) {
+      setToast(message);
+      return;
+    }
+    setToast((current) => current === STORAGE_READ_FAILURE_MESSAGE ? null : current);
   }, []);
+
+  useEffect(() => subscribeStorageReadFailureToast(setStorageReadToast), [setStorageReadToast]);
 
   const setAndPersistTab = useCallback((tab: TabName) => {
     setActiveView(tab);
@@ -455,7 +461,7 @@ export default function App() {
 
   const showTrayGuardToast = useCallback(() => {
     setToast(TRAY_GUARD_MESSAGE);
-    setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS);
+    setTimeout(() => setToast((current) => current === TRAY_GUARD_MESSAGE ? null : current), TRAY_GUARD_TOAST_MS);
   }, []);
 
   const handleTrayToggle = useCallback((service: TrayServiceName) => {
@@ -567,7 +573,7 @@ export default function App() {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to open dashboard';
       setToast(message);
-      setTimeout(() => setToast(null), 2000);
+      setTimeout(() => setToast((current) => current === message ? null : current), 2000);
     }
   }, [activeProvider]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,8 @@ export {
   getClaudeTrayUsedPercent,
 } from './services/app_state';
 
-type ToastSetter = (message: string | null) => void;
+type ToastValue = string | null;
+type ToastSetter = (value: ToastValue | ((current: ToastValue) => ToastValue)) => void;
 type ToastScheduler = (callback: () => void, delayMs: number) => void;
 
 const SWITCHER_GUARD_MESSAGE = 'At least one provider must stay in the switcher';
@@ -150,7 +151,16 @@ export default function App() {
   const [theme, setTheme] = useState<ThemeName>(getSavedTheme);
   const [dockHidden, setDockHidden] = useState<boolean>(getSavedDockHidden);
   const [trayEnabled, setTrayEnabled] = useState<TrayEnabledState>(getInitialTrayEnabledState);
-  const [toast, setToast] = useState<string | null>(null);
+  const [toast, setToastState] = useState<ToastValue>(null);
+  const switcherGuardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const setToast = useCallback<ToastSetter>((value) => {
+    setToastState((current) => {
+      const next = typeof value === 'function' ? value(current) : value;
+      return next === null && current === SWITCHER_GUARD_MESSAGE && switcherGuardTimerRef.current !== null
+        ? current
+        : next;
+    });
+  }, []);
   const [activeView, setActiveView] = useState<AppViewName>(() =>
     getSavedSettingsExpanded() ? 'settings' : getSavedTab(),
   );
@@ -170,7 +180,6 @@ export default function App() {
   const containerRef = useRef<HTMLDivElement>(null);
   const windowVisible = usePopoverWindow(containerRef, [activeView, quota, connected]);
   const lastTrayIconRequestRef = useRef<Partial<Record<TrayServiceName, TrayIconRequest>>>({});
-  const switcherGuardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const setServiceConnected = useCallback((service: TrayServiceName, value: boolean) => {
     setConnected((prev) => (prev[service] === value ? prev : { ...prev, [service]: value }));
@@ -220,22 +229,16 @@ export default function App() {
 
   const showStorageWriteFailure = useCallback(() => {
     setToast(STORAGE_WRITE_FAILURE_MESSAGE);
-    setTimeout(() => setToast((current) => current === STORAGE_WRITE_FAILURE_MESSAGE ? null : current), TRAY_GUARD_TOAST_MS);
+    setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS);
   }, []);
 
   useEffect(() => {
     return subscribeStorageWriteFailures(showStorageWriteFailure);
   }, [showStorageWriteFailure]);
 
-  const setStorageReadToast = useCallback<ToastSetter>((message) => {
-    if (message !== null) {
-      setToast(message);
-      return;
-    }
-    setToast((current) => current === STORAGE_READ_FAILURE_MESSAGE ? null : current);
-  }, []);
-
-  useEffect(() => subscribeStorageReadFailureToast(setStorageReadToast), [setStorageReadToast]);
+  useEffect(() => {
+    return subscribeStorageReadFailureToast(setToast);
+  }, [setToast]);
 
   const setAndPersistTab = useCallback((tab: TabName) => {
     setActiveView(tab);
@@ -461,7 +464,7 @@ export default function App() {
 
   const showTrayGuardToast = useCallback(() => {
     setToast(TRAY_GUARD_MESSAGE);
-    setTimeout(() => setToast((current) => current === TRAY_GUARD_MESSAGE ? null : current), TRAY_GUARD_TOAST_MS);
+    setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS);
   }, []);
 
   const handleTrayToggle = useCallback((service: TrayServiceName) => {
@@ -573,7 +576,7 @@ export default function App() {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to open dashboard';
       setToast(message);
-      setTimeout(() => setToast((current) => current === message ? null : current), 2000);
+      setTimeout(() => setToast(null), 2000);
     }
   }, [activeProvider]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,6 +106,8 @@ export {
 type ToastSetter = (message: string | null) => void;
 type ToastScheduler = (callback: () => void, delayMs: number) => void;
 
+const SWITCHER_GUARD_MESSAGE = 'At least one provider must stay in the switcher';
+
 const scheduleToastClear: ToastScheduler = (callback, delayMs) => {
   setTimeout(callback, delayMs);
 };
@@ -168,6 +170,7 @@ export default function App() {
   const containerRef = useRef<HTMLDivElement>(null);
   const windowVisible = usePopoverWindow(containerRef, [activeView, quota, connected]);
   const lastTrayIconRequestRef = useRef<Partial<Record<TrayServiceName, TrayIconRequest>>>({});
+  const switcherGuardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const setServiceConnected = useCallback((service: TrayServiceName, value: boolean) => {
     setConnected((prev) => (prev[service] === value ? prev : { ...prev, [service]: value }));
@@ -363,23 +366,34 @@ export default function App() {
 
   useServiceEvents(quota, connected, usedPercent, notifSettings, logEvent);
 
-  const handleSwitcherToggle = useCallback((service: TrayServiceName) => {
-    let blocked = false;
-    setSwitcherVisibility((prev) => {
-      const nextValue = !prev[service];
-      if (!nextValue && !SERVICES.some((other) => other !== service && prev[other])) {
-        blocked = true;
-        return prev;
-      }
-      const next = { ...prev, [service]: nextValue };
-      saveSwitcherVisibility(next);
-      return next;
-    });
-    if (blocked) {
-      setToast('At least one provider must stay in the switcher');
-      setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS);
+  const showSwitcherGuardToast = useCallback(() => {
+    if (switcherGuardTimerRef.current !== null) {
+      clearTimeout(switcherGuardTimerRef.current);
+    }
+    setToast(SWITCHER_GUARD_MESSAGE);
+    switcherGuardTimerRef.current = setTimeout(() => {
+      switcherGuardTimerRef.current = null;
+      setToast((current) => current === SWITCHER_GUARD_MESSAGE ? null : current);
+    }, TRAY_GUARD_TOAST_MS);
+  }, []);
+
+  useEffect(() => () => {
+    if (switcherGuardTimerRef.current !== null) {
+      clearTimeout(switcherGuardTimerRef.current);
+      switcherGuardTimerRef.current = null;
     }
   }, []);
+
+  const handleSwitcherToggle = useCallback((service: TrayServiceName) => {
+    const nextValue = !switcherVisibility[service];
+    if (!nextValue && !SERVICES.some((other) => other !== service && switcherVisibility[other])) {
+      showSwitcherGuardToast();
+      return;
+    }
+    const next = { ...switcherVisibility, [service]: nextValue };
+    setSwitcherVisibility(next);
+    saveSwitcherVisibility(next);
+  }, [showSwitcherGuardToast, switcherVisibility]);
 
   // If the active provider tab gets hidden from the switcher, fall back to Overview.
   useEffect(() => {

--- a/tests/switcher_visibility_transactions.test.tsx
+++ b/tests/switcher_visibility_transactions.test.tsx
@@ -1,0 +1,298 @@
+import { createElement, StrictMode } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import SettingsView from '../src/components/SettingsView';
+import TabSwitcher from '../src/components/TabSwitcher';
+import { backend } from '../src/services/backend';
+import { SERVICES } from '../src/services/service_meta';
+import {
+  saveSwitcherVisibility,
+  type SwitcherVisibility,
+} from '../src/services/switcher_providers';
+import type { TrayServiceName } from '../src/services/tray_visibility';
+import {
+  STORAGE_WRITE_FAILURE_MESSAGE,
+  type StorageReadResult,
+} from '../src/services/storage';
+import { TRAY_GUARD_TOAST_MS } from '../src/services/app_state';
+
+const SWITCHER_GUARD_MESSAGE = 'At least one provider must stay in the switcher';
+
+const harness = vi.hoisted(() => ({
+  initial_visibility: {
+    antigravity: false,
+    claude: true,
+    codex: false,
+    cursor: false,
+  },
+  saved_tab: 'all',
+  settings_expanded: true,
+  save_visibility: vi.fn(() => true),
+  write_failure_listener: null as (() => void) | null,
+}));
+
+vi.mock('../src/hooks/use_popover_window', () => ({
+  usePopoverWindow: () => false,
+}));
+
+vi.mock('../src/services/app_state', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/app_state')>();
+  return {
+    ...actual,
+    getSavedSettingsExpanded: () => harness.settings_expanded,
+    getSavedTab: () => harness.saved_tab,
+  };
+});
+
+vi.mock('../src/services/switcher_providers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/switcher_providers')>();
+  return {
+    ...actual,
+    getSavedSwitcherVisibility: () => ({ ...harness.initial_visibility }),
+    saveSwitcherVisibility: harness.save_visibility,
+  };
+});
+
+vi.mock('../src/services/storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/storage')>();
+  return {
+    ...actual,
+    readStorageValue: <T,>(): StorageReadResult<T> => ({ status: 'missing' }),
+    writeStorageItem: vi.fn(() => true),
+    subscribeStorageReadFailures: () => () => {},
+    subscribeStorageWriteFailures: (listener: () => void) => {
+      harness.write_failure_listener = listener;
+      return () => {
+        if (harness.write_failure_listener === listener) {
+          harness.write_failure_listener = null;
+        }
+      };
+    },
+  };
+});
+
+import App from '../src/App';
+
+function visibility(
+  target: TrayServiceName,
+  target_value: boolean,
+  peer?: TrayServiceName,
+): SwitcherVisibility {
+  return {
+    antigravity: target === 'antigravity' ? target_value : peer === 'antigravity',
+    claude: target === 'claude' ? target_value : peer === 'claude',
+    codex: target === 'codex' ? target_value : peer === 'codex',
+    cursor: target === 'cursor' ? target_value : peer === 'cursor',
+  };
+}
+
+function peer_for(service: TrayServiceName): TrayServiceName {
+  return SERVICES.find((candidate) => candidate !== service)!;
+}
+
+function rendered_text(renderer: ReactTestRenderer): string {
+  return JSON.stringify(renderer.toJSON());
+}
+
+function settings(renderer: ReactTestRenderer) {
+  return renderer.root.findByType(SettingsView);
+}
+
+async function render_app(): Promise<ReactTestRenderer> {
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(createElement(StrictMode, null, createElement(App)));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return renderer;
+}
+
+async function unmount(renderer: ReactTestRenderer): Promise<void> {
+  await act(async () => renderer.unmount());
+}
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  harness.initial_visibility = visibility('claude', true);
+  harness.saved_tab = 'all';
+  harness.settings_expanded = true;
+  harness.save_visibility.mockReset();
+  harness.save_visibility.mockReturnValue(true);
+  harness.write_failure_listener = null;
+
+  vi.spyOn(backend, 'getQuota').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({ connected: true, availableCount: 0, credits: [] });
+  vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getAntigravityInfo').mockResolvedValue({ connected: false, status: 'pending' });
+  vi.spyOn(backend, 'getCostOverview').mockImplementation(async (source) => ({
+    source,
+    displayName: source,
+    currency: 'USD',
+    generatedAt: '2026-07-16T00:00:00Z',
+    cached: false,
+    ranges: [],
+  }));
+  vi.spyOn(backend, 'getCostDaily').mockImplementation(async (source) => ({
+    source,
+    currency: 'USD',
+    generatedAt: '2026-07-16T00:00:00Z',
+    cached: false,
+    days: [],
+  }));
+  vi.spyOn(backend, 'setDockVisibility').mockResolvedValue(undefined);
+  vi.spyOn(backend, 'updateTrayIcon').mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe.each(SERVICES)('blocked %s visibility transition', (service) => {
+  test('keeps the only visible provider and reports the guard without persistence', async () => {
+    const initial = visibility(service, true);
+    harness.initial_visibility = initial;
+    const renderer = await render_app();
+
+    await act(async () => settings(renderer).props.onSwitcherToggle(service));
+
+    expect(settings(renderer).props.switcherVisibility).toEqual(initial);
+    expect(harness.save_visibility).not.toHaveBeenCalled();
+    expect(rendered_text(renderer).split(SWITCHER_GUARD_MESSAGE)).toHaveLength(2);
+    await unmount(renderer);
+  });
+});
+
+describe.each(SERVICES)('accepted %s visibility transition', (service) => {
+  test('enables the target once and preserves every peer', async () => {
+    const initial = visibility(service, false, peer_for(service));
+    const expected = { ...initial, [service]: true };
+    harness.initial_visibility = initial;
+    const renderer = await render_app();
+
+    await act(async () => settings(renderer).props.onSwitcherToggle(service));
+
+    expect(settings(renderer).props.switcherVisibility).toEqual(expected);
+    expect(saveSwitcherVisibility).toHaveBeenCalledTimes(1);
+    expect(saveSwitcherVisibility).toHaveBeenCalledWith(expected);
+    expect(rendered_text(renderer)).not.toContain(SWITCHER_GUARD_MESSAGE);
+    await unmount(renderer);
+  });
+
+  test('disables the target once when a peer remains visible', async () => {
+    const initial = visibility(service, true, peer_for(service));
+    const expected = { ...initial, [service]: false };
+    harness.initial_visibility = initial;
+    const renderer = await render_app();
+
+    await act(async () => settings(renderer).props.onSwitcherToggle(service));
+
+    expect(settings(renderer).props.switcherVisibility).toEqual(expected);
+    expect(saveSwitcherVisibility).toHaveBeenCalledTimes(1);
+    expect(saveSwitcherVisibility).toHaveBeenCalledWith(expected);
+    expect(rendered_text(renderer)).not.toContain(SWITCHER_GUARD_MESSAGE);
+    await unmount(renderer);
+  });
+});
+
+test('uses the latest committed callback for sequential accepted transitions', async () => {
+  harness.initial_visibility = visibility('claude', true);
+  const renderer = await render_app();
+
+  await act(async () => settings(renderer).props.onSwitcherToggle('codex'));
+  const after_enable = { ...harness.initial_visibility, codex: true };
+  expect(settings(renderer).props.switcherVisibility).toEqual(after_enable);
+
+  await act(async () => settings(renderer).props.onSwitcherToggle('claude'));
+  const after_disable = { ...after_enable, claude: false };
+  expect(settings(renderer).props.switcherVisibility).toEqual(after_disable);
+  expect(harness.save_visibility.mock.calls).toEqual([[after_enable], [after_disable]]);
+  await unmount(renderer);
+});
+
+test('gives the latest blocked event a full owned toast duration', async () => {
+  const renderer = await render_app();
+  const set_timeout = vi.spyOn(globalThis, 'setTimeout');
+  const clear_timeout = vi.spyOn(globalThis, 'clearTimeout');
+  set_timeout.mockClear();
+  clear_timeout.mockClear();
+
+  await act(async () => settings(renderer).props.onSwitcherToggle('claude'));
+  expect(set_timeout).toHaveBeenCalledTimes(1);
+  expect(set_timeout.mock.calls[0][1]).toBe(TRAY_GUARD_TOAST_MS);
+  const first_timer = set_timeout.mock.results[0].value;
+
+  await act(async () => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS / 2));
+  await act(async () => settings(renderer).props.onSwitcherToggle('claude'));
+  expect(clear_timeout).toHaveBeenCalledWith(first_timer);
+  expect(set_timeout).toHaveBeenCalledTimes(2);
+  expect(set_timeout.mock.calls[1][1]).toBe(TRAY_GUARD_TOAST_MS);
+
+  await act(async () => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS / 2));
+  expect(rendered_text(renderer)).toContain(SWITCHER_GUARD_MESSAGE);
+  await act(async () => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS / 2 - 1));
+  expect(rendered_text(renderer)).toContain(SWITCHER_GUARD_MESSAGE);
+  await act(async () => vi.advanceTimersByTime(1));
+  expect(rendered_text(renderer)).not.toContain(SWITCHER_GUARD_MESSAGE);
+  expect(harness.save_visibility).not.toHaveBeenCalled();
+  await unmount(renderer);
+});
+
+test('does not let the owned guard timer clear a newer storage toast', async () => {
+  const renderer = await render_app();
+  await act(async () => settings(renderer).props.onSwitcherToggle('claude'));
+  await act(async () => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS / 4));
+
+  expect(harness.write_failure_listener).not.toBeNull();
+  await act(async () => harness.write_failure_listener!());
+  expect(rendered_text(renderer)).toContain(STORAGE_WRITE_FAILURE_MESSAGE);
+
+  await act(async () => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS * 3 / 4));
+  expect(rendered_text(renderer)).toContain(STORAGE_WRITE_FAILURE_MESSAGE);
+  await act(async () => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS / 4));
+  expect(rendered_text(renderer)).not.toContain(STORAGE_WRITE_FAILURE_MESSAGE);
+  await unmount(renderer);
+});
+
+test('cancels the owned guard timer on unmount', async () => {
+  const renderer = await render_app();
+  const set_timeout = vi.spyOn(globalThis, 'setTimeout');
+  const clear_timeout = vi.spyOn(globalThis, 'clearTimeout');
+  set_timeout.mockClear();
+  clear_timeout.mockClear();
+
+  await act(async () => settings(renderer).props.onSwitcherToggle('claude'));
+  const guard_timer = set_timeout.mock.results[0].value;
+  await unmount(renderer);
+
+  expect(clear_timeout).toHaveBeenCalledWith(guard_timer);
+  expect(() => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS)).not.toThrow();
+});
+
+test('keeps the existing Overview fallback when the active provider is hidden', async () => {
+  harness.initial_visibility = visibility('codex', true, 'claude');
+  harness.saved_tab = 'codex';
+  const renderer = await render_app();
+
+  await act(async () => settings(renderer).props.onSwitcherToggle('codex'));
+  await act(async () => {
+    settings(renderer).props.onClose();
+    await Promise.resolve();
+  });
+
+  expect(renderer.root.findByType(TabSwitcher).props.activeTab).toBe('all');
+  expect(harness.save_visibility).toHaveBeenCalledTimes(1);
+  await unmount(renderer);
+});

--- a/tests/switcher_visibility_transactions.test.tsx
+++ b/tests/switcher_visibility_transactions.test.tsx
@@ -266,6 +266,25 @@ test('does not let the owned guard timer clear a newer storage toast', async () 
   await unmount(renderer);
 });
 
+test('does not let an older storage timer clear a newer switcher guard', async () => {
+  const renderer = await render_app();
+  expect(harness.write_failure_listener).not.toBeNull();
+  await act(async () => harness.write_failure_listener!());
+  expect(rendered_text(renderer)).toContain(STORAGE_WRITE_FAILURE_MESSAGE);
+  await act(async () => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS / 4));
+
+  await act(async () => settings(renderer).props.onSwitcherToggle('claude'));
+  expect(rendered_text(renderer)).toContain(SWITCHER_GUARD_MESSAGE);
+
+  await act(async () => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS * 3 / 4));
+  expect(rendered_text(renderer)).toContain(SWITCHER_GUARD_MESSAGE);
+  await act(async () => vi.advanceTimersByTime(TRAY_GUARD_TOAST_MS / 4 - 1));
+  expect(rendered_text(renderer)).toContain(SWITCHER_GUARD_MESSAGE);
+  await act(async () => vi.advanceTimersByTime(1));
+  expect(rendered_text(renderer)).not.toContain(SWITCHER_GUARD_MESSAGE);
+  await unmount(renderer);
+});
+
 test('cancels the owned guard timer on unmount', async () => {
   const renderer = await render_app();
   const set_timeout = vi.spyOn(globalThis, 'setTimeout');


### PR DESCRIPTION
Closes #61

## Why

The switcher handler assigned a mutable guard flag and persisted settings inside a React functional updater, then read the flag immediately outside it. A blocked last-provider event therefore kept state but lost its toast, while the real StrictMode entry contract evaluated accepted updaters twice and persisted one user transition twice.

## Implementation

- decide blocked versus accepted from the current committed visibility snapshot
- keep blocked transitions at zero state/persistence calls and show the fixed guard toast
- give the latest blocked event ownership of one timer, cancel the prior timer, and cancel ownership on unmount
- protect the owned switcher guard at the shared toast state boundary so any older App timer cannot clear it before its full duration; the guard timer releases ownership before clearing
- commit accepted transitions with one exact next snapshot and one persistence call outside any updater
- preserve the existing active-provider-to-Overview fallback and all storage/backend/provider contracts

## Verification

- disposable pre-fix real-App reproduction: missing blocked toast and two StrictMode persistence calls; 2/2 reproduced, temporary test deleted
- targeted real `<StrictMode><App /></StrictMode>` matrix: 18/18 passed
- blocked matrix: all four services
- accepted matrix: four enables plus four disables with full peer snapshot and exact-one persistence
- timer matrix: latest-event replacement/full duration, guard-to-storage preservation, storage-to-guard preservation, and unmount cleanup
- full frontend: 25 files, 338 tests passed
- executable TypeScript diff coverage: 26/26 lines, 100%
- critical changed lines in `src/App.tsx`: 100%
- coverage checker line/function/branch: 100%
- frontend build: passed
- cargo fmt --check, cargo check, cargo test: passed; 29 passed, 2 ignored
- exact changed-path contract: `src/App.tsx`, `tests/switcher_visibility_transactions.test.tsx`, `specs/GH61/tasks.md`
- git diff --check: passed

## Boundaries and rollback

SettingsView props, switcher storage schema and failure subscriber, tray toggle decisions, backend/Tauri/provider/polling/notification/cost contracts, dependencies, and build configuration are unchanged. `App.tsx` remains below the 800-line hard ceiling at 790 lines. Rollback is the commits in this PR; no migration or compatibility step is required.

Spec: #62