### PR TITLE
fix: retain Codex quota across transient refresh failures

### DIFF
--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -124,7 +124,7 @@ fn read_auth_json_with_stamp() -> Result<(serde_json::Value, AuthFileStamp), Sta
     })?;
     let stamp_after = auth_file_stamp(&auth_file).map_err(|message| StampedAuthReadError {
         message,
-        pre_read_stamp: None,
+        pre_read_stamp: Some(stamp_before.clone()),
     })?;
     if stamp_before != stamp_after {
         return Err(StampedAuthReadError {
@@ -284,6 +284,7 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
                 .as_str()
                 .map(ToString::to_string)
         });
+    let request_sequence = codex_cache::next_request_sequence();
 
     let client = shared_http_client();
     let mut request = client
@@ -333,7 +334,7 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
     if status.as_u16() == 401 || status.as_u16() == 403 {
         let error = "Token expired. Please run 'codex' to re-login.";
         log_msg(&format!("[RateLimits] auth failure: status={status}"));
-        if let Err(cache_error) = codex_cache::invalidate(&auth_stamp, account_id.as_deref()) {
+        if let Err(cache_error) = codex_cache::invalidate(account_id.as_deref(), request_sequence) {
             log_msg(&format!(
                 "[RateLimits] failed to invalidate last-good cache: {cache_error}"
             ));
@@ -411,10 +412,12 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
 
     match account_id {
         Some(account_id) => {
-            if let Err(error) = codex_cache::store(account_id, auth_stamp, limits.clone()) {
-                log_msg(&format!(
+            match codex_cache::store(account_id, auth_stamp, request_sequence, limits.clone()) {
+                Ok(true) => {}
+                Ok(false) => log_msg("[RateLimits] ignored out-of-order response"),
+                Err(error) => log_msg(&format!(
                     "[RateLimits] failed to update last-good cache: {error}"
-                ));
+                )),
             }
         }
         None => log_msg("[RateLimits] account ID missing; last-good cache not updated"),

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -103,20 +103,42 @@ fn auth_file_stamp(auth_file: &Path) -> Result<AuthFileStamp, String> {
     })
 }
 
-fn read_auth_json_with_stamp() -> Result<(serde_json::Value, AuthFileStamp), String> {
-    let auth_file = auth_file_path()?;
-    let stamp_before = auth_file_stamp(&auth_file)?;
+struct StampedAuthReadError {
+    message: String,
+    pre_read_stamp: Option<AuthFileStamp>,
+}
 
-    let content =
-        fs::read_to_string(&auth_file).map_err(|e| format!("Failed to read auth.json: {e}"))?;
-    let stamp_after = auth_file_stamp(&auth_file)?;
+fn read_auth_json_with_stamp() -> Result<(serde_json::Value, AuthFileStamp), StampedAuthReadError> {
+    let auth_file = auth_file_path().map_err(|message| StampedAuthReadError {
+        message,
+        pre_read_stamp: None,
+    })?;
+    let stamp_before = auth_file_stamp(&auth_file).map_err(|message| StampedAuthReadError {
+        message,
+        pre_read_stamp: None,
+    })?;
+
+    let content = fs::read_to_string(&auth_file).map_err(|error| StampedAuthReadError {
+        message: format!("Failed to read auth.json: {error}"),
+        pre_read_stamp: Some(stamp_before.clone()),
+    })?;
+    let stamp_after = auth_file_stamp(&auth_file).map_err(|message| StampedAuthReadError {
+        message,
+        pre_read_stamp: None,
+    })?;
     if stamp_before != stamp_after {
-        return Err("auth.json changed while it was being read".to_string());
+        return Err(StampedAuthReadError {
+            message: "auth.json changed while it was being read".to_string(),
+            pre_read_stamp: None,
+        });
     }
 
     serde_json::from_str(&content)
         .map(|auth_json| (auth_json, stamp_after))
-        .map_err(|e| format!("Failed to parse auth.json: {e}"))
+        .map_err(|error| StampedAuthReadError {
+            message: format!("Failed to parse auth.json: {error}"),
+            pre_read_stamp: None,
+        })
 }
 
 fn read_auth_json() -> Result<serde_json::Value, String> {
@@ -207,11 +229,11 @@ fn transient_failure_limits(account_id: Option<&str>, error: String) -> CodexRat
     }
 }
 
-fn transient_auth_failure_limits(error: String) -> CodexRateLimits {
-    let auth_stamp = auth_file_path()
-        .and_then(|auth_file| auth_file_stamp(&auth_file))
-        .ok();
-    match codex_cache::retain_for_auth_stamp(auth_stamp.as_ref(), error.clone()) {
+fn transient_auth_failure_limits(
+    auth_stamp: Option<&AuthFileStamp>,
+    error: String,
+) -> CodexRateLimits {
+    match codex_cache::retain_for_auth_stamp(auth_stamp, error.clone()) {
         Ok(limits) => limits,
         Err(lock_error) => {
             log_msg(&format!("[RateLimits] {lock_error}"));
@@ -236,11 +258,11 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
     let (auth_json, auth_stamp) = match read_auth_json_with_stamp() {
         Ok(auth) => auth,
         Err(error) => {
-            log_msg(&format!("[RateLimits] auth read failed: {error}"));
-            return if is_transient_os_error(&error) {
-                transient_auth_failure_limits(error)
+            log_msg(&format!("[RateLimits] auth read failed: {}", error.message));
+            return if is_transient_os_error(&error.message) {
+                transient_auth_failure_limits(error.pre_read_stamp.as_ref(), error.message)
             } else {
-                CodexRateLimits::disconnected(error)
+                CodexRateLimits::disconnected(error.message)
             };
         }
     };

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -13,13 +13,18 @@ use std::time::Instant;
 /// Most recent successful fetch results, retained without TTL so a transient
 /// polling failure does not erase quota that was already displayed.
 static LAST_GOOD_INFO: OnceLock<Mutex<Option<CodexData>>> = OnceLock::new();
-static LAST_GOOD_LIMITS: OnceLock<Mutex<Option<CodexRateLimits>>> = OnceLock::new();
+static LAST_GOOD_LIMITS: OnceLock<Mutex<Option<CachedCodexRateLimits>>> = OnceLock::new();
+
+struct CachedCodexRateLimits {
+    account_id: String,
+    limits: CodexRateLimits,
+}
 
 fn last_good_info() -> &'static Mutex<Option<CodexData>> {
     LAST_GOOD_INFO.get_or_init(|| Mutex::new(None))
 }
 
-fn last_good_limits() -> &'static Mutex<Option<CodexRateLimits>> {
+fn last_good_limits() -> &'static Mutex<Option<CachedCodexRateLimits>> {
     LAST_GOOD_LIMITS.get_or_init(|| Mutex::new(None))
 }
 
@@ -169,16 +174,9 @@ pub async fn fetch_codex_info() -> CodexData {
     info
 }
 
-fn fallback_or_disconnected_limits(error: String) -> CodexRateLimits {
-    if is_transient_os_error(&error) {
-        return transient_failure_limits(error);
-    }
-    CodexRateLimits::disconnected(error)
-}
-
-fn transient_failure_limits(error: String) -> CodexRateLimits {
+fn transient_failure_limits(account_id: Option<&str>, error: String) -> CodexRateLimits {
     match last_good_limits().lock() {
-        Ok(guard) => retain_limits_or_disconnect(guard.as_ref(), error),
+        Ok(guard) => retain_limits_or_disconnect(guard.as_ref(), account_id, error),
         Err(lock_error) => {
             log_msg(&format!(
                 "[RateLimits] last-good cache lock poisoned: {lock_error}"
@@ -188,14 +186,18 @@ fn transient_failure_limits(error: String) -> CodexRateLimits {
     }
 }
 
-fn retain_limits_or_disconnect(cached: Option<&CodexRateLimits>, error: String) -> CodexRateLimits {
-    match cached {
-        Some(stale) => {
-            let mut result = stale.clone();
+fn retain_limits_or_disconnect(
+    cached: Option<&CachedCodexRateLimits>,
+    account_id: Option<&str>,
+    error: String,
+) -> CodexRateLimits {
+    match (cached, account_id) {
+        (Some(stale), Some(current_account_id)) if stale.account_id == current_account_id => {
+            let mut result = stale.limits.clone();
             result.error = Some(error);
             result
         }
-        None => CodexRateLimits::disconnected(error),
+        _ => CodexRateLimits::disconnected(error),
     }
 }
 
@@ -216,7 +218,7 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
         Ok(v) => v,
         Err(error) => {
             log_msg(&format!("[RateLimits] auth read failed: {error}"));
-            return fallback_or_disconnected_limits(error);
+            return CodexRateLimits::disconnected(error);
         }
     };
 
@@ -245,7 +247,7 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
         .header("User-Agent", "codex-cli")
         .timeout(std::time::Duration::from_secs(10));
 
-    if let Some(account_id) = account_id {
+    if let Some(account_id) = account_id.as_deref() {
         request = request.header("ChatGPT-Account-Id", account_id);
     }
 
@@ -264,7 +266,7 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
                 started_at.elapsed().as_secs_f64(),
             ));
             return if should_preserve {
-                transient_failure_limits(error)
+                transient_failure_limits(account_id.as_deref(), error)
             } else {
                 CodexRateLimits::disconnected(error)
             };
@@ -280,7 +282,7 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
     if should_preserve_for_status(status) {
         let error = format!("API error: {status}");
         log_msg("[RateLimits] rate limited; retaining last successful quota if available");
-        return transient_failure_limits(error);
+        return transient_failure_limits(account_id.as_deref(), error);
     }
 
     if status.as_u16() == 401 || status.as_u16() == 403 {
@@ -342,11 +344,19 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
         error: None,
     };
 
-    match last_good_limits().lock() {
-        Ok(mut guard) => *guard = Some(limits.clone()),
-        Err(error) => log_msg(&format!(
-            "[RateLimits] failed to update last-good cache: {error}"
-        )),
+    match account_id {
+        Some(account_id) => match last_good_limits().lock() {
+            Ok(mut guard) => {
+                *guard = Some(CachedCodexRateLimits {
+                    account_id,
+                    limits: limits.clone(),
+                });
+            }
+            Err(error) => log_msg(&format!(
+                "[RateLimits] failed to update last-good cache: {error}"
+            )),
+        },
+        None => log_msg("[RateLimits] account ID missing; last-good cache not updated"),
     }
     log_msg(&format!(
         "[RateLimits] parsed: primary_used={:?}, secondary_used={:?}",
@@ -443,7 +453,7 @@ pub async fn fetch_codex_reset_credits() -> CodexResetCredits {
 mod tests {
     use super::{
         parse_rate_limit_window, parse_reset_credit, retain_limits_or_disconnect,
-        should_preserve_for_status, should_preserve_transport_failure,
+        should_preserve_for_status, should_preserve_transport_failure, CachedCodexRateLimits,
     };
     use crate::domain::models::{CodexRateLimitWindow, CodexRateLimits};
     use serde_json::json;
@@ -465,9 +475,13 @@ mod tests {
 
     #[test]
     fn transient_network_failure_preserves_last_good_limits_and_surfaces_error() {
-        let cached = sample_rate_limits();
+        let cached = CachedCodexRateLimits {
+            account_id: "account-a".to_string(),
+            limits: sample_rate_limits(),
+        };
         let result = retain_limits_or_disconnect(
             Some(&cached),
+            Some("account-a"),
             "Network error: operation timed out".to_string(),
         );
 
@@ -484,8 +498,11 @@ mod tests {
 
     #[test]
     fn transient_failure_without_cached_limits_stays_disconnected() {
-        let result =
-            retain_limits_or_disconnect(None, "Network error: operation timed out".to_string());
+        let result = retain_limits_or_disconnect(
+            None,
+            Some("account-a"),
+            "Network error: operation timed out".to_string(),
+        );
 
         assert!(!result.connected);
         assert!(result.primary.is_none());
@@ -493,6 +510,30 @@ mod tests {
             result.error.as_deref(),
             Some("Network error: operation timed out")
         );
+    }
+
+    #[test]
+    fn transient_failure_never_reuses_another_accounts_limits() {
+        let cached = CachedCodexRateLimits {
+            account_id: "account-a".to_string(),
+            limits: sample_rate_limits(),
+        };
+
+        let switched_account = retain_limits_or_disconnect(
+            Some(&cached),
+            Some("account-b"),
+            "Network error: operation timed out".to_string(),
+        );
+        let unknown_account = retain_limits_or_disconnect(
+            Some(&cached),
+            None,
+            "Network error: operation timed out".to_string(),
+        );
+
+        assert!(!switched_account.connected);
+        assert!(switched_account.primary.is_none());
+        assert!(!unknown_account.connected);
+        assert!(unknown_account.primary.is_none());
     }
 
     #[test]

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -4,12 +4,14 @@ use crate::domain::models::{
 };
 use crate::services::http::{is_transient_os_error, shared_http_client};
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
 
-/// Most recent successful fetch results, retained without TTL so we can
-/// short-circuit transient OS errors (EMFILE etc.) without flashing UI.
+/// Most recent successful fetch results, retained without TTL so a transient
+/// polling failure does not erase quota that was already displayed.
 static LAST_GOOD_INFO: OnceLock<Mutex<Option<CodexData>>> = OnceLock::new();
 static LAST_GOOD_LIMITS: OnceLock<Mutex<Option<CodexRateLimits>>> = OnceLock::new();
 
@@ -19,6 +21,39 @@ fn last_good_info() -> &'static Mutex<Option<CodexData>> {
 
 fn last_good_limits() -> &'static Mutex<Option<CodexRateLimits>> {
     LAST_GOOD_LIMITS.get_or_init(|| Mutex::new(None))
+}
+
+fn log_msg(msg: &str) {
+    let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+    let line = format!("[{timestamp}] {msg}\n");
+
+    print!("{line}");
+
+    let home_dir = match dirs::home_dir() {
+        Some(path) => path,
+        None => {
+            eprintln!("[CodexLog] failed to resolve home directory");
+            return;
+        }
+    };
+    let log_dir = home_dir.join("Library/Logs/quotabar");
+    if let Err(error) = fs::create_dir_all(&log_dir) {
+        eprintln!("[CodexLog] failed to create log directory: {error}");
+        return;
+    }
+
+    match OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_dir.join("codex.log"))
+    {
+        Ok(mut file) => {
+            if let Err(error) = file.write_all(line.as_bytes()) {
+                eprintln!("[CodexLog] failed to write log: {error}");
+            }
+        }
+        Err(error) => eprintln!("[CodexLog] failed to open log file: {error}"),
+    }
 }
 
 fn get_codex_home() -> Option<PathBuf> {
@@ -136,24 +171,62 @@ pub async fn fetch_codex_info() -> CodexData {
 
 fn fallback_or_disconnected_limits(error: String) -> CodexRateLimits {
     if is_transient_os_error(&error) {
-        if let Ok(guard) = last_good_limits().lock() {
-            if let Some(stale) = guard.as_ref() {
-                return stale.clone();
-            }
-        }
+        return transient_failure_limits(error);
     }
     CodexRateLimits::disconnected(error)
+}
+
+fn transient_failure_limits(error: String) -> CodexRateLimits {
+    match last_good_limits().lock() {
+        Ok(guard) => retain_limits_or_disconnect(guard.as_ref(), error),
+        Err(lock_error) => {
+            log_msg(&format!(
+                "[RateLimits] last-good cache lock poisoned: {lock_error}"
+            ));
+            CodexRateLimits::disconnected(error)
+        }
+    }
+}
+
+fn retain_limits_or_disconnect(cached: Option<&CodexRateLimits>, error: String) -> CodexRateLimits {
+    match cached {
+        Some(stale) => {
+            let mut result = stale.clone();
+            result.error = Some(error);
+            result
+        }
+        None => CodexRateLimits::disconnected(error),
+    }
+}
+
+fn should_preserve_for_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS
+}
+
+fn should_preserve_transport_failure(
+    is_timeout: bool,
+    is_connect: bool,
+    is_transient_os_error: bool,
+) -> bool {
+    is_timeout || is_connect || is_transient_os_error
 }
 
 pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
     let auth_json = match read_auth_json() {
         Ok(v) => v,
-        Err(error) => return fallback_or_disconnected_limits(error),
+        Err(error) => {
+            log_msg(&format!("[RateLimits] auth read failed: {error}"));
+            return fallback_or_disconnected_limits(error);
+        }
     };
 
     let access_token = match auth_json["tokens"]["access_token"].as_str() {
         Some(token) => token,
-        None => return CodexRateLimits::disconnected("No access_token found in auth.json"),
+        None => {
+            let error = "No access_token found in auth.json";
+            log_msg(&format!("[RateLimits] {error}"));
+            return CodexRateLimits::disconnected(error);
+        }
     };
 
     let account_id = auth_json["tokens"]["id_token"]
@@ -176,23 +249,58 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
         request = request.header("ChatGPT-Account-Id", account_id);
     }
 
+    let started_at = Instant::now();
     let response = match request.send().await {
         Ok(resp) => resp,
-        Err(err) => return CodexRateLimits::disconnected(format!("Network error: {err}")),
+        Err(err) => {
+            let error = format!("Network error: {err}");
+            let should_preserve = should_preserve_transport_failure(
+                err.is_timeout(),
+                err.is_connect(),
+                is_transient_os_error(&error),
+            );
+            log_msg(&format!(
+                "[RateLimits] request failed: latency={:.1}s, preservable={should_preserve}, error={error}",
+                started_at.elapsed().as_secs_f64(),
+            ));
+            return if should_preserve {
+                transient_failure_limits(error)
+            } else {
+                CodexRateLimits::disconnected(error)
+            };
+        }
     };
 
-    if response.status().as_u16() == 401 || response.status().as_u16() == 403 {
-        return CodexRateLimits::disconnected("Token expired. Please run 'codex' to re-login.");
+    let status = response.status();
+    log_msg(&format!(
+        "[RateLimits] response: status={status}, latency={:.1}s",
+        started_at.elapsed().as_secs_f64()
+    ));
+
+    if should_preserve_for_status(status) {
+        let error = format!("API error: {status}");
+        log_msg("[RateLimits] rate limited; retaining last successful quota if available");
+        return transient_failure_limits(error);
     }
 
-    if !response.status().is_success() {
-        return CodexRateLimits::disconnected(format!("API error: {}", response.status()));
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        let error = "Token expired. Please run 'codex' to re-login.";
+        log_msg(&format!("[RateLimits] auth failure: status={status}"));
+        return CodexRateLimits::disconnected(error);
+    }
+
+    if !status.is_success() {
+        let error = format!("API error: {status}");
+        log_msg(&format!("[RateLimits] non-success response: {status}"));
+        return CodexRateLimits::disconnected(error);
     }
 
     let data = match response.json::<serde_json::Value>().await {
         Ok(data) => data,
         Err(err) => {
-            return CodexRateLimits::disconnected(format!("Failed to parse response: {err}"))
+            let error = format!("Failed to parse response: {err}");
+            log_msg(&format!("[RateLimits] {error}"));
+            return CodexRateLimits::disconnected(error);
         }
     };
 
@@ -205,9 +313,9 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
         .and_then(parse_rate_limit_window);
 
     if primary.is_none() && secondary.is_none() {
-        return CodexRateLimits::disconnected(
-            "Failed to parse response: no numeric Codex rate limit usage fields",
-        );
+        let error = "Failed to parse response: no numeric Codex rate limit usage fields";
+        log_msg(&format!("[RateLimits] {error}"));
+        return CodexRateLimits::disconnected(error);
     }
 
     let credits = data["credits"].as_object().map(|credits| CodexCredits {
@@ -234,9 +342,17 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
         error: None,
     };
 
-    if let Ok(mut guard) = last_good_limits().lock() {
-        *guard = Some(limits.clone());
+    match last_good_limits().lock() {
+        Ok(mut guard) => *guard = Some(limits.clone()),
+        Err(error) => log_msg(&format!(
+            "[RateLimits] failed to update last-good cache: {error}"
+        )),
     }
+    log_msg(&format!(
+        "[RateLimits] parsed: primary_used={:?}, secondary_used={:?}",
+        limits.primary.as_ref().map(|window| window.used_percent),
+        limits.secondary.as_ref().map(|window| window.used_percent)
+    ));
     limits
 }
 
@@ -325,8 +441,80 @@ pub async fn fetch_codex_reset_credits() -> CodexResetCredits {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_rate_limit_window, parse_reset_credit};
+    use super::{
+        parse_rate_limit_window, parse_reset_credit, retain_limits_or_disconnect,
+        should_preserve_for_status, should_preserve_transport_failure,
+    };
+    use crate::domain::models::{CodexRateLimitWindow, CodexRateLimits};
     use serde_json::json;
+
+    fn sample_rate_limits() -> CodexRateLimits {
+        CodexRateLimits {
+            connected: true,
+            plan_type: Some("pro".to_string()),
+            primary: Some(CodexRateLimitWindow {
+                used_percent: 39.0,
+                window_minutes: Some(300),
+                resets_at: Some(1_781_000_000),
+            }),
+            secondary: None,
+            credits: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn transient_network_failure_preserves_last_good_limits_and_surfaces_error() {
+        let cached = sample_rate_limits();
+        let result = retain_limits_or_disconnect(
+            Some(&cached),
+            "Network error: operation timed out".to_string(),
+        );
+
+        assert!(result.connected);
+        assert_eq!(
+            result.primary.as_ref().map(|window| window.used_percent),
+            Some(39.0)
+        );
+        assert_eq!(
+            result.error.as_deref(),
+            Some("Network error: operation timed out")
+        );
+    }
+
+    #[test]
+    fn transient_failure_without_cached_limits_stays_disconnected() {
+        let result =
+            retain_limits_or_disconnect(None, "Network error: operation timed out".to_string());
+
+        assert!(!result.connected);
+        assert!(result.primary.is_none());
+        assert_eq!(
+            result.error.as_deref(),
+            Some("Network error: operation timed out")
+        );
+    }
+
+    #[test]
+    fn only_rate_limiting_is_a_preservable_http_failure() {
+        assert!(should_preserve_for_status(
+            reqwest::StatusCode::TOO_MANY_REQUESTS
+        ));
+        assert!(!should_preserve_for_status(
+            reqwest::StatusCode::UNAUTHORIZED
+        ));
+        assert!(!should_preserve_for_status(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        ));
+    }
+
+    #[test]
+    fn only_explicitly_transient_transport_failures_are_preservable() {
+        assert!(should_preserve_transport_failure(true, false, false));
+        assert!(should_preserve_transport_failure(false, true, false));
+        assert!(should_preserve_transport_failure(false, false, true));
+        assert!(!should_preserve_transport_failure(false, false, false));
+    }
 
     #[test]
     fn parse_reset_credit_requires_status() {

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -2,30 +2,21 @@ use crate::domain::models::{
     CodexCredits, CodexData, CodexRateLimitWindow, CodexRateLimits, CodexResetCredit,
     CodexResetCredits,
 };
+use crate::services::codex_cache::{self, AuthFileStamp};
 use crate::services::http::{is_transient_os_error, shared_http_client};
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 /// Most recent successful fetch results, retained without TTL so a transient
 /// polling failure does not erase quota that was already displayed.
 static LAST_GOOD_INFO: OnceLock<Mutex<Option<CodexData>>> = OnceLock::new();
-static LAST_GOOD_LIMITS: OnceLock<Mutex<Option<CachedCodexRateLimits>>> = OnceLock::new();
-
-struct CachedCodexRateLimits {
-    account_id: String,
-    limits: CodexRateLimits,
-}
 
 fn last_good_info() -> &'static Mutex<Option<CodexData>> {
     LAST_GOOD_INFO.get_or_init(|| Mutex::new(None))
-}
-
-fn last_good_limits() -> &'static Mutex<Option<CachedCodexRateLimits>> {
-    LAST_GOOD_LIMITS.get_or_init(|| Mutex::new(None))
 }
 
 fn log_msg(msg: &str) {
@@ -91,13 +82,45 @@ fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
         .and_then(|json| serde_json::from_str(&json).ok())
 }
 
-fn read_auth_json() -> Result<serde_json::Value, String> {
+fn auth_file_path() -> Result<PathBuf, String> {
     let codex_home = get_codex_home().ok_or_else(|| "Could not find home directory".to_string())?;
     let auth_file = codex_home.join("auth.json");
     if !auth_file.exists() {
         return Err("Codex not configured. Please run 'codex' to login.".to_string());
     }
+    Ok(auth_file)
+}
 
+fn auth_file_stamp(auth_file: &Path) -> Result<AuthFileStamp, String> {
+    let metadata =
+        fs::metadata(auth_file).map_err(|error| format!("Failed to inspect auth.json: {error}"))?;
+    let modified = metadata
+        .modified()
+        .map_err(|error| format!("Failed to inspect auth.json modification time: {error}"))?;
+    Ok(AuthFileStamp {
+        len: metadata.len(),
+        modified,
+    })
+}
+
+fn read_auth_json_with_stamp() -> Result<(serde_json::Value, AuthFileStamp), String> {
+    let auth_file = auth_file_path()?;
+    let stamp_before = auth_file_stamp(&auth_file)?;
+
+    let content =
+        fs::read_to_string(&auth_file).map_err(|e| format!("Failed to read auth.json: {e}"))?;
+    let stamp_after = auth_file_stamp(&auth_file)?;
+    if stamp_before != stamp_after {
+        return Err("auth.json changed while it was being read".to_string());
+    }
+
+    serde_json::from_str(&content)
+        .map(|auth_json| (auth_json, stamp_after))
+        .map_err(|e| format!("Failed to parse auth.json: {e}"))
+}
+
+fn read_auth_json() -> Result<serde_json::Value, String> {
+    let auth_file = auth_file_path()?;
     let content =
         fs::read_to_string(&auth_file).map_err(|e| format!("Failed to read auth.json: {e}"))?;
     serde_json::from_str(&content).map_err(|e| format!("Failed to parse auth.json: {e}"))
@@ -175,29 +198,25 @@ pub async fn fetch_codex_info() -> CodexData {
 }
 
 fn transient_failure_limits(account_id: Option<&str>, error: String) -> CodexRateLimits {
-    match last_good_limits().lock() {
-        Ok(guard) => retain_limits_or_disconnect(guard.as_ref(), account_id, error),
+    match codex_cache::retain_for_account(account_id, error.clone()) {
+        Ok(limits) => limits,
         Err(lock_error) => {
-            log_msg(&format!(
-                "[RateLimits] last-good cache lock poisoned: {lock_error}"
-            ));
+            log_msg(&format!("[RateLimits] {lock_error}"));
             CodexRateLimits::disconnected(error)
         }
     }
 }
 
-fn retain_limits_or_disconnect(
-    cached: Option<&CachedCodexRateLimits>,
-    account_id: Option<&str>,
-    error: String,
-) -> CodexRateLimits {
-    match (cached, account_id) {
-        (Some(stale), Some(current_account_id)) if stale.account_id == current_account_id => {
-            let mut result = stale.limits.clone();
-            result.error = Some(error);
-            result
+fn transient_auth_failure_limits(error: String) -> CodexRateLimits {
+    let auth_stamp = auth_file_path()
+        .and_then(|auth_file| auth_file_stamp(&auth_file))
+        .ok();
+    match codex_cache::retain_for_auth_stamp(auth_stamp.as_ref(), error.clone()) {
+        Ok(limits) => limits,
+        Err(lock_error) => {
+            log_msg(&format!("[RateLimits] {lock_error}"));
+            CodexRateLimits::disconnected(error)
         }
-        _ => CodexRateLimits::disconnected(error),
     }
 }
 
@@ -214,11 +233,15 @@ fn should_preserve_transport_failure(
 }
 
 pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
-    let auth_json = match read_auth_json() {
-        Ok(v) => v,
+    let (auth_json, auth_stamp) = match read_auth_json_with_stamp() {
+        Ok(auth) => auth,
         Err(error) => {
             log_msg(&format!("[RateLimits] auth read failed: {error}"));
-            return CodexRateLimits::disconnected(error);
+            return if is_transient_os_error(&error) {
+                transient_auth_failure_limits(error)
+            } else {
+                CodexRateLimits::disconnected(error)
+            };
         }
     };
 
@@ -288,6 +311,11 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
     if status.as_u16() == 401 || status.as_u16() == 403 {
         let error = "Token expired. Please run 'codex' to re-login.";
         log_msg(&format!("[RateLimits] auth failure: status={status}"));
+        if let Err(cache_error) = codex_cache::invalidate(&auth_stamp, account_id.as_deref()) {
+            log_msg(&format!(
+                "[RateLimits] failed to invalidate last-good cache: {cache_error}"
+            ));
+        }
         return CodexRateLimits::disconnected(error);
     }
 
@@ -300,9 +328,24 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
     let data = match response.json::<serde_json::Value>().await {
         Ok(data) => data,
         Err(err) => {
-            let error = format!("Failed to parse response: {err}");
-            log_msg(&format!("[RateLimits] {error}"));
-            return CodexRateLimits::disconnected(error);
+            let should_preserve = should_preserve_transport_failure(
+                err.is_timeout(),
+                err.is_connect(),
+                is_transient_os_error(&err.to_string()),
+            );
+            let error = if should_preserve {
+                format!("Failed to read response body: {err}")
+            } else {
+                format!("Failed to parse response: {err}")
+            };
+            log_msg(&format!(
+                "[RateLimits] body read failed: preservable={should_preserve}, error={error}"
+            ));
+            return if should_preserve {
+                transient_failure_limits(account_id.as_deref(), error)
+            } else {
+                CodexRateLimits::disconnected(error)
+            };
         }
     };
 
@@ -345,17 +388,13 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
     };
 
     match account_id {
-        Some(account_id) => match last_good_limits().lock() {
-            Ok(mut guard) => {
-                *guard = Some(CachedCodexRateLimits {
-                    account_id,
-                    limits: limits.clone(),
-                });
+        Some(account_id) => {
+            if let Err(error) = codex_cache::store(account_id, auth_stamp, limits.clone()) {
+                log_msg(&format!(
+                    "[RateLimits] failed to update last-good cache: {error}"
+                ));
             }
-            Err(error) => log_msg(&format!(
-                "[RateLimits] failed to update last-good cache: {error}"
-            )),
-        },
+        }
         None => log_msg("[RateLimits] account ID missing; last-good cache not updated"),
     }
     log_msg(&format!(
@@ -452,89 +491,10 @@ pub async fn fetch_codex_reset_credits() -> CodexResetCredits {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_rate_limit_window, parse_reset_credit, retain_limits_or_disconnect,
-        should_preserve_for_status, should_preserve_transport_failure, CachedCodexRateLimits,
+        parse_rate_limit_window, parse_reset_credit, should_preserve_for_status,
+        should_preserve_transport_failure,
     };
-    use crate::domain::models::{CodexRateLimitWindow, CodexRateLimits};
     use serde_json::json;
-
-    fn sample_rate_limits() -> CodexRateLimits {
-        CodexRateLimits {
-            connected: true,
-            plan_type: Some("pro".to_string()),
-            primary: Some(CodexRateLimitWindow {
-                used_percent: 39.0,
-                window_minutes: Some(300),
-                resets_at: Some(1_781_000_000),
-            }),
-            secondary: None,
-            credits: None,
-            error: None,
-        }
-    }
-
-    #[test]
-    fn transient_network_failure_preserves_last_good_limits_and_surfaces_error() {
-        let cached = CachedCodexRateLimits {
-            account_id: "account-a".to_string(),
-            limits: sample_rate_limits(),
-        };
-        let result = retain_limits_or_disconnect(
-            Some(&cached),
-            Some("account-a"),
-            "Network error: operation timed out".to_string(),
-        );
-
-        assert!(result.connected);
-        assert_eq!(
-            result.primary.as_ref().map(|window| window.used_percent),
-            Some(39.0)
-        );
-        assert_eq!(
-            result.error.as_deref(),
-            Some("Network error: operation timed out")
-        );
-    }
-
-    #[test]
-    fn transient_failure_without_cached_limits_stays_disconnected() {
-        let result = retain_limits_or_disconnect(
-            None,
-            Some("account-a"),
-            "Network error: operation timed out".to_string(),
-        );
-
-        assert!(!result.connected);
-        assert!(result.primary.is_none());
-        assert_eq!(
-            result.error.as_deref(),
-            Some("Network error: operation timed out")
-        );
-    }
-
-    #[test]
-    fn transient_failure_never_reuses_another_accounts_limits() {
-        let cached = CachedCodexRateLimits {
-            account_id: "account-a".to_string(),
-            limits: sample_rate_limits(),
-        };
-
-        let switched_account = retain_limits_or_disconnect(
-            Some(&cached),
-            Some("account-b"),
-            "Network error: operation timed out".to_string(),
-        );
-        let unknown_account = retain_limits_or_disconnect(
-            Some(&cached),
-            None,
-            "Network error: operation timed out".to_string(),
-        );
-
-        assert!(!switched_account.connected);
-        assert!(switched_account.primary.is_none());
-        assert!(!unknown_account.connected);
-        assert!(unknown_account.primary.is_none());
-    }
 
     #[test]
     fn only_rate_limiting_is_a_preservable_http_failure() {

--- a/src-tauri/src/services/codex_cache.rs
+++ b/src-tauri/src/services/codex_cache.rs
@@ -52,9 +52,10 @@ impl CodexRateLimitCache {
 
     fn invalidate(&mut self, auth_stamp: &AuthFileStamp, account_id: Option<&str>) {
         let should_clear = self.cached.as_ref().is_some_and(|cached| {
-            cached.auth_stamp == *auth_stamp
-                && account_id
-                    .is_none_or(|current_account_id| cached.account_id == current_account_id)
+            account_id.map_or_else(
+                || cached.auth_stamp == *auth_stamp,
+                |current_account_id| cached.account_id == current_account_id,
+            )
         });
         if should_clear {
             self.cached = None;
@@ -212,10 +213,22 @@ mod tests {
     }
 
     #[test]
-    fn old_authentication_failure_does_not_clear_a_new_accounts_cache() {
+    fn authentication_failure_clears_same_account_after_auth_file_changes() {
         let mut cache = populated_cache();
 
-        cache.invalidate(&auth_stamp(511, 99), Some("account-a"));
+        cache.invalidate(&auth_stamp(513, 101), Some("account-a"));
+        let result = cache.retain_for_account(
+            Some("account-a"),
+            "Network error: operation timed out".to_string(),
+        );
+
+        assert!(!result.connected);
+    }
+
+    #[test]
+    fn old_authentication_failure_does_not_clear_a_different_accounts_cache() {
+        let mut cache = populated_cache();
+
         cache.invalidate(&auth_stamp(512, 100), Some("account-b"));
         let result = cache.retain_for_account(
             Some("account-a"),

--- a/src-tauri/src/services/codex_cache.rs
+++ b/src-tauri/src/services/codex_cache.rs
@@ -1,4 +1,6 @@
 use crate::domain::models::CodexRateLimits;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::SystemTime;
 
@@ -11,12 +13,15 @@ pub(super) struct AuthFileStamp {
 struct CachedCodexRateLimits {
     account_id: String,
     auth_stamp: AuthFileStamp,
+    request_sequence: u64,
     limits: CodexRateLimits,
 }
 
 #[derive(Default)]
 struct CodexRateLimitCache {
     cached: Option<CachedCodexRateLimits>,
+    auth_failures: HashMap<String, u64>,
+    unknown_auth_failure: Option<u64>,
 }
 
 impl CodexRateLimitCache {
@@ -42,20 +47,59 @@ impl CodexRateLimitCache {
         }
     }
 
-    fn store(&mut self, account_id: String, auth_stamp: AuthFileStamp, limits: CodexRateLimits) {
+    fn store(
+        &mut self,
+        account_id: String,
+        auth_stamp: AuthFileStamp,
+        request_sequence: u64,
+        limits: CodexRateLimits,
+    ) -> bool {
+        let blocked_by_account = self
+            .auth_failures
+            .get(&account_id)
+            .is_some_and(|failure_sequence| *failure_sequence >= request_sequence);
+        let blocked_by_unknown = self
+            .unknown_auth_failure
+            .is_some_and(|failure_sequence| failure_sequence >= request_sequence);
+        let blocked_by_newer_cache = self
+            .cached
+            .as_ref()
+            .is_some_and(|cached| cached.request_sequence > request_sequence);
+        if blocked_by_account || blocked_by_unknown || blocked_by_newer_cache {
+            return false;
+        }
+
+        self.auth_failures.remove(&account_id);
+        self.unknown_auth_failure = None;
         self.cached = Some(CachedCodexRateLimits {
             account_id,
             auth_stamp,
+            request_sequence,
             limits,
         });
+        true
     }
 
-    fn invalidate(&mut self, auth_stamp: &AuthFileStamp, account_id: Option<&str>) {
+    fn invalidate(&mut self, account_id: Option<&str>, request_sequence: u64) {
+        match account_id {
+            Some(account_id) => {
+                self.auth_failures
+                    .entry(account_id.to_string())
+                    .and_modify(|sequence| *sequence = (*sequence).max(request_sequence))
+                    .or_insert(request_sequence);
+            }
+            None => {
+                self.unknown_auth_failure = Some(
+                    self.unknown_auth_failure
+                        .map_or(request_sequence, |sequence| sequence.max(request_sequence)),
+                );
+            }
+        }
+
         let should_clear = self.cached.as_ref().is_some_and(|cached| {
-            account_id.map_or_else(
-                || cached.auth_stamp == *auth_stamp,
-                |current_account_id| cached.account_id == current_account_id,
-            )
+            cached.request_sequence <= request_sequence
+                && account_id
+                    .is_none_or(|current_account_id| cached.account_id == current_account_id)
         });
         if should_clear {
             self.cached = None;
@@ -70,6 +114,7 @@ fn stale_limits_with_error(limits: &CodexRateLimits, error: String) -> CodexRate
 }
 
 static LAST_GOOD_LIMITS: OnceLock<Mutex<CodexRateLimitCache>> = OnceLock::new();
+static NEXT_REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 
 fn cache() -> &'static Mutex<CodexRateLimitCache> {
     LAST_GOOD_LIMITS.get_or_init(|| Mutex::new(CodexRateLimitCache::default()))
@@ -98,24 +143,26 @@ pub(super) fn retain_for_auth_stamp(
 pub(super) fn store(
     account_id: String,
     auth_stamp: AuthFileStamp,
+    request_sequence: u64,
     limits: CodexRateLimits,
-) -> Result<(), String> {
+) -> Result<bool, String> {
+    let stored = cache()
+        .lock()
+        .map_err(|lock_error| format!("last-good cache lock poisoned: {lock_error}"))?
+        .store(account_id, auth_stamp, request_sequence, limits);
+    Ok(stored)
+}
+
+pub(super) fn invalidate(account_id: Option<&str>, request_sequence: u64) -> Result<(), String> {
     cache()
         .lock()
         .map_err(|lock_error| format!("last-good cache lock poisoned: {lock_error}"))?
-        .store(account_id, auth_stamp, limits);
+        .invalidate(account_id, request_sequence);
     Ok(())
 }
 
-pub(super) fn invalidate(
-    auth_stamp: &AuthFileStamp,
-    account_id: Option<&str>,
-) -> Result<(), String> {
-    cache()
-        .lock()
-        .map_err(|lock_error| format!("last-good cache lock poisoned: {lock_error}"))?
-        .invalidate(auth_stamp, account_id);
-    Ok(())
+pub(super) fn next_request_sequence() -> u64 {
+    NEXT_REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed)
 }
 
 #[cfg(test)]
@@ -148,11 +195,12 @@ mod tests {
 
     fn populated_cache() -> CodexRateLimitCache {
         let mut cache = CodexRateLimitCache::default();
-        cache.store(
+        assert!(cache.store(
             "account-a".to_string(),
             auth_stamp(512, 100),
+            1,
             sample_rate_limits(),
-        );
+        ));
         cache
     }
 
@@ -199,10 +247,10 @@ mod tests {
     }
 
     #[test]
-    fn matching_authentication_failure_clears_cached_limits() {
+    fn unknown_account_authentication_failure_clears_older_cached_limits() {
         let mut cache = populated_cache();
 
-        cache.invalidate(&auth_stamp(512, 100), Some("account-a"));
+        cache.invalidate(None, 2);
         let result = cache.retain_for_account(
             Some("account-a"),
             "Network error: operation timed out".to_string(),
@@ -216,7 +264,7 @@ mod tests {
     fn authentication_failure_clears_same_account_after_auth_file_changes() {
         let mut cache = populated_cache();
 
-        cache.invalidate(&auth_stamp(513, 101), Some("account-a"));
+        cache.invalidate(Some("account-a"), 2);
         let result = cache.retain_for_account(
             Some("account-a"),
             "Network error: operation timed out".to_string(),
@@ -226,10 +274,69 @@ mod tests {
     }
 
     #[test]
+    fn older_authentication_failure_does_not_clear_new_same_account_limits() {
+        let mut cache = populated_cache();
+        assert!(cache.store(
+            "account-a".to_string(),
+            auth_stamp(513, 101),
+            3,
+            sample_rate_limits(),
+        ));
+
+        cache.invalidate(Some("account-a"), 2);
+        let result = cache.retain_for_account(
+            Some("account-a"),
+            "Network error: operation timed out".to_string(),
+        );
+
+        assert!(result.connected);
+    }
+
+    #[test]
+    fn authentication_failure_blocks_an_older_success_from_repopulating_cache() {
+        let mut cache = populated_cache();
+        cache.invalidate(Some("account-a"), 3);
+
+        let stored = cache.store(
+            "account-a".to_string(),
+            auth_stamp(512, 100),
+            2,
+            sample_rate_limits(),
+        );
+
+        assert!(!stored);
+        assert!(
+            !cache
+                .retain_for_account(Some("account-a"), "timeout".to_string())
+                .connected
+        );
+    }
+
+    #[test]
+    fn older_success_does_not_replace_newer_cached_limits() {
+        let mut cache = populated_cache();
+        assert!(cache.store(
+            "account-a".to_string(),
+            auth_stamp(513, 101),
+            3,
+            sample_rate_limits(),
+        ));
+
+        let stored = cache.store(
+            "account-a".to_string(),
+            auth_stamp(512, 100),
+            2,
+            sample_rate_limits(),
+        );
+
+        assert!(!stored);
+    }
+
+    #[test]
     fn old_authentication_failure_does_not_clear_a_different_accounts_cache() {
         let mut cache = populated_cache();
 
-        cache.invalidate(&auth_stamp(512, 100), Some("account-b"));
+        cache.invalidate(Some("account-b"), 2);
         let result = cache.retain_for_account(
             Some("account-a"),
             "Network error: operation timed out".to_string(),

--- a/src-tauri/src/services/codex_cache.rs
+++ b/src-tauri/src/services/codex_cache.rs
@@ -1,0 +1,227 @@
+use crate::domain::models::CodexRateLimits;
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct AuthFileStamp {
+    pub(super) len: u64,
+    pub(super) modified: SystemTime,
+}
+
+struct CachedCodexRateLimits {
+    account_id: String,
+    auth_stamp: AuthFileStamp,
+    limits: CodexRateLimits,
+}
+
+#[derive(Default)]
+struct CodexRateLimitCache {
+    cached: Option<CachedCodexRateLimits>,
+}
+
+impl CodexRateLimitCache {
+    fn retain_for_account(&self, account_id: Option<&str>, error: String) -> CodexRateLimits {
+        match (&self.cached, account_id) {
+            (Some(stale), Some(current_account_id)) if stale.account_id == current_account_id => {
+                stale_limits_with_error(&stale.limits, error)
+            }
+            _ => CodexRateLimits::disconnected(error),
+        }
+    }
+
+    fn retain_for_auth_stamp(
+        &self,
+        auth_stamp: Option<&AuthFileStamp>,
+        error: String,
+    ) -> CodexRateLimits {
+        match (&self.cached, auth_stamp) {
+            (Some(stale), Some(current_stamp)) if stale.auth_stamp == *current_stamp => {
+                stale_limits_with_error(&stale.limits, error)
+            }
+            _ => CodexRateLimits::disconnected(error),
+        }
+    }
+
+    fn store(&mut self, account_id: String, auth_stamp: AuthFileStamp, limits: CodexRateLimits) {
+        self.cached = Some(CachedCodexRateLimits {
+            account_id,
+            auth_stamp,
+            limits,
+        });
+    }
+
+    fn invalidate(&mut self, auth_stamp: &AuthFileStamp, account_id: Option<&str>) {
+        let should_clear = self.cached.as_ref().is_some_and(|cached| {
+            cached.auth_stamp == *auth_stamp
+                && account_id
+                    .is_none_or(|current_account_id| cached.account_id == current_account_id)
+        });
+        if should_clear {
+            self.cached = None;
+        }
+    }
+}
+
+fn stale_limits_with_error(limits: &CodexRateLimits, error: String) -> CodexRateLimits {
+    let mut result = limits.clone();
+    result.error = Some(error);
+    result
+}
+
+static LAST_GOOD_LIMITS: OnceLock<Mutex<CodexRateLimitCache>> = OnceLock::new();
+
+fn cache() -> &'static Mutex<CodexRateLimitCache> {
+    LAST_GOOD_LIMITS.get_or_init(|| Mutex::new(CodexRateLimitCache::default()))
+}
+
+pub(super) fn retain_for_account(
+    account_id: Option<&str>,
+    error: String,
+) -> Result<CodexRateLimits, String> {
+    cache()
+        .lock()
+        .map_err(|lock_error| format!("last-good cache lock poisoned: {lock_error}"))
+        .map(|cache| cache.retain_for_account(account_id, error))
+}
+
+pub(super) fn retain_for_auth_stamp(
+    auth_stamp: Option<&AuthFileStamp>,
+    error: String,
+) -> Result<CodexRateLimits, String> {
+    cache()
+        .lock()
+        .map_err(|lock_error| format!("last-good cache lock poisoned: {lock_error}"))
+        .map(|cache| cache.retain_for_auth_stamp(auth_stamp, error))
+}
+
+pub(super) fn store(
+    account_id: String,
+    auth_stamp: AuthFileStamp,
+    limits: CodexRateLimits,
+) -> Result<(), String> {
+    cache()
+        .lock()
+        .map_err(|lock_error| format!("last-good cache lock poisoned: {lock_error}"))?
+        .store(account_id, auth_stamp, limits);
+    Ok(())
+}
+
+pub(super) fn invalidate(
+    auth_stamp: &AuthFileStamp,
+    account_id: Option<&str>,
+) -> Result<(), String> {
+    cache()
+        .lock()
+        .map_err(|lock_error| format!("last-good cache lock poisoned: {lock_error}"))?
+        .invalidate(auth_stamp, account_id);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AuthFileStamp, CodexRateLimitCache};
+    use crate::domain::models::{CodexRateLimitWindow, CodexRateLimits};
+    use std::time::{Duration, UNIX_EPOCH};
+
+    fn sample_rate_limits() -> CodexRateLimits {
+        CodexRateLimits {
+            connected: true,
+            plan_type: Some("pro".to_string()),
+            primary: Some(CodexRateLimitWindow {
+                used_percent: 39.0,
+                window_minutes: Some(300),
+                resets_at: Some(1_781_000_000),
+            }),
+            secondary: None,
+            credits: None,
+            error: None,
+        }
+    }
+
+    fn auth_stamp(len: u64, seconds: u64) -> AuthFileStamp {
+        AuthFileStamp {
+            len,
+            modified: UNIX_EPOCH + Duration::from_secs(seconds),
+        }
+    }
+
+    fn populated_cache() -> CodexRateLimitCache {
+        let mut cache = CodexRateLimitCache::default();
+        cache.store(
+            "account-a".to_string(),
+            auth_stamp(512, 100),
+            sample_rate_limits(),
+        );
+        cache
+    }
+
+    #[test]
+    fn transient_failure_preserves_only_the_same_accounts_limits() {
+        let cache = populated_cache();
+        let error = "Network error: operation timed out".to_string();
+
+        let same_account = cache.retain_for_account(Some("account-a"), error.clone());
+        let switched_account = cache.retain_for_account(Some("account-b"), error.clone());
+        let unknown_account = cache.retain_for_account(None, error);
+
+        assert!(same_account.connected);
+        assert_eq!(
+            same_account.primary.map(|window| window.used_percent),
+            Some(39.0)
+        );
+        assert_eq!(
+            same_account.error.as_deref(),
+            Some("Network error: operation timed out")
+        );
+        assert!(!switched_account.connected);
+        assert!(!unknown_account.connected);
+    }
+
+    #[test]
+    fn transient_auth_read_preserves_only_the_same_file_stamp() {
+        let cache = populated_cache();
+        let error = "Failed to read auth.json: too many open files".to_string();
+
+        let same_file = cache.retain_for_auth_stamp(Some(&auth_stamp(512, 100)), error.clone());
+        let changed_file = cache.retain_for_auth_stamp(Some(&auth_stamp(513, 100)), error.clone());
+        let replaced_file = cache.retain_for_auth_stamp(Some(&auth_stamp(512, 101)), error.clone());
+        let unknown_file = cache.retain_for_auth_stamp(None, error);
+
+        assert!(same_file.connected);
+        assert_eq!(
+            same_file.error.as_deref(),
+            Some("Failed to read auth.json: too many open files")
+        );
+        assert!(!changed_file.connected);
+        assert!(!replaced_file.connected);
+        assert!(!unknown_file.connected);
+    }
+
+    #[test]
+    fn matching_authentication_failure_clears_cached_limits() {
+        let mut cache = populated_cache();
+
+        cache.invalidate(&auth_stamp(512, 100), Some("account-a"));
+        let result = cache.retain_for_account(
+            Some("account-a"),
+            "Network error: operation timed out".to_string(),
+        );
+
+        assert!(!result.connected);
+        assert!(result.primary.is_none());
+    }
+
+    #[test]
+    fn old_authentication_failure_does_not_clear_a_new_accounts_cache() {
+        let mut cache = populated_cache();
+
+        cache.invalidate(&auth_stamp(511, 99), Some("account-a"));
+        cache.invalidate(&auth_stamp(512, 100), Some("account-b"));
+        let result = cache.retain_for_account(
+            Some("account-a"),
+            "Network error: operation timed out".to_string(),
+        );
+
+        assert!(result.connected);
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod antigravity;
 pub mod claude;
 pub mod codex;
+mod codex_cache;
 pub mod cost;
 pub mod cursor;
 pub mod http;


### PR DESCRIPTION
## Summary

- add redacted Codex rate-limit diagnostics at ~/Library/Logs/quotabar/codex.log
- retain the last successful quota for explicit transient transport failures and HTTP 429 while surfacing the error
- keep authentication, other HTTP, JSON, and schema failures fail-closed
- key stale quota by Codex account ID so switched or unknown accounts never reuse another account's data

## Root cause

Periodic Codex refreshes replaced the last successful rate-limit payload with disconnected data after a transient request failure. Account metadata could remain connected, so quota windows disappeared without a Codex disconnected event or persistent request log.

## Verification

- cargo fmt --check
- cargo check
- cargo test: 34 passed, 0 failed, 2 ignored
- npm run build
- cargo clippy --all-targets -- -A clippy::let_and_return -D warnings
- release app build and live authenticated request: HTTP 200, primary quota parsed
- runtime codex.log secret-pattern scan: clean

The Clippy allowance is limited to two pre-existing let_and_return findings in tray.rs; no new Clippy findings remain.
