### PR TITLE
Cache local cost summaries on disk and stop forced re-parses

### DIFF
--- a/src-tauri/src/services/cost.rs
+++ b/src-tauri/src/services/cost.rs
@@ -4,17 +4,18 @@ use ccstats::{
     summarize_cost_ranges, CostSummary, ModelCostSummary, MultiCostSummary, MultiSummaryOptions,
     TokenBreakdown, UsageRange, UsageSource,
 };
+use super::cost_disk_cache::{self as disk, SnapshotUse};
 use chrono::{Days, Local, NaiveDate};
 use once_cell::sync::Lazy;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     str::FromStr,
     sync::Mutex,
     time::{Duration, Instant},
 };
 
-const CACHE_TTL: Duration = Duration::from_secs(300);
+const CACHE_TTL: Duration = Duration::from_secs(1200);
 const MAX_DAILY_DAYS: u32 = 60;
 
 static COST_CACHE: Lazy<Mutex<HashMap<String, CachedOverview>>> =
@@ -22,6 +23,9 @@ static COST_CACHE: Lazy<Mutex<HashMap<String, CachedOverview>>> =
 
 static DAILY_CACHE: Lazy<Mutex<HashMap<String, CachedDaily>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Cache keys whose expired disk snapshot was already handed out once.
+static STALE_SERVED: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
 #[derive(Clone)]
 struct CachedOverview {
@@ -35,7 +39,7 @@ struct CachedDaily {
     series: CostDailySeries,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CostOverview {
     pub source: String,
@@ -46,7 +50,7 @@ pub struct CostOverview {
     pub ranges: Vec<CostRangeSummary>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CostRangeSummary {
     pub range: String,
@@ -63,7 +67,7 @@ pub struct CostRangeSummary {
     pub elapsed_ms: f64,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CostTokenBreakdown {
     pub input_tokens: i64,
@@ -74,7 +78,7 @@ pub struct CostTokenBreakdown {
     pub total_tokens: i64,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CostModelSummary {
     pub model: String,
@@ -83,7 +87,7 @@ pub struct CostModelSummary {
     pub tokens: CostTokenBreakdown,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CostDailySeries {
     pub source: String,
@@ -93,7 +97,7 @@ pub struct CostDailySeries {
     pub days: Vec<CostDailyPoint>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CostDailyPoint {
     pub date: String,
@@ -143,6 +147,9 @@ fn build_cost_daily(
     if !force {
         if let Some(cached) = get_cached_daily(&cache_key)? {
             return Ok(cached);
+        }
+        if let Some(series) = load_daily_snapshot(&cache_key) {
+            return Ok(series);
         }
     }
 
@@ -233,6 +240,7 @@ fn get_cached_daily(cache_key: &str) -> Result<Option<CostDailySeries>, String> 
 }
 
 fn set_cached_daily(cache_key: String, series: CostDailySeries) -> Result<(), String> {
+    disk::write_snapshot(&cache_key, &series);
     let mut cache = DAILY_CACHE.lock().map_err(|err| err.to_string())?;
     cache.insert(
         cache_key,
@@ -242,6 +250,45 @@ fn set_cached_daily(cache_key: String, series: CostDailySeries) -> Result<(), St
         },
     );
     Ok(())
+}
+
+/// Serves a disk snapshot after a memory-cache miss: fresh snapshots act like a
+/// cache hit; expired ones are handed out once per key so a cold start can
+/// paint immediately while the next poll triggers a real parse.
+fn load_daily_snapshot(cache_key: &str) -> Option<CostDailySeries> {
+    let (age, mut series): (Duration, CostDailySeries) = disk::read_snapshot(cache_key)?;
+    match disk::classify_snapshot(age, CACHE_TTL, stale_already_served(cache_key)) {
+        SnapshotUse::Fresh => {}
+        SnapshotUse::ServeStaleOnce => mark_stale_served(cache_key),
+        SnapshotUse::Ignore => return None,
+    }
+    series.cached = true;
+    Some(series)
+}
+
+fn load_overview_snapshot(cache_key: &str) -> Option<CostOverview> {
+    let (age, mut overview): (Duration, CostOverview) = disk::read_snapshot(cache_key)?;
+    match disk::classify_snapshot(age, CACHE_TTL, stale_already_served(cache_key)) {
+        SnapshotUse::Fresh => {}
+        SnapshotUse::ServeStaleOnce => mark_stale_served(cache_key),
+        SnapshotUse::Ignore => return None,
+    }
+    overview.cached = true;
+    Some(overview)
+}
+
+fn stale_already_served(cache_key: &str) -> bool {
+    match STALE_SERVED.lock() {
+        Ok(served) => served.contains(cache_key),
+        // Poisoned lock: err on the side of not serving stale data again.
+        Err(_) => true,
+    }
+}
+
+fn mark_stale_served(cache_key: &str) {
+    if let Ok(mut served) = STALE_SERVED.lock() {
+        served.insert(cache_key.to_string());
+    }
 }
 
 pub async fn get_cost_overview(
@@ -295,6 +342,9 @@ fn build_cost_overview(
     if !force {
         if let Some(cached) = get_cached_overview(&cache_key)? {
             return Ok(cached);
+        }
+        if let Some(overview) = load_overview_snapshot(&cache_key) {
+            return Ok(overview);
         }
     }
 
@@ -405,6 +455,7 @@ fn get_cached_overview(cache_key: &str) -> Result<Option<CostOverview>, String> 
 }
 
 fn set_cached_overview(cache_key: String, overview: CostOverview) -> Result<(), String> {
+    disk::write_snapshot(&cache_key, &overview);
     let mut cache = COST_CACHE.lock().map_err(|err| err.to_string())?;
     cache.insert(
         cache_key,

--- a/src-tauri/src/services/cost_disk_cache.rs
+++ b/src-tauri/src/services/cost_disk_cache.rs
@@ -1,0 +1,206 @@
+//! Disk persistence for cost summaries so cold starts can paint instantly.
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+/// Snapshots older than this are ignored entirely.
+pub const STALE_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Snapshot<T> {
+    saved_at_unix_ms: u64,
+    payload: T,
+}
+
+/// How a disk snapshot may be used by the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotUse {
+    /// Within the cache TTL: as good as a memory-cache hit.
+    Fresh,
+    /// Expired but recent enough to paint a first frame once.
+    ServeStaleOnce,
+    /// Too old (or callers already served it once): ignore.
+    Ignore,
+}
+
+pub fn classify_snapshot(age: Duration, ttl: Duration, already_served: bool) -> SnapshotUse {
+    if age <= ttl {
+        SnapshotUse::Fresh
+    } else if age <= STALE_MAX_AGE && !already_served {
+        SnapshotUse::ServeStaleOnce
+    } else {
+        SnapshotUse::Ignore
+    }
+}
+
+fn default_cache_dir() -> Option<PathBuf> {
+    dirs::cache_dir().map(|dir| dir.join("quotabar"))
+}
+
+fn snapshot_path(base_dir: &Path, cache_key: &str) -> PathBuf {
+    let file_name: String = cache_key
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect();
+    base_dir.join(format!("cost-{file_name}.json"))
+}
+
+pub fn read_snapshot<T: DeserializeOwned>(cache_key: &str) -> Option<(Duration, T)> {
+    read_snapshot_in(&default_cache_dir()?, cache_key)
+}
+
+pub fn write_snapshot<T: Serialize>(cache_key: &str, payload: &T) {
+    let Some(base_dir) = default_cache_dir() else {
+        eprintln!("[CostCache] cache dir unavailable; skipping disk write");
+        return;
+    };
+    write_snapshot_in(&base_dir, cache_key, payload);
+}
+
+fn read_snapshot_in<T: DeserializeOwned>(base_dir: &Path, cache_key: &str) -> Option<(Duration, T)> {
+    let path = snapshot_path(base_dir, cache_key);
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(err) => {
+            eprintln!("[CostCache] failed to read {}: {err}", path.display());
+            return None;
+        }
+    };
+    let snapshot: Snapshot<T> = match serde_json::from_slice(&bytes) {
+        Ok(snapshot) => snapshot,
+        Err(err) => {
+            eprintln!("[CostCache] discarding corrupt {}: {err}", path.display());
+            let _removed = fs::remove_file(&path);
+            return None;
+        }
+    };
+
+    let saved_at = UNIX_EPOCH + Duration::from_millis(snapshot.saved_at_unix_ms);
+    let age = SystemTime::now()
+        .duration_since(saved_at)
+        .unwrap_or(Duration::ZERO);
+    Some((age, snapshot.payload))
+}
+
+fn write_snapshot_in<T: Serialize>(base_dir: &Path, cache_key: &str, payload: &T) {
+    let saved_at_unix_ms = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(elapsed) => elapsed.as_millis() as u64,
+        Err(err) => {
+            eprintln!("[CostCache] system clock before epoch; skipping disk write: {err}");
+            return;
+        }
+    };
+    let snapshot = Snapshot {
+        saved_at_unix_ms,
+        payload,
+    };
+    let bytes = match serde_json::to_vec(&snapshot) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!("[CostCache] failed to serialize snapshot {cache_key}: {err}");
+            return;
+        }
+    };
+
+    if let Err(err) = fs::create_dir_all(base_dir) {
+        eprintln!(
+            "[CostCache] failed to create {}: {err}",
+            base_dir.display()
+        );
+        return;
+    }
+    let path = snapshot_path(base_dir, cache_key);
+    let tmp_path = path.with_extension("json.tmp");
+    if let Err(err) = fs::write(&tmp_path, &bytes) {
+        eprintln!("[CostCache] failed to write {}: {err}", tmp_path.display());
+        return;
+    }
+    if let Err(err) = fs::rename(&tmp_path, &path) {
+        eprintln!("[CostCache] failed to move {}: {err}", path.display());
+        let _removed = fs::remove_file(&tmp_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn temp_base() -> PathBuf {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        std::env::temp_dir().join(format!(
+            "quotabar-cost-cache-test-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn snapshot_roundtrip_preserves_payload_and_reports_small_age() {
+        let base = temp_base();
+        write_snapshot_in(&base, "overview|claude|USD|local", &vec![1_i64, 2, 3]);
+        let (age, payload): (Duration, Vec<i64>) =
+            read_snapshot_in(&base, "overview|claude|USD|local")
+                .expect("snapshot should read back");
+        assert_eq!(payload, vec![1, 2, 3]);
+        assert!(age < Duration::from_secs(60), "age should be near zero");
+        let _cleanup = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn missing_snapshot_returns_none() {
+        let base = temp_base();
+        let result: Option<(Duration, Vec<i64>)> = read_snapshot_in(&base, "missing");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn corrupt_snapshot_is_discarded_and_removed() {
+        let base = temp_base();
+        std::fs::create_dir_all(&base).expect("temp dir should create");
+        let path = snapshot_path(&base, "bad");
+        std::fs::write(&path, b"not json").expect("corrupt file should write");
+        let result: Option<(Duration, Vec<i64>)> = read_snapshot_in(&base, "bad");
+        assert!(result.is_none());
+        assert!(!path.exists(), "corrupt file should be deleted");
+        let _cleanup = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn cache_keys_map_to_distinct_sanitized_files() {
+        let base = PathBuf::from("/base");
+        let overview = snapshot_path(&base, "overview|claude|USD|local");
+        let daily = snapshot_path(&base, "daily|claude|30|USD|local");
+        assert_ne!(overview, daily);
+        assert_eq!(
+            overview.file_name().and_then(|name| name.to_str()),
+            Some("cost-overview-claude-USD-local.json")
+        );
+    }
+
+    #[test]
+    fn classify_snapshot_covers_fresh_stale_and_ignore() {
+        let ttl = Duration::from_secs(1200);
+        assert_eq!(
+            classify_snapshot(Duration::from_secs(60), ttl, false),
+            SnapshotUse::Fresh
+        );
+        assert_eq!(
+            classify_snapshot(Duration::from_secs(3600), ttl, false),
+            SnapshotUse::ServeStaleOnce
+        );
+        assert_eq!(
+            classify_snapshot(Duration::from_secs(3600), ttl, true),
+            SnapshotUse::Ignore
+        );
+        assert_eq!(
+            classify_snapshot(STALE_MAX_AGE + Duration::from_secs(1), ttl, false),
+            SnapshotUse::Ignore
+        );
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod claude;
 pub mod codex;
 mod codex_cache;
 pub mod cost;
+mod cost_disk_cache;
 pub mod cursor;
 pub mod http;
 pub mod link;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,7 @@ import {
   AUTO_REFRESH_INTERVAL_MS,
   BACKGROUND_REFRESH_INTERVAL_MS,
   TRAY_CYCLE_INTERVAL_MS,
+  TRAY_FORCE_SYNC_INTERVAL_MS,
   TRAY_GUARD_MESSAGE,
   TRAY_GUARD_TOAST_MS,
   TRAY_SERVICE_ACTIVATED_EVENT,
@@ -357,7 +358,7 @@ export default function App() {
   useEffect(() => {
     const interval = setInterval(() => {
       syncTrayIcons(true);
-    }, 5000);
+    }, TRAY_FORCE_SYNC_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [syncTrayIcons]);
 

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { backend } from '../services/backend';
 import { getBudgetForSources, getSavedMonthlyBudgets } from '../services/budget';
 import type { CostDailyPoint, CostDailySeries, CostOverview, CostRangeSummary, CostSource } from '../types/models';
@@ -47,8 +47,10 @@ export function startCostSummaryAutoRefresh(
   loadCost: (force: boolean) => void | Promise<void>,
 ): ReturnType<typeof setInterval> | undefined {
   if (autoRefreshIntervalMs <= 0) return undefined;
+  // Non-forced so the backend cache TTL governs how often local logs are
+  // re-parsed; only a manual refresh bypasses it.
   return setInterval(() => {
-    void loadCost(true);
+    void loadCost(false);
   }, autoRefreshIntervalMs);
 }
 
@@ -215,6 +217,7 @@ export default function CostSummarySection({
   const sourceKey = Array.isArray(source) ? source.join(',') : source;
   const overview_generation = useLatestRequestGeneration();
   const daily_generation = useLatestRequestGeneration();
+  const lastRefreshKeyRef = useRef(refreshKey);
 
   useEffect(() => {
     let interval: number | undefined;
@@ -256,8 +259,12 @@ export default function CostSummarySection({
       }
     };
 
-    loadCost(refreshKey > 0);
-    void loadDaily(refreshKey > 0);
+    // Force only when the manual-refresh nonce actually advanced; otherwise a
+    // single manual refresh would make every later effect run bypass the cache.
+    const manualRefresh = refreshKey > lastRefreshKeyRef.current;
+    lastRefreshKeyRef.current = refreshKey;
+    loadCost(manualRefresh);
+    void loadDaily(manualRefresh);
     interval = startCostSummaryAutoRefresh(autoRefreshIntervalMs, (force) => {
       void loadCost(force);
       void loadDaily(force);

--- a/src/services/app_state.ts
+++ b/src/services/app_state.ts
@@ -17,6 +17,9 @@ export const BACKGROUND_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 export const TRAY_SERVICE_ACTIVATED_EVENT = 'tray-service-activated';
 export const TRAY_GUARD_TOAST_MS = 2000;
 export const TRAY_CYCLE_INTERVAL_MS = 15 * 1000;
+// Forced resync only repairs a desynced tray runtime; quota data changes at
+// most every AUTO_REFRESH_INTERVAL_MS, so forcing faster than that is waste.
+export const TRAY_FORCE_SYNC_INTERVAL_MS = 60 * 1000;
 export const TRAY_GUARD_MESSAGE = 'At least one tray must remain enabled';
 export const VALID_TABS = new Set<string>(['all', ...SERVICES]);
 

--- a/tests/cost_refresh_force.test.tsx
+++ b/tests/cost_refresh_force.test.tsx
@@ -1,0 +1,101 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import CostSummarySection from '../src/components/CostSummarySection';
+import { backend } from '../src/services/backend';
+import type { CostDailySeries, CostOverview } from '../src/types/models';
+
+function cost_overview(): CostOverview {
+  return {
+    source: 'claude',
+    displayName: 'Claude',
+    currency: 'USD',
+    generatedAt: '2026-07-16T00:00:00Z',
+    cached: false,
+    ranges: [],
+  };
+}
+
+function cost_daily(): CostDailySeries {
+  return {
+    source: 'claude',
+    currency: 'USD',
+    generatedAt: '2026-07-16T00:00:00Z',
+    cached: false,
+    days: [],
+  };
+}
+
+describe('CostSummarySection manual-refresh force flag', () => {
+  let overview_forces: Array<boolean | undefined>;
+  let daily_forces: Array<boolean | undefined>;
+  let renderer: ReactTestRenderer;
+
+  beforeAll(() => {
+    (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    (globalThis as Record<string, unknown>).localStorage = {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    overview_forces = [];
+    daily_forces = [];
+    vi.spyOn(backend, 'getCostOverview').mockImplementation(async (_source, force) => {
+      overview_forces.push(force);
+      return cost_overview();
+    });
+    vi.spyOn(backend, 'getCostDaily').mockImplementation(async (_source, _days, force) => {
+      daily_forces.push(force);
+      return cost_daily();
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => renderer.unmount());
+    vi.restoreAllMocks();
+  });
+
+  async function render(refreshKey: number, autoRefreshIntervalMs = 0): Promise<void> {
+    await act(async () => {
+      renderer = create(
+        createElement(CostSummarySection, { source: 'claude', refreshKey, autoRefreshIntervalMs }),
+      );
+    });
+  }
+
+  async function update(refreshKey: number, autoRefreshIntervalMs = 0): Promise<void> {
+    await act(async () => {
+      renderer.update(
+        createElement(CostSummarySection, { source: 'claude', refreshKey, autoRefreshIntervalMs }),
+      );
+    });
+  }
+
+  it('loads without force on mount', async () => {
+    await render(0);
+    expect(overview_forces).toEqual([false]);
+    expect(daily_forces).toEqual([false]);
+  });
+
+  it('forces only when the refresh nonce advances', async () => {
+    await render(0);
+    await update(1);
+    expect(overview_forces).toEqual([false, true]);
+    expect(daily_forces).toEqual([false, true]);
+  });
+
+  it('does not keep forcing after a manual refresh when the effect reruns', async () => {
+    await render(0);
+    await update(1);
+    // Same nonce, different interval: the effect reruns but this is not a
+    // manual refresh, so the backend cache must be used.
+    await update(1, 1000);
+    expect(overview_forces).toEqual([false, true, false]);
+    expect(daily_forces).toEqual([false, true, false]);
+  });
+});

--- a/tests/cost_summary_error.test.ts
+++ b/tests/cost_summary_error.test.ts
@@ -22,7 +22,7 @@ describe('startCostSummaryAutoRefresh', () => {
     vi.useRealTimers();
   });
 
-  test('refreshes with force enabled on interval ticks', () => {
+  test('refreshes without force on interval ticks so the backend cache is used', () => {
     vi.useFakeTimers();
     const loadCost = vi.fn();
     const interval = startCostSummaryAutoRefresh(1000, loadCost);
@@ -30,7 +30,7 @@ describe('startCostSummaryAutoRefresh', () => {
     vi.advanceTimersByTime(1000);
 
     expect(loadCost).toHaveBeenCalledTimes(1);
-    expect(loadCost).toHaveBeenCalledWith(true);
+    expect(loadCost).toHaveBeenCalledWith(false);
     if (interval !== undefined) clearInterval(interval);
   });
 


### PR DESCRIPTION
Fixes #65

- Persist cost snapshots to `~/Library/Caches/quotabar` (atomic write); expired snapshots (<=24h) serve once per key for instant cold-start paint.
- Cost cache TTL 300s -> 1200s; auto-refresh no longer passes `force=true`; force only when the manual-refresh nonce advances.
- Tray forced resync 5s -> 60s.

Trade-off: non-manual freshness bound is now the 20min TTL; manual refresh still bypasses the cache.

Tested: `cargo test --lib` (44), `npm test` (341, 3 new regression tests), `tsc --noEmit`.