### PR TITLE
Apply rustfmt to cost services

### DIFF
--- a/src-tauri/src/services/cost.rs
+++ b/src-tauri/src/services/cost.rs
@@ -1,10 +1,10 @@
 //! Local cost summaries powered by the `ccstats` SDK.
 
+use super::cost_disk_cache::{self as disk, SnapshotUse};
 use ccstats::{
     summarize_cost_ranges, CostSummary, ModelCostSummary, MultiCostSummary, MultiSummaryOptions,
     TokenBreakdown, UsageRange, UsageSource,
 };
-use super::cost_disk_cache::{self as disk, SnapshotUse};
 use chrono::{Days, Local, NaiveDate};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/services/cost_disk_cache.rs
+++ b/src-tauri/src/services/cost_disk_cache.rs
@@ -61,7 +61,10 @@ pub fn write_snapshot<T: Serialize>(cache_key: &str, payload: &T) {
     write_snapshot_in(&base_dir, cache_key, payload);
 }
 
-fn read_snapshot_in<T: DeserializeOwned>(base_dir: &Path, cache_key: &str) -> Option<(Duration, T)> {
+fn read_snapshot_in<T: DeserializeOwned>(
+    base_dir: &Path,
+    cache_key: &str,
+) -> Option<(Duration, T)> {
     let path = snapshot_path(base_dir, cache_key);
     let bytes = match fs::read(&path) {
         Ok(bytes) => bytes,
@@ -108,10 +111,7 @@ fn write_snapshot_in<T: Serialize>(base_dir: &Path, cache_key: &str, payload: &T
     };
 
     if let Err(err) = fs::create_dir_all(base_dir) {
-        eprintln!(
-            "[CostCache] failed to create {}: {err}",
-            base_dir.display()
-        );
+        eprintln!("[CostCache] failed to create {}: {err}", base_dir.display());
         return;
     }
     let path = snapshot_path(base_dir, cache_key);


### PR DESCRIPTION
## Summary

Apply the canonical Rust formatting to the two cost service files reported by the default-branch Verify workflow.

## Root cause

The code was functionally passing, but its import ordering and multiline formatting differed from cargo fmt output.

## Validation

- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- git diff --check