### PR TITLE
Add Codex weekly quota projection via ccstats

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ QuotaBar is a Tauri v2 menubar app for monitoring Claude Code, Codex, Cursor, an
 - Overview: glass popover shell with provider summary tiles and real-data quota windows.
 - Provider switcher: overview plus full-name cards for Claude, Codex, Cursor, and Antigravity.
 - Claude quota: 5-hour, 7-day, Opus, Sonnet, and Claude Design windows.
-- Codex quota: short and weekly ChatGPT usage windows, with reset times shown as days plus hours when available.
+- Codex quota: short and weekly ChatGPT usage windows, plus a local weekly pace projection sourced from Codex CLI session data.
 - Cursor quota: signed-in Cursor usage and request-limit windows when session data is available.
 - Antigravity panel: placeholder provider status while quota tracking is pending.
 - Local cost tracking: today, week, and month estimates for Claude Code, Codex, and Cursor.

--- a/scripts/check_latest_request_wiring.mjs
+++ b/scripts/check_latest_request_wiring.mjs
@@ -32,6 +32,17 @@ const owner_configs = [
     },
   },
   {
+    path: 'src/components/CodexPanel.tsx',
+    component_name: 'CodexPanel',
+    function_name: 'fetchWeeklyQuota',
+    owner_name: 'weekly_request_generation',
+    backend_methods: ['getCodexWeeklyQuota'],
+    loading: false,
+    await_kind: 'direct',
+    target_scope: 'component',
+    backend_arguments: { getCodexWeeklyQuota: [] },
+  },
+  {
     path: 'src/components/CursorPanel.tsx',
     component_name: 'CursorPanel',
     function_name: 'fetchData',

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -454,8 +454,8 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.2.65"
-source = "git+https://github.com/majiayu000/ccstats.git?rev=7dbfad0ffc29277da22cd095db067e88982f3f12#7dbfad0ffc29277da22cd095db067e88982f3f12"
+version = "0.5.0"
+source = "git+https://github.com/majiayu000/ccstats.git?rev=16d06637c5dff8cf1d7c5b77b9d0168d26bc640f#16d06637c5dff8cf1d7c5b77b9d0168d26bc640f"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -464,7 +464,6 @@ dependencies = [
  "dirs 6.0.0",
  "glob",
  "rayon",
- "rusqlite",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -919,7 +918,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1103,7 +1102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1126,18 +1125,6 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1191,12 +1178,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1688,7 +1669,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -1696,18 +1677,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
-dependencies = [
- "hashbrown 0.16.1",
-]
 
 [[package]]
 name = "heck"
@@ -2263,17 +2232,6 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3605,31 +3563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsqlite-vfs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
-dependencies = [
- "hashbrown 0.16.1",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
-dependencies = [
- "bitflags 2.11.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
- "sqlite-wasm-rs",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,7 +3581,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4107,18 +4040,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
-dependencies = [
- "cc",
- "js-sys",
- "rsqlite-vfs",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4603,7 +4524,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5470,7 +5391,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -454,8 +454,28 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
+version = "0.2.65"
+source = "git+https://github.com/majiayu000/ccstats.git?rev=7dbfad0ffc29277da22cd095db067e88982f3f12#7dbfad0ffc29277da22cd095db067e88982f3f12"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "clap",
+ "comfy-table",
+ "dirs 6.0.0",
+ "glob",
+ "rayon",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "toml 1.0.1+spec-1.1.0",
+ "ureq",
+]
+
+[[package]]
+name = "ccstats"
 version = "0.5.0"
-source = "git+https://github.com/majiayu000/ccstats.git?rev=16d06637c5dff8cf1d7c5b77b9d0168d26bc640f#16d06637c5dff8cf1d7c5b77b9d0168d26bc640f"
+source = "git+https://github.com/majiayu000/ccstats.git?rev=1067bba80d545f4307380609f5a2c51ab0f75fdf#1067bba80d545f4307380609f5a2c51ab0f75fdf"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1127,6 +1147,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1210,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1669,7 +1707,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1677,6 +1715,18 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
@@ -2232,6 +2282,17 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3228,7 +3289,8 @@ name = "quotabar"
 version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
- "ccstats",
+ "ccstats 0.2.65",
+ "ccstats 0.5.0",
  "chrono",
  "dirs 5.0.1",
  "image",
@@ -3560,6 +3622,31 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -4040,6 +4127,18 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 dirs = "5"
 image = { version = "0.25", default-features = false, features = ["png"] }
 once_cell = "1.19"
-ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "7dbfad0ffc29277da22cd095db067e88982f3f12" }
+ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "16d06637c5dff8cf1d7c5b77b9d0168d26bc640f" }
 tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,8 @@ base64 = "0.22"
 dirs = "5"
 image = { version = "0.25", default-features = false, features = ["png"] }
 once_cell = "1.19"
-ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "16d06637c5dff8cf1d7c5b77b9d0168d26bc640f" }
+ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "7dbfad0ffc29277da22cd095db067e88982f3f12" }
+ccstats-quota = { package = "ccstats", git = "https://github.com/majiayu000/ccstats.git", rev = "1067bba80d545f4307380609f5a2c51ab0f75fdf" }
 tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,7 +2,8 @@ use tauri::{AppHandle, State};
 
 use crate::{
     domain::models::{
-        AntigravityData, CodexData, CodexRateLimits, CodexResetCredits, CursorData, QuotaData,
+        AntigravityData, CodexData, CodexRateLimits, CodexResetCredits, CodexWeeklyQuotaData,
+        CursorData, QuotaData,
     },
     services::{antigravity, claude, codex, cost, cursor, link, tray, tray_icon, window},
 };
@@ -25,6 +26,24 @@ pub async fn get_codex_rate_limits() -> Result<CodexRateLimits, String> {
 #[tauri::command]
 pub async fn get_codex_reset_credits() -> Result<CodexResetCredits, String> {
     Ok(codex::fetch_codex_reset_credits().await)
+}
+
+#[tauri::command]
+pub async fn get_codex_weekly_quota() -> Result<CodexWeeklyQuotaData, String> {
+    let Some(codex_home) = codex::get_codex_home() else {
+        return Ok(CodexWeeklyQuotaData::unavailable(
+            "Could not find the Codex home directory",
+        ));
+    };
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        ccstats_quota::load_codex_weekly_quota(Some(&codex_home))
+    })
+    .await
+    .map_err(|err| format!("Codex weekly quota task failed: {err}"))?;
+    Ok(match result {
+        Ok(quota) => CodexWeeklyQuotaData::available(quota),
+        Err(err) => CodexWeeklyQuotaData::unavailable(err.to_string()),
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -148,6 +148,62 @@ pub struct CodexResetCredits {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexWeeklyQuota {
+    #[serde(rename = "observedAt")]
+    pub observed_at: String,
+    #[serde(rename = "resetsAt")]
+    pub resets_at: String,
+    #[serde(rename = "estimatedDepletionAt")]
+    pub estimated_depletion_at: Option<String>,
+    #[serde(rename = "windowMinutes")]
+    pub window_minutes: i64,
+    #[serde(rename = "usedPct")]
+    pub used_pct: f64,
+    #[serde(rename = "remainingPct")]
+    pub remaining_pct: f64,
+    #[serde(rename = "projectedPctAtReset")]
+    pub projected_pct_at_reset: f64,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexWeeklyQuotaData {
+    pub quota: Option<CodexWeeklyQuota>,
+    pub error: Option<String>,
+}
+
+impl CodexWeeklyQuotaData {
+    pub fn available(quota: ccstats_quota::CodexWeeklyQuota) -> Self {
+        Self {
+            quota: Some(CodexWeeklyQuota::from(quota)),
+            error: None,
+        }
+    }
+
+    pub fn unavailable(error: impl Into<String>) -> Self {
+        Self {
+            quota: None,
+            error: Some(error.into()),
+        }
+    }
+}
+
+impl From<ccstats_quota::CodexWeeklyQuota> for CodexWeeklyQuota {
+    fn from(quota: ccstats_quota::CodexWeeklyQuota) -> Self {
+        Self {
+            observed_at: quota.observed_at.to_rfc3339(),
+            resets_at: quota.resets_at.to_rfc3339(),
+            estimated_depletion_at: quota.estimated_depletion_at.map(|value| value.to_rfc3339()),
+            window_minutes: quota.window_minutes,
+            used_pct: quota.used_pct,
+            remaining_pct: quota.remaining_pct,
+            projected_pct_at_reset: quota.projected_pct_at_reset,
+            status: quota.status.as_str().to_string(),
+        }
+    }
+}
+
 impl CodexResetCredits {
     pub fn disconnected(error: impl Into<String>) -> Self {
         Self {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() {
             commands::get_codex_info,
             commands::get_codex_rate_limits,
             commands::get_codex_reset_credits,
+            commands::get_codex_weekly_quota,
             commands::get_cursor_info,
             commands::get_antigravity_info,
             commands::get_cost_overview,

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -52,8 +52,12 @@ fn log_msg(msg: &str) {
     }
 }
 
-fn get_codex_home() -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(".codex"))
+pub(crate) fn get_codex_home() -> Option<PathBuf> {
+    match std::env::var_os("CODEX_HOME") {
+        Some(home) if !home.is_empty() => Some(PathBuf::from(home)),
+        Some(_) => None,
+        None => dirs::home_dir().map(|home| home.join(".codex")),
+    }
 }
 
 fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {

--- a/src-tauri/src/services/cost.rs
+++ b/src-tauri/src/services/cost.rs
@@ -541,14 +541,10 @@ mod tests {
             currency: "USD".to_string(),
             cost: None,
             cost_usd: None,
-            estimated_cost: None,
-            estimated_cost_usd: None,
-            cost_kind: "real".to_string(),
             tokens: TokenBreakdown::default(),
             models: Vec::new(),
             valid_entries,
             skipped_entries: 0,
-            parse_error_entries: 0,
             elapsed_ms: 12.0,
         }
     }

--- a/src-tauri/src/services/cost.rs
+++ b/src-tauri/src/services/cost.rs
@@ -541,10 +541,14 @@ mod tests {
             currency: "USD".to_string(),
             cost: None,
             cost_usd: None,
+            estimated_cost: None,
+            estimated_cost_usd: None,
+            cost_kind: "real".to_string(),
             tokens: TokenBreakdown::default(),
             models: Vec::new(),
             valid_entries,
             skipped_entries: 0,
+            parse_error_entries: 0,
             elapsed_ms: 12.0,
         }
     }

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -6,9 +6,11 @@ import ResetTimeline from './ResetTimeline';
 import SmartTip from './SmartTip';
 import type {
   CodexData,
+  CodexRateLimitWindow,
   CodexRateLimits,
   CodexResetCredit,
   CodexResetCredits,
+  CodexWeeklyQuota,
 } from '../types/models';
 import { buildCodexQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
 import { getAvailableResetCredits, getHighUsageTip } from '../services/detail_helpers';
@@ -89,6 +91,73 @@ function formatGrantDate(value?: string): string {
   });
 }
 
+function formatWeeklyQuotaStatus(status: CodexWeeklyQuota['status']): string {
+  switch (status) {
+    case 'on_track':
+      return 'On track';
+    case 'watch':
+      return 'Watch pace';
+    case 'likely_exhausted':
+      return 'Likely to exhaust';
+    case 'exhausted':
+      return 'Exhausted';
+  }
+}
+
+function formatProjectionTime(value?: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function validateWeeklyQuotaWindow(
+  quota: CodexWeeklyQuota,
+  official?: CodexRateLimits['secondary'],
+): string | null {
+  if (!official) return 'The official weekly quota window is unavailable.';
+  if (!Number.isFinite(official.windowMinutes) || (official.windowMinutes ?? 0) <= 0) {
+    return 'The official weekly window length is unavailable.';
+  }
+  if (official.windowMinutes !== quota.windowMinutes) {
+    return 'The local pace snapshot does not match the official weekly window.';
+  }
+  const officialReset = official.resetsAt;
+  if (!Number.isFinite(officialReset) || (officialReset ?? 0) <= 0) {
+    return 'The official weekly reset time is unavailable.';
+  }
+  const localReset = Date.parse(quota.resetsAt) / 1000;
+  if (!Number.isFinite(localReset) || localReset <= 0) {
+    return 'The local pace snapshot has an invalid reset time.';
+  }
+  if (Math.abs(localReset - (officialReset ?? 0)) > 5 * 60) {
+    return 'The local pace snapshot does not match the current official reset.';
+  }
+  return null;
+}
+
+function selectOfficialWeeklyWindow(
+  limits: CodexRateLimits | null,
+  quota: CodexWeeklyQuota | null,
+): CodexRateLimitWindow | undefined {
+  const candidates = [limits?.secondary, limits?.primary].filter(
+    (window): window is CodexRateLimitWindow => window != null,
+  );
+  if (quota) {
+    const exact = candidates.find((window) => window.windowMinutes === quota.windowMinutes);
+    if (exact) return exact;
+  }
+  return candidates.find((window) => window.windowMinutes === 10_080)
+    ?? limits?.secondary
+    ?? limits?.primary;
+}
+
 const BONUS_EXPIRY_REMINDER_DAYS = 3;
 
 function getDaysLeft(value?: string): number | null {
@@ -148,15 +217,35 @@ export default function CodexPanel({
   const [codexData, setCodexData] = useState<CodexData | null>(null);
   const [rateLimits, setRateLimits] = useState<CodexRateLimits | null>(null);
   const [resetCredits, setResetCredits] = useState<CodexResetCredits | null>(null);
+  const [weeklyQuota, setWeeklyQuota] = useState<CodexWeeklyQuota | null>(null);
+  const [weeklyQuotaError, setWeeklyQuotaError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const request_generation = useLatestRequestGeneration();
+  const weekly_request_generation = useLatestRequestGeneration();
+
+  const fetchWeeklyQuota = useCallback(async () => {
+    const generation = weekly_request_generation.begin();
+    try {
+      const weekly = await backend.getCodexWeeklyQuota();
+      if (!weekly_request_generation.isCurrent(generation)) return;
+      setWeeklyQuota(weekly.quota ?? null);
+      setWeeklyQuotaError(weekly.error ?? null);
+    } catch (err) {
+      if (!weekly_request_generation.isCurrent(generation)) return;
+      setWeeklyQuota(null);
+      setWeeklyQuotaError(
+        err instanceof Error ? err.message : 'Failed to load local weekly pace',
+      );
+    }
+  }, [weekly_request_generation]);
 
   const fetchData = useCallback(async () => {
     const generation = request_generation.begin();
     try {
       setLoading(true);
       setError(null);
+      void fetchWeeklyQuota();
 
       const [info, limits, credits] = await Promise.all([
         backend.getCodexInfo(),
@@ -193,7 +282,7 @@ export default function CodexPanel({
         setLoading(false);
       }
     }
-  }, [onConnectionChange, onQuotaWindowsChange, onUsageChange, request_generation]);
+  }, [fetchWeeklyQuota, onConnectionChange, onQuotaWindowsChange, onUsageChange, request_generation]);
 
   useEffect(() => {
     fetchData();
@@ -238,6 +327,38 @@ export default function CodexPanel({
   const topWindow = sortMostConstrained(windows)[0];
   const availableResetCredits = getAvailableResetCredits(resetCredits);
   const bonusGrantGroups = buildBonusGrantGroups(availableResetCredits);
+  const officialWeeklyWindow = selectOfficialWeeklyWindow(rateLimits, weeklyQuota);
+  const weeklyQuotaValidationError = weeklyQuota
+    ? validateWeeklyQuotaWindow(weeklyQuota, officialWeeklyWindow)
+    : null;
+  const displayedWeeklyQuota = weeklyQuotaValidationError ? null : weeklyQuota;
+  const displayedWeeklyQuotaError = weeklyQuotaValidationError ?? weeklyQuotaError;
+  const renderWeeklyPace = (window: CodexRateLimitWindow) => {
+    if (window !== officialWeeklyWindow) return null;
+    const depletionTime = formatProjectionTime(displayedWeeklyQuota?.estimatedDepletionAt);
+    return (
+      <>
+        {displayedWeeklyQuota && (
+          <>
+            <span className={`quota-pace ${displayedWeeklyQuota.status !== 'on_track' ? 'warning' : ''}`}>
+              Local pace: {formatWeeklyQuotaStatus(displayedWeeklyQuota.status)} · projected{' '}
+              {Math.round(displayedWeeklyQuota.projectedPctAtReset)}% at reset
+            </span>
+            {depletionTime && (
+              <span className="quota-pace warning">
+                Estimated depletion: {depletionTime}
+              </span>
+            )}
+          </>
+        )}
+        {!displayedWeeklyQuota && displayedWeeklyQuotaError && (
+          <span className="quota-pace warning">
+            Local pace unavailable: {displayedWeeklyQuotaError}
+          </span>
+        )}
+      </>
+    );
+  };
 
   return (
     <div className="codex-panel">
@@ -297,6 +418,7 @@ export default function CodexPanel({
                         </span>
                       ) : null;
                     })()}
+                    {renderWeeklyPace(rateLimits.primary)}
                   </div>
                 )}
 
@@ -322,6 +444,7 @@ export default function CodexPanel({
                         <span>{formatResetAt(rateLimits.secondary.resetsAt)}</span>
                       </div>
                     )}
+                    {renderWeeklyPace(rateLimits.secondary)}
                   </div>
                 )}
 

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -139,6 +139,20 @@ function validateWeeklyQuotaWindow(
   if (Math.abs(localReset - (officialReset ?? 0)) > 5 * 60) {
     return 'The local pace snapshot does not match the current official reset.';
   }
+  const observedAt = Date.parse(quota.observedAt);
+  const now = Date.now();
+  if (!Number.isFinite(observedAt)) {
+    return 'The local pace snapshot has an invalid observation time.';
+  }
+  if (observedAt > now + 5 * 60 * 1000) {
+    return 'The local pace snapshot is dated in the future.';
+  }
+  if (now - observedAt > 30 * 60 * 1000) {
+    return 'The local pace snapshot is older than 30 minutes.';
+  }
+  if (Math.abs(quota.usedPct - official.usedPercent) > 1) {
+    return 'The local pace usage does not match the current official usage.';
+  }
   return null;
 }
 

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -4,6 +4,7 @@ import type {
   CodexData,
   CodexRateLimits,
   CodexResetCredits,
+  CodexWeeklyQuotaData,
   CostDailySeries,
   CostOverview,
   CostSource,
@@ -42,6 +43,10 @@ export const backend = {
 
   getCodexResetCredits() {
     return invokeBackend<CodexResetCredits>('get_codex_reset_credits');
+  },
+
+  getCodexWeeklyQuota() {
+    return invokeBackend<CodexWeeklyQuotaData>('get_codex_weekly_quota');
   },
 
   getCursorInfo() {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -60,6 +60,24 @@ export interface CodexResetCredits {
   error?: string;
 }
 
+export type CodexQuotaStatus = 'on_track' | 'watch' | 'likely_exhausted' | 'exhausted';
+
+export interface CodexWeeklyQuota {
+  observedAt: string;
+  resetsAt: string;
+  estimatedDepletionAt?: string;
+  windowMinutes: number;
+  usedPct: number;
+  remainingPct: number;
+  projectedPctAtReset: number;
+  status: CodexQuotaStatus;
+}
+
+export interface CodexWeeklyQuotaData {
+  quota?: CodexWeeklyQuota;
+  error?: string;
+}
+
 export interface CursorData {
   connected: boolean;
   planType?: string;

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -324,7 +324,7 @@ describe('Codex weekly pace', () => {
   it('renders the ccstats projection in the weekly quota card', async () => {
     const renderer = await render_codex({
       quota: {
-        observedAt: '2026-08-22T00:00:00Z',
+        observedAt: new Date().toISOString(),
         resetsAt: '2026-08-29T00:00:00Z',
         estimatedDepletionAt: '2026-08-27T12:00:00Z',
         windowMinutes: 10_080,
@@ -364,7 +364,7 @@ describe('Codex weekly pace', () => {
   it('fails closed when official weekly timing metadata is missing', async () => {
     const renderer = await render_codex({
       quota: {
-        observedAt: '2026-08-22T00:00:00Z',
+        observedAt: new Date().toISOString(),
         resetsAt: '2026-08-29T00:00:00Z',
         windowMinutes: 10_080,
         usedPct: 40,
@@ -383,7 +383,7 @@ describe('Codex weekly pace', () => {
   it('fails closed when the official weekly reset is missing', async () => {
     const renderer = await render_codex({
       quota: {
-        observedAt: '2026-08-22T00:00:00Z',
+        observedAt: new Date().toISOString(),
         resetsAt: '2026-08-29T00:00:00Z',
         windowMinutes: 10_080,
         usedPct: 40,
@@ -401,7 +401,7 @@ describe('Codex weekly pace', () => {
   it('renders weekly pace on a primary-slot weekly window', async () => {
     const renderer = await render_codex({
       quota: {
-        observedAt: '2026-08-22T00:00:00Z',
+        observedAt: new Date().toISOString(),
         resetsAt: '2026-08-29T00:00:00Z',
         windowMinutes: 10_080,
         usedPct: 40,
@@ -424,7 +424,7 @@ describe('Codex weekly pace', () => {
   it('rejects a stale local reset without hiding official quota data', async () => {
     const renderer = await render_codex({
       quota: {
-        observedAt: '2026-08-22T00:00:00Z',
+        observedAt: new Date().toISOString(),
         resetsAt: '2026-08-30T00:00:00Z',
         windowMinutes: 10_080,
         usedPct: 40,
@@ -436,6 +436,42 @@ describe('Codex weekly pace', () => {
 
     expect(rendered_text(renderer)).toContain('40%');
     expect(rendered_text(renderer)).toContain('does not match the current official reset');
+    expect(rendered_text(renderer)).not.toContain('projected');
+    await unmount(renderer);
+  });
+
+  it('rejects a stale local observation', async () => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: new Date(Date.now() - 31 * 60 * 1000).toISOString(),
+        resetsAt: '2026-08-29T00:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 40,
+        remainingPct: 60,
+        projectedPctAtReset: 75,
+        status: 'on_track',
+      },
+    });
+
+    expect(rendered_text(renderer)).toContain('older than 30 minutes');
+    expect(rendered_text(renderer)).not.toContain('projected');
+    await unmount(renderer);
+  });
+
+  it('rejects local usage that diverges from official usage', async () => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: new Date().toISOString(),
+        resetsAt: '2026-08-29T00:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 30,
+        remainingPct: 70,
+        projectedPctAtReset: 60,
+        status: 'on_track',
+      },
+    });
+
+    expect(rendered_text(renderer)).toContain('does not match the current official usage');
     expect(rendered_text(renderer)).not.toContain('projected');
     await unmount(renderer);
   });

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -12,6 +12,7 @@ import type {
   CodexData,
   CodexRateLimits,
   CodexResetCredits,
+  CodexWeeklyQuotaData,
   CostDailySeries,
   CostOverview,
   CursorData,
@@ -120,6 +121,7 @@ function codex_requests(): PanelRequests & { reject_member(index: number, member
   vi.spyOn(backend, 'getCodexInfo').mockImplementation(() => get_bundle(info_index++).info.promise);
   vi.spyOn(backend, 'getCodexRateLimits').mockImplementation(() => get_bundle(limits_index++).limits.promise);
   vi.spyOn(backend, 'getCodexResetCredits').mockImplementation(() => get_bundle(credits_index++).credits.promise);
+  vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
   return {
     reject: (index, reason) => get_bundle(index).info.reject(reason),
     reject_member: (index, member, reason) => get_bundle(index)[member].reject(reason),
@@ -283,11 +285,168 @@ describe('Codex atomic bundle failures', () => {
   }
 });
 
+describe('Codex weekly pace', () => {
+  async function render_codex(
+    weekly: CodexWeeklyQuotaData | Error,
+    secondary: CodexRateLimits['secondary'] | null = {
+      usedPercent: 40,
+      windowMinutes: 10_080,
+      resetsAt: 1_787_961_600,
+    },
+    primary?: CodexRateLimits['primary'],
+  ): Promise<ReactTestRenderer> {
+    vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true });
+    vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({
+      connected: true,
+      primary,
+      secondary: secondary ?? undefined,
+    });
+    vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({
+      connected: true,
+      availableCount: 0,
+      credits: [],
+    });
+    const weeklyRequest = vi.spyOn(backend, 'getCodexWeeklyQuota');
+    if (weekly instanceof Error) weeklyRequest.mockRejectedValue(weekly);
+    else weeklyRequest.mockResolvedValue(weekly);
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    return renderer;
+  }
+
+  it('renders the ccstats projection in the weekly quota card', async () => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: '2026-08-22T00:00:00Z',
+        resetsAt: '2026-08-29T00:00:00Z',
+        estimatedDepletionAt: '2026-08-27T12:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 40,
+        remainingPct: 60,
+        projectedPctAtReset: 112.4,
+        status: 'likely_exhausted',
+      },
+    });
+
+    expect(rendered_text(renderer)).toContain('Likely to exhaust');
+    expect(rendered_text(renderer)).toContain('projected');
+    expect(rendered_text(renderer)).toContain('112');
+    expect(rendered_text(renderer)).toContain('% at reset');
+    expect(rendered_text(renderer)).toContain('Estimated depletion');
+    await unmount(renderer);
+  });
+
+  it('shows a local pace error without hiding official quota data', async () => {
+    const renderer = await render_codex({ error: 'Start a Codex CLI session to refresh rate-limit data.' });
+
+    expect(rendered_text(renderer)).toContain('40%');
+    expect(rendered_text(renderer)).toContain('Local pace unavailable');
+    expect(rendered_text(renderer)).toContain('Start a Codex CLI session');
+    await unmount(renderer);
+  });
+
+  it('isolates a weekly IPC rejection from official quota data', async () => {
+    const renderer = await render_codex(new Error('weekly IPC failed'));
+
+    expect(rendered_text(renderer)).toContain('40%');
+    expect(rendered_text(renderer)).toContain('Local pace unavailable');
+    expect(rendered_text(renderer)).toContain('weekly IPC failed');
+    await unmount(renderer);
+  });
+
+  it('fails closed when official weekly timing metadata is missing', async () => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: '2026-08-22T00:00:00Z',
+        resetsAt: '2026-08-29T00:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 40,
+        remainingPct: 60,
+        projectedPctAtReset: 90,
+        status: 'on_track',
+      },
+    }, { usedPercent: 40 });
+
+    expect(rendered_text(renderer)).toContain('40%');
+    expect(rendered_text(renderer)).toContain('official weekly window length is unavailable');
+    expect(rendered_text(renderer)).not.toContain('projected');
+    await unmount(renderer);
+  });
+
+  it('fails closed when the official weekly reset is missing', async () => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: '2026-08-22T00:00:00Z',
+        resetsAt: '2026-08-29T00:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 40,
+        remainingPct: 60,
+        projectedPctAtReset: 90,
+        status: 'on_track',
+      },
+    }, { usedPercent: 40, windowMinutes: 10_080 });
+
+    expect(rendered_text(renderer)).toContain('official weekly reset time is unavailable');
+    expect(rendered_text(renderer)).not.toContain('projected');
+    await unmount(renderer);
+  });
+
+  it('renders weekly pace on a primary-slot weekly window', async () => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: '2026-08-22T00:00:00Z',
+        resetsAt: '2026-08-29T00:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 40,
+        remainingPct: 60,
+        projectedPctAtReset: 75,
+        status: 'on_track',
+      },
+    }, null, {
+      usedPercent: 40,
+      windowMinutes: 10_080,
+      resetsAt: 1_787_961_600,
+    });
+
+    expect(rendered_text(renderer)).toContain('Local pace');
+    expect(rendered_text(renderer)).toContain('75');
+    expect(rendered_text(renderer)).toContain('% at reset');
+    await unmount(renderer);
+  });
+
+  it('rejects a stale local reset without hiding official quota data', async () => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: '2026-08-22T00:00:00Z',
+        resetsAt: '2026-08-30T00:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 40,
+        remainingPct: 60,
+        projectedPctAtReset: 90,
+        status: 'on_track',
+      },
+    });
+
+    expect(rendered_text(renderer)).toContain('40%');
+    expect(rendered_text(renderer)).toContain('does not match the current official reset');
+    expect(rendered_text(renderer)).not.toContain('projected');
+    await unmount(renderer);
+  });
+});
+
 function install_app_backend(quota_requests: Array<Deferred<QuotaData>>): void {
   vi.spyOn(backend, 'getQuota').mockImplementation(() => quota_requests.shift()!.promise);
   vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true });
   vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({ connected: true });
   vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({ connected: true, availableCount: 0, credits: [] });
+  vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
   vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({ connected: true });
   vi.spyOn(backend, 'getAntigravityInfo').mockResolvedValue({ connected: false, status: 'pending' });
   vi.spyOn(backend, 'setDockVisibility').mockResolvedValue(undefined);

--- a/tests/switcher_visibility_transactions.test.tsx
+++ b/tests/switcher_visibility_transactions.test.tsx
@@ -129,6 +129,7 @@ beforeEach(() => {
   vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true });
   vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({ connected: true });
   vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({ connected: true, availableCount: 0, credits: [] });
+  vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
   vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({ connected: true });
   vi.spyOn(backend, 'getAntigravityInfo').mockResolvedValue({ connected: false, status: 'pending' });
   vi.spyOn(backend, 'getCostOverview').mockImplementation(async (source) => ({


### PR DESCRIPTION
## Summary

- add the merged ccstats 0.5 weekly quota SDK as a dedicated dependency
- show Codex weekly pace, projected usage at reset, and estimated depletion in the matching official quota card
- keep the existing ccstats 0.2.65 cost path so Cursor local cost behavior does not regress
- isolate weekly snapshot failures from official Codex quota and fail closed on home/window/reset mismatches
- honor CODEX_HOME consistently for Codex auth and local sessions

## Upstream

- Issue: majiayu000/ccstats#107
- SDK PR: majiayu000/ccstats#108 (merged as 1067bba)

## Validation

- npm test — 26 files, 348 tests passed
- npm run build
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml — 44 passed, 2 ignored
- git diff --check
- Codex CLI review findings fixed
- native thread review: no findings; safe to proceed

## Compatibility note

QuotaBar intentionally keeps cost summaries on ccstats 0.2.65. ccstats 0.5 changed Cursor costs to a remote API without a stable credential/error SDK contract for desktop embedding; the newer revision is therefore used only for the weekly quota SDK in this PR.