### PR TITLE
Bump QuotaBar release version to v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 - None.
 
-## 0.3.0 - 2026-08-22
+## 0.3.1 - 2026-08-22
 
 - Added a validated Codex weekly quota pace projection, including projected usage at reset, risk status, and estimated depletion time from the ccstats SDK.
 - Kept weekly pace failures isolated from official Codex quota data and rejected stale, cross-window, or divergent local snapshots instead of displaying misleading projections.
@@ -15,7 +15,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 - Reduced repeated local cost parsing with multi-range summaries and cached snapshots.
 - Removed sensitive Claude credential fragments from diagnostics and improved explicit browser-preview/backend error reporting.
 - Split legacy and redesigned stylesheets into smaller modules without changing their rendered output.
-- Updated the application version to 0.3.0 and refreshed macOS and Windows release artifacts.
+- Updated the application version to 0.3.1 and refreshed macOS and Windows release artifacts.
 
 ## 0.2.0 - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,19 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 - Added a validated Codex weekly quota pace projection, including projected usage at reset, risk status, and estimated depletion time from the ccstats SDK.
 - Kept weekly pace failures isolated from official Codex quota data and rejected stale, cross-window, or divergent local snapshots instead of displaying misleading projections.
-- Hardened concurrent provider refreshes, Codex authentication caching, notification delivery, popover visibility, and settings persistence against stale or silent failures.
-- Made provider switching and tray visibility updates transactional while preserving the latest user intent.
+- Hardened concurrent Codex refreshes and account-scoped quota caching against stale or partial state.
+- Made provider switcher transitions transactional and reduced unnecessary forced tray icon resynchronization.
 - Reduced repeated local cost parsing with multi-range summaries and cached snapshots.
-- Removed sensitive Claude credential fragments from diagnostics and improved explicit browser-preview/backend error reporting.
-- Split legacy and redesigned stylesheets into smaller modules without changing their rendered output.
 - Updated the application version to 0.3.1 and refreshed macOS and Windows release artifacts.
+
+## 0.3.0 - 2026-07-17
+
+- Surfaced settings storage read and write failures instead of silently degrading, including background-write failures.
+- Prevented stale provider refreshes from overwriting newer state and made popover visibility failures observable and fail closed.
+- Committed notification deduplication only after delivery and kept fatal frontend diagnostics safe and observable.
+- Removed sensitive Claude credential fragments from diagnostics, unused Codex stats wiring, and the obsolete priority price override.
+- Split legacy and redesigned stylesheets into smaller modules without changing their rendered output.
+- Created the annotated v0.3.0 source tag. No GitHub Release artifacts were published for this tag.
 
 ## 0.2.0 - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ QuotaBar is a Tauri v2 menubar app for monitoring Claude Code, Codex, Cursor, an
 
 ![QuotaBar browser preview without provider credentials](docs/assets/quotabar-no-provider-preview.png)
 
-This `v0.3.0` screenshot was refreshed on 2026-08-22 from the production React UI in browser preview without a Tauri desktop backend. It intentionally shows the default unavailable-backend state and includes no provider quota values, account identifiers, tokens, cookies, or sessions. Desktop widget and notification visuals are static design previews only until a runtime implementation ships. See `docs/demo-proof.md` for the capture scope and refresh steps.
+This `v0.3.1` screenshot was refreshed on 2026-08-22 from the production React UI in browser preview without a Tauri desktop backend. It intentionally shows the default unavailable-backend state and includes no provider quota values, account identifiers, tokens, cookies, or sessions. Desktop widget and notification visuals are static design previews only until a runtime implementation ships. See `docs/demo-proof.md` for the capture scope and refresh steps.
 
 ## Quota Semantics
 
@@ -129,9 +129,9 @@ Expected output locations:
 
 ## Release Artifacts
 
-The latest published release is [QuotaBar v0.3.0](https://github.com/majiayu000/quotabar/releases/tag/v0.3.0).
+The latest published release is [QuotaBar v0.3.1](https://github.com/majiayu000/quotabar/releases/tag/v0.3.1).
 
-The v0.3.0 macOS artifact is unsigned and not notarized. macOS may require users to approve the app in Privacy & Security before first launch.
+The v0.3.1 macOS artifact is unsigned and not notarized. macOS may require users to approve the app in Privacy & Security before first launch.
 
 Release candidates should be built by the `release-artifacts` GitHub Actions workflow or from a clean checkout, then attached manually to the matching GitHub release only after final human approval. The workflow uploads build artifacts for inspection; it does not publish a GitHub Release. See [docs/release.md](docs/release.md) for the release checklist.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Expected output locations:
 
 ## Release Artifacts
 
-The latest published release is [QuotaBar v0.3.1](https://github.com/majiayu000/quotabar/releases/tag/v0.3.1).
+The latest published release is available from [GitHub Releases](https://github.com/majiayu000/quotabar/releases/latest).
 
 The v0.3.1 macOS artifact is unsigned and not notarized. macOS may require users to approve the app in Privacy & Security before first launch.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quotabar",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quotabar",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",
         "@tauri-apps/plugin-notification": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quotabar",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "quotabar"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "ccstats 0.2.65",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quotabar"
-version = "0.3.0"
+version = "0.3.1"
 description = "Quota and cost monitor for Claude Code and Codex"
 authors = ["QuotaBar Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "QuotaBar",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.majiayu.quotabar",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- move the release version from 0.3.0 to 0.3.1 because the remote v0.3.0 tag already points to an older commit
- keep package, Tauri, Cargo, changelog, and README versions aligned

## Verification

- npm test: 350 passed
- npm run build
- npm audit: 0 vulnerabilities
- cargo fmt --check
- cargo check
- cargo test: 44 passed, 2 ignored
- git diff --check