### PR TITLE
Add Codex weekly API-equivalent value estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 ## Unreleased
 
 - Added Grok Build quota tracking: SuperGrok weekly/monthly pool, product mix, extra credits, and a per-provider tray.
+- Added Codex weekly API-equivalent USD and token estimates from the ccstats SDK,
+  while keeping estimate failures isolated from official quota and pace data.
 
 ## 0.3.1 - 2026-08-22
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
 [[package]]
 name = "ccstats"
 version = "0.5.0"
-source = "git+https://github.com/majiayu000/ccstats.git?rev=1067bba80d545f4307380609f5a2c51ab0f75fdf#1067bba80d545f4307380609f5a2c51ab0f75fdf"
+source = "git+https://github.com/majiayu000/ccstats.git?rev=ad50478776da6d464caf5e2f7676b931acb8ff02#ad50478776da6d464caf5e2f7676b931acb8ff02"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ dirs = "5"
 image = { version = "0.25", default-features = false, features = ["png"] }
 once_cell = "1.19"
 ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "7dbfad0ffc29277da22cd095db067e88982f3f12" }
-ccstats-quota = { package = "ccstats", git = "https://github.com/majiayu000/ccstats.git", rev = "1067bba80d545f4307380609f5a2c51ab0f75fdf" }
+ccstats-quota = { package = "ccstats", git = "https://github.com/majiayu000/ccstats.git", rev = "ad50478776da6d464caf5e2f7676b931acb8ff02" }
 tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,7 +5,9 @@ use crate::{
         AntigravityData, CodexData, CodexRateLimits, CodexResetCredits, CodexWeeklyQuotaData,
         CursorData, GrokData, QuotaData,
     },
-    services::{antigravity, claude, codex, cost, cursor, grok, link, tray, tray_icon, window},
+    services::{
+        antigravity, claude, codex, codex_weekly, cost, cursor, grok, link, tray, tray_icon, window,
+    },
 };
 
 #[tauri::command]
@@ -35,15 +37,19 @@ pub async fn get_codex_weekly_quota() -> Result<CodexWeeklyQuotaData, String> {
             "Could not find the Codex home directory",
         ));
     };
-    let result = tauri::async_runtime::spawn_blocking(move || {
-        ccstats_quota::load_codex_weekly_quota(Some(&codex_home))
-    })
-    .await
-    .map_err(|err| format!("Codex weekly quota task failed: {err}"))?;
-    Ok(match result {
-        Ok(quota) => CodexWeeklyQuotaData::available(quota),
-        Err(err) => CodexWeeklyQuotaData::unavailable(err.to_string()),
-    })
+    let data =
+        tauri::async_runtime::spawn_blocking(move || match ccstats_quota::load_codex_weekly_quota(
+            Some(&codex_home),
+        ) {
+            Ok(quota) => {
+                let value_estimate = codex_weekly::estimate_codex_weekly_value(&codex_home, &quota);
+                CodexWeeklyQuotaData::available(quota, value_estimate)
+            }
+            Err(error) => CodexWeeklyQuotaData::unavailable(error.to_string()),
+        })
+        .await
+        .map_err(|err| format!("Codex weekly quota task failed: {err}"))?;
+    Ok(data)
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -168,15 +168,48 @@ pub struct CodexWeeklyQuota {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CodexWeeklyValueEstimate {
+    #[serde(rename = "observedAt")]
+    pub observed_at: String,
+    #[serde(rename = "windowStartedAt")]
+    pub window_started_at: String,
+    #[serde(rename = "resetsAt")]
+    pub resets_at: String,
+    #[serde(rename = "usedPct")]
+    pub used_pct: f64,
+    #[serde(rename = "observedCostUsd")]
+    pub observed_cost_usd: f64,
+    #[serde(rename = "estimatedWeeklyValueUsd")]
+    pub estimated_weekly_value_usd: f64,
+    #[serde(rename = "observedTokens")]
+    pub observed_tokens: i64,
+    #[serde(rename = "estimatedWeeklyTokens")]
+    pub estimated_weekly_tokens: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CodexWeeklyQuotaData {
     pub quota: Option<CodexWeeklyQuota>,
+    #[serde(rename = "valueEstimate")]
+    pub value_estimate: Option<CodexWeeklyValueEstimate>,
+    #[serde(rename = "valueEstimateError")]
+    pub value_estimate_error: Option<String>,
     pub error: Option<String>,
 }
 
 impl CodexWeeklyQuotaData {
-    pub fn available(quota: ccstats_quota::CodexWeeklyQuota) -> Self {
+    pub fn available(
+        quota: ccstats_quota::CodexWeeklyQuota,
+        value_estimate: Result<ccstats_quota::CodexWeeklyValueEstimate, String>,
+    ) -> Self {
+        let (value_estimate, value_estimate_error) = match value_estimate {
+            Ok(estimate) => (Some(CodexWeeklyValueEstimate::from(estimate)), None),
+            Err(error) => (None, Some(error.to_string())),
+        };
         Self {
             quota: Some(CodexWeeklyQuota::from(quota)),
+            value_estimate,
+            value_estimate_error,
             error: None,
         }
     }
@@ -184,7 +217,24 @@ impl CodexWeeklyQuotaData {
     pub fn unavailable(error: impl Into<String>) -> Self {
         Self {
             quota: None,
+            value_estimate: None,
+            value_estimate_error: None,
             error: Some(error.into()),
+        }
+    }
+}
+
+impl From<ccstats_quota::CodexWeeklyValueEstimate> for CodexWeeklyValueEstimate {
+    fn from(estimate: ccstats_quota::CodexWeeklyValueEstimate) -> Self {
+        Self {
+            observed_at: estimate.observed_at.to_rfc3339(),
+            window_started_at: estimate.window_started_at.to_rfc3339(),
+            resets_at: estimate.resets_at.to_rfc3339(),
+            used_pct: estimate.used_pct,
+            observed_cost_usd: estimate.observed_cost_usd,
+            estimated_weekly_value_usd: estimate.estimated_weekly_value_usd,
+            observed_tokens: estimate.observed_tokens,
+            estimated_weekly_tokens: estimate.estimated_weekly_tokens,
         }
     }
 }

--- a/src-tauri/src/services/codex_weekly.rs
+++ b/src-tauri/src/services/codex_weekly.rs
@@ -1,0 +1,139 @@
+//! Cached Codex weekly value estimates powered by the `ccstats` SDK.
+
+use once_cell::sync::Lazy;
+use std::{
+    path::{Path, PathBuf},
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+const SUCCESS_CACHE_TTL: Duration = Duration::from_secs(300);
+const ERROR_CACHE_TTL: Duration = Duration::from_secs(60);
+
+type WeeklyValueResult = Result<ccstats_quota::CodexWeeklyValueEstimate, String>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WeeklyQuotaIdentity {
+    observed_at: chrono::DateTime<chrono::Utc>,
+    resets_at: chrono::DateTime<chrono::Utc>,
+    used_pct_bits: u64,
+}
+
+impl From<&ccstats_quota::CodexWeeklyQuota> for WeeklyQuotaIdentity {
+    fn from(quota: &ccstats_quota::CodexWeeklyQuota) -> Self {
+        Self {
+            observed_at: quota.observed_at,
+            resets_at: quota.resets_at,
+            used_pct_bits: quota.used_pct.to_bits(),
+        }
+    }
+}
+
+impl WeeklyQuotaIdentity {
+    fn matches_estimate(&self, estimate: &ccstats_quota::CodexWeeklyValueEstimate) -> bool {
+        self.observed_at == estimate.observed_at
+            && self.resets_at == estimate.resets_at
+            && self.used_pct_bits == estimate.used_pct.to_bits()
+    }
+}
+
+#[derive(Clone)]
+struct CachedWeeklyValue {
+    codex_home: PathBuf,
+    quota: WeeklyQuotaIdentity,
+    inserted_at: Instant,
+    result: WeeklyValueResult,
+}
+
+static WEEKLY_VALUE_CACHE: Lazy<Mutex<Option<CachedWeeklyValue>>> = Lazy::new(|| Mutex::new(None));
+
+fn cache_ttl(result: &WeeklyValueResult) -> Duration {
+    if result.is_ok() {
+        SUCCESS_CACHE_TTL
+    } else {
+        ERROR_CACHE_TTL
+    }
+}
+
+pub fn estimate_codex_weekly_value(
+    codex_home: &Path,
+    quota: &ccstats_quota::CodexWeeklyQuota,
+) -> WeeklyValueResult {
+    let quota_identity = WeeklyQuotaIdentity::from(quota);
+    let mut cache = WEEKLY_VALUE_CACHE
+        .lock()
+        .map_err(|error| format!("Codex weekly value cache unavailable: {error}"))?;
+
+    if let Some(cached) = cache.as_ref() {
+        if cached.codex_home == codex_home
+            && cached.quota == quota_identity
+            && cached.inserted_at.elapsed() < cache_ttl(&cached.result)
+        {
+            return cached.result.clone();
+        }
+    }
+
+    let result = ccstats_quota::estimate_codex_weekly_value(Some(codex_home), true, false)
+        .map_err(|error| error.to_string())
+        .and_then(|estimate| {
+            if quota_identity.matches_estimate(&estimate) {
+                Ok(estimate)
+            } else {
+                Err(
+                    "Codex weekly quota changed while estimating its local value; refresh to retry"
+                        .to_string(),
+                )
+            }
+        });
+    *cache = Some(CachedWeeklyValue {
+        codex_home: codex_home.to_path_buf(),
+        quota: quota_identity,
+        inserted_at: Instant::now(),
+        result: result.clone(),
+    });
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn estimate() -> ccstats_quota::CodexWeeklyValueEstimate {
+        ccstats_quota::CodexWeeklyValueEstimate {
+            observed_at: chrono::DateTime::UNIX_EPOCH,
+            window_started_at: chrono::DateTime::UNIX_EPOCH,
+            resets_at: chrono::DateTime::UNIX_EPOCH + chrono::Duration::days(7),
+            used_pct: 25.0,
+            observed_cost_usd: 50.0,
+            estimated_weekly_value_usd: 200.0,
+            observed_tokens: 1_000,
+            estimated_weekly_tokens: 4_000.0,
+            valid_entries: 1,
+            dedup_skipped_entries: 0,
+        }
+    }
+
+    fn identity(used_pct: f64) -> WeeklyQuotaIdentity {
+        WeeklyQuotaIdentity {
+            observed_at: chrono::DateTime::UNIX_EPOCH,
+            resets_at: chrono::DateTime::UNIX_EPOCH + chrono::Duration::days(7),
+            used_pct_bits: used_pct.to_bits(),
+        }
+    }
+
+    #[test]
+    fn successful_estimates_live_longer_than_errors() {
+        let estimate = estimate();
+
+        assert_eq!(cache_ttl(&Ok(estimate)), SUCCESS_CACHE_TTL);
+        assert_eq!(cache_ttl(&Err("unavailable".to_string())), ERROR_CACHE_TTL);
+    }
+
+    #[test]
+    fn quota_identity_rejects_estimates_from_another_snapshot() {
+        let estimate = estimate();
+
+        assert!(identity(25.0).matches_estimate(&estimate));
+        assert!(!identity(30.0).matches_estimate(&estimate));
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -2,6 +2,7 @@ pub mod antigravity;
 pub mod claude;
 pub mod codex;
 mod codex_cache;
+pub mod codex_weekly;
 pub mod cost;
 mod cost_disk_cache;
 pub mod cursor;

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -92,19 +92,6 @@ function formatGrantDate(value?: string): string {
   });
 }
 
-function formatWeeklyQuotaStatus(status: CodexWeeklyQuota['status']): string {
-  switch (status) {
-    case 'on_track':
-      return 'On track';
-    case 'watch':
-      return 'Watch pace';
-    case 'likely_exhausted':
-      return 'Likely to exhaust';
-    case 'exhausted':
-      return 'Exhausted';
-  }
-}
-
 const USD_FORMAT = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
@@ -414,21 +401,14 @@ export default function CodexPanel({
     ?? weeklyValueEstimateError;
   const renderWeeklyPace = (window: CodexRateLimitWindow) => {
     if (window !== officialWeeklyWindow) return null;
-    return (
-      <>
-        {displayedWeeklyQuota && (
-          <span className={`quota-pace ${displayedWeeklyQuota.status !== 'on_track' ? 'warning' : ''}`}>
-            Local pace: {formatWeeklyQuotaStatus(displayedWeeklyQuota.status)} · projected{' '}
-            {Math.round(displayedWeeklyQuota.projectedPctAtReset)}% at reset
-          </span>
-        )}
-        {!displayedWeeklyQuota && displayedWeeklyQuotaError && (
-          <span className="quota-pace warning">
-            Local pace unavailable: {displayedWeeklyQuotaError}
-          </span>
-        )}
-      </>
-    );
+    if (!displayedWeeklyQuota && displayedWeeklyQuotaError) {
+      return (
+        <span className="quota-pace warning">
+          Local pace unavailable: {displayedWeeklyQuotaError}
+        </span>
+      );
+    }
+    return null;
   };
 
   return (

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
-import { useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, type CSSProperties } from 'react';
 import { backend } from '../services/backend';
 import CostSummarySection from './CostSummarySection';
 import ProviderDetailHeader from './ProviderDetailHeader';
@@ -564,18 +563,43 @@ export default function CodexPanel({
                 <div className="quota-card weekly-value-card">
                   {displayedWeeklyValueEstimate ? (
                     <>
-                      <div className="quota-header">
-                        <span className="quota-label">API-equivalent week</span>
-                        <span className="quota-value">
-                          ≈{USD_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyValueUsd)}
+                      <div className="weekly-value-topline">
+                        <span className="weekly-value-title">
+                          <span className="weekly-value-dot" />
+                          API-equivalent week
                         </span>
+                        <span className="weekly-value-badge">Local estimate</span>
                       </div>
-                      <span className="quota-estimate-tokens">
-                        ≈{COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyTokens)} tokens at current mix
-                      </span>
-                      <span className="quota-estimate-note">
-                        Estimated from local usage · not an official allowance
-                      </span>
+                      <div className="weekly-value-body">
+                        <div className="weekly-value-metrics">
+                          <span className="weekly-value-amount">
+                          ≈{USD_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyValueUsd)}
+                          </span>
+                          <span className="weekly-value-token-row">
+                            <strong>
+                              ≈{COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyTokens)}
+                            </strong>
+                            <span>tokens at current mix</span>
+                          </span>
+                        </div>
+                        <div
+                          className="weekly-value-gauge"
+                          role="img"
+                          aria-label={`Estimate based on ${Math.round(displayedWeeklyValueEstimate.usedPct)}% used`}
+                          style={{
+                            '--weekly-value-used': `${Math.min(Math.max(displayedWeeklyValueEstimate.usedPct, 0), 100)}%`,
+                          } as CSSProperties}
+                        >
+                          <span className="weekly-value-gauge-center">
+                            <strong>{Math.round(displayedWeeklyValueEstimate.usedPct)}%</strong>
+                            <small>used</small>
+                          </span>
+                        </div>
+                      </div>
+                      <div className="weekly-value-footer">
+                        <span>Projected from local usage</span>
+                        <span>Not an official allowance</span>
+                      </div>
                     </>
                   ) : (
                     <span className="quota-pace warning">

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -12,6 +12,7 @@ import type {
   CodexResetCredit,
   CodexResetCredits,
   CodexWeeklyQuota,
+  CodexWeeklyValueEstimate,
 } from '../types/models';
 import { buildCodexQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
 import { getAvailableResetCredits, getHighUsageTip } from '../services/detail_helpers';
@@ -105,17 +106,56 @@ function formatWeeklyQuotaStatus(status: CodexWeeklyQuota['status']): string {
   }
 }
 
-function formatProjectionTime(value?: string): string | null {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  });
+const USD_FORMAT = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const COMPACT_TOKEN_FORMAT = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+
+function validateWeeklyValueEstimate(
+  estimate: CodexWeeklyValueEstimate,
+  quota: CodexWeeklyQuota,
+): string | null {
+  if (
+    !Number.isFinite(estimate.observedCostUsd)
+    || estimate.observedCostUsd <= 0
+    || !Number.isFinite(estimate.estimatedWeeklyValueUsd)
+    || estimate.estimatedWeeklyValueUsd <= 0
+    || !Number.isFinite(estimate.observedTokens)
+    || estimate.observedTokens <= 0
+    || !Number.isFinite(estimate.estimatedWeeklyTokens)
+    || estimate.estimatedWeeklyTokens <= 0
+  ) {
+    return 'The local weekly value estimate contains invalid totals.';
+  }
+  if (Math.abs(estimate.usedPct - quota.usedPct) > 5) {
+    return 'The local weekly value estimate does not match the quota usage.';
+  }
+  const estimateObservedAt = Date.parse(estimate.observedAt);
+  const now = Date.now();
+  if (
+    !Number.isFinite(estimateObservedAt)
+    || estimateObservedAt > now + 5 * 60 * 1000
+    || now - estimateObservedAt > 10 * 60 * 1000
+  ) {
+    return 'The local weekly value estimate is stale or has an invalid observation time.';
+  }
+  const estimateReset = Date.parse(estimate.resetsAt);
+  const quotaReset = Date.parse(quota.resetsAt);
+  if (
+    !Number.isFinite(estimateReset)
+    || !Number.isFinite(quotaReset)
+    || Math.abs(estimateReset - quotaReset) > 5 * 60 * 1000
+  ) {
+    return 'The local weekly value estimate does not match the quota reset.';
+  }
+  return null;
 }
 
 function validateWeeklyQuotaWindow(
@@ -234,6 +274,8 @@ export default function CodexPanel({
   const [resetCredits, setResetCredits] = useState<CodexResetCredits | null>(null);
   const [weeklyQuota, setWeeklyQuota] = useState<CodexWeeklyQuota | null>(null);
   const [weeklyQuotaError, setWeeklyQuotaError] = useState<string | null>(null);
+  const [weeklyValueEstimate, setWeeklyValueEstimate] = useState<CodexWeeklyValueEstimate | null>(null);
+  const [weeklyValueEstimateError, setWeeklyValueEstimateError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [rateLimitsError, setRateLimitsError] = useState<string | null>(null);
@@ -248,12 +290,16 @@ export default function CodexPanel({
       if (!weekly_request_generation.isCurrent(generation)) return;
       setWeeklyQuota(weekly.quota ?? null);
       setWeeklyQuotaError(weekly.error ?? null);
+      setWeeklyValueEstimate(weekly.valueEstimate ?? null);
+      setWeeklyValueEstimateError(weekly.valueEstimateError ?? null);
     } catch (err) {
       if (!weekly_request_generation.isCurrent(generation)) return;
       setWeeklyQuota(null);
       setWeeklyQuotaError(
         err instanceof Error ? err.message : 'Failed to load local weekly pace',
       );
+      setWeeklyValueEstimate(null);
+      setWeeklyValueEstimateError(null);
     }
   }, [weekly_request_generation]);
 
@@ -359,23 +405,23 @@ export default function CodexPanel({
     : null;
   const displayedWeeklyQuota = weeklyQuotaValidationError ? null : weeklyQuota;
   const displayedWeeklyQuotaError = weeklyQuotaValidationError ?? weeklyQuotaError;
+  const weeklyValueValidationError = displayedWeeklyQuota && weeklyValueEstimate
+    ? validateWeeklyValueEstimate(weeklyValueEstimate, displayedWeeklyQuota)
+    : null;
+  const displayedWeeklyValueEstimate = weeklyValueValidationError
+    ? null
+    : weeklyValueEstimate;
+  const displayedWeeklyValueEstimateError = weeklyValueValidationError
+    ?? weeklyValueEstimateError;
   const renderWeeklyPace = (window: CodexRateLimitWindow) => {
     if (window !== officialWeeklyWindow) return null;
-    const depletionTime = formatProjectionTime(displayedWeeklyQuota?.estimatedDepletionAt);
     return (
       <>
         {displayedWeeklyQuota && (
-          <>
-            <span className={`quota-pace ${displayedWeeklyQuota.status !== 'on_track' ? 'warning' : ''}`}>
-              Local pace: {formatWeeklyQuotaStatus(displayedWeeklyQuota.status)} · projected{' '}
-              {Math.round(displayedWeeklyQuota.projectedPctAtReset)}% at reset
-            </span>
-            {depletionTime && (
-              <span className="quota-pace warning">
-                Estimated depletion: {depletionTime}
-              </span>
-            )}
-          </>
+          <span className={`quota-pace ${displayedWeeklyQuota.status !== 'on_track' ? 'warning' : ''}`}>
+            Local pace: {formatWeeklyQuotaStatus(displayedWeeklyQuota.status)} · projected{' '}
+            {Math.round(displayedWeeklyQuota.projectedPctAtReset)}% at reset
+          </span>
         )}
         {!displayedWeeklyQuota && displayedWeeklyQuotaError && (
           <span className="quota-pace warning">
@@ -507,6 +553,36 @@ export default function CodexPanel({
                     </div>
                   </div>
                 )}
+              </div>
+            </div>
+          )}
+
+          {displayedWeeklyQuota
+            && (displayedWeeklyValueEstimate || displayedWeeklyValueEstimateError) && (
+            <div className="section weekly-value-section">
+              <div className="quota-group">
+                <div className="quota-card weekly-value-card">
+                  {displayedWeeklyValueEstimate ? (
+                    <>
+                      <div className="quota-header">
+                        <span className="quota-label">API-equivalent week</span>
+                        <span className="quota-value">
+                          ≈{USD_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyValueUsd)}
+                        </span>
+                      </div>
+                      <span className="quota-estimate-tokens">
+                        ≈{COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyTokens)} tokens at current mix
+                      </span>
+                      <span className="quota-estimate-note">
+                        Estimated from local usage · not an official allowance
+                      </span>
+                    </>
+                  ) : (
+                    <span className="quota-pace warning">
+                      Weekly value unavailable: {displayedWeeklyValueEstimateError}
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
           )}

--- a/src/redesign/panels.css
+++ b/src/redesign/panels.css
@@ -331,6 +331,34 @@
   }
 }
 
+.weekly-value-section {
+  margin-top: 8px;
+}
+
+.weekly-value-card .quota-header {
+  margin-bottom: 4px;
+}
+
+.weekly-value-card .quota-value {
+  color: var(--accent);
+}
+
+.quota-estimate-tokens,
+.quota-estimate-note {
+  display: block;
+  color: var(--sub);
+  font-size: 10px;
+  line-height: 1.3;
+}
+
+.quota-estimate-note {
+  margin-top: 2px;
+}
+
+.quota-estimate-tokens {
+  font-family: var(--metric-font);
+}
+
 .smart-tip {
   display: flex;
   align-items: baseline;

--- a/src/redesign/panels.css
+++ b/src/redesign/panels.css
@@ -335,28 +335,165 @@
   margin-top: 8px;
 }
 
-.weekly-value-card .quota-header {
-  margin-bottom: 4px;
+.weekly-value-section .quota-group {
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--mint) 13%, transparent), transparent 55%),
+    var(--card);
+  box-shadow:
+    0 0 0 0.5px color-mix(in srgb, var(--mint) 26%, var(--line)),
+    inset 0 0.5px 0 var(--inner);
 }
 
-.weekly-value-card .quota-value {
-  color: var(--accent);
+.weekly-value-card {
+  position: relative;
+  padding: 11px 0 9px;
 }
 
-.quota-estimate-tokens,
-.quota-estimate-note {
-  display: block;
+.weekly-value-card::before {
+  position: absolute;
+  top: 11px;
+  bottom: 9px;
+  left: -12px;
+  width: 2px;
+  border-radius: 2px;
+  background: var(--mint);
+  content: '';
+}
+
+.weekly-value-topline,
+.weekly-value-title,
+.weekly-value-body,
+.weekly-value-token-row,
+.weekly-value-footer {
+  display: flex;
+  align-items: center;
+}
+
+.weekly-value-topline {
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.weekly-value-title {
+  min-width: 0;
+  gap: 6px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.weekly-value-dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--mint);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--mint) 14%, transparent);
+}
+
+.weekly-value-badge {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border-radius: 5px;
+  color: var(--mint);
+  background: color-mix(in srgb, var(--mint) 13%, transparent);
+  font-size: 8px;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.weekly-value-body {
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.weekly-value-metrics {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.weekly-value-amount {
+  color: var(--text);
+  font-family: var(--metric-font);
+  font-size: 22px;
+  font-weight: 750;
+  line-height: 1;
+  letter-spacing: -0.045em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.weekly-value-token-row {
+  gap: 6px;
   color: var(--sub);
   font-size: 10px;
-  line-height: 1.3;
+  line-height: 1.2;
 }
 
-.quota-estimate-note {
-  margin-top: 2px;
-}
-
-.quota-estimate-tokens {
+.weekly-value-token-row strong {
+  color: var(--mint);
   font-family: var(--metric-font);
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.weekly-value-gauge {
+  width: 46px;
+  height: 46px;
+  flex: 0 0 auto;
+  display: grid;
+  padding: 4px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--mint) var(--weekly-value-used),
+    color-mix(in srgb, var(--track) 82%, transparent) 0
+  );
+  box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--mint) 18%, var(--line));
+}
+
+.weekly-value-gauge-center {
+  display: grid;
+  place-content: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--card) 70%, var(--pop));
+  color: var(--text);
+  text-align: center;
+  line-height: 1;
+}
+
+.weekly-value-gauge-center strong {
+  font-family: var(--metric-font);
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.weekly-value-gauge-center small {
+  margin-top: 2px;
+  color: var(--sub);
+  font-size: 7px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.weekly-value-footer {
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 9px;
+  padding-top: 7px;
+  border-top: 0.5px solid var(--line);
+  color: var(--sub);
+  font-size: 8.5px;
+  line-height: 1.2;
+}
+
+.weekly-value-footer span:last-child {
+  color: color-mix(in srgb, var(--sub) 78%, var(--text));
+  text-align: right;
 }
 
 .smart-tip {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -73,8 +73,21 @@ export interface CodexWeeklyQuota {
   status: CodexQuotaStatus;
 }
 
+export interface CodexWeeklyValueEstimate {
+  observedAt: string;
+  windowStartedAt: string;
+  resetsAt: string;
+  usedPct: number;
+  observedCostUsd: number;
+  estimatedWeeklyValueUsd: number;
+  observedTokens: number;
+  estimatedWeeklyTokens: number;
+}
+
 export interface CodexWeeklyQuotaData {
   quota?: CodexWeeklyQuota;
+  valueEstimate?: CodexWeeklyValueEstimate;
+  valueEstimateError?: string;
   error?: string;
 }
 

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -378,10 +378,9 @@ describe('Codex weekly pace', () => {
       },
     });
 
-    expect(rendered_text(renderer)).toContain('Likely to exhaust');
-    expect(rendered_text(renderer)).toContain('projected');
-    expect(rendered_text(renderer)).toContain('112');
-    expect(rendered_text(renderer)).toContain('% at reset');
+    expect(rendered_text(renderer)).not.toContain('Local pace:');
+    expect(rendered_text(renderer)).not.toContain('Likely to exhaust');
+    expect(rendered_text(renderer)).not.toContain('% at reset');
     expect(rendered_text(renderer)).toContain('API-equivalent week');
     expect(rendered_text(renderer)).toContain('$200.00');
     expect(rendered_text(renderer)).toContain('4M');
@@ -439,7 +438,7 @@ describe('Codex weekly pace', () => {
     await unmount(renderer);
   });
 
-  it('keeps weekly pace visible when the value estimate is unavailable', async () => {
+  it('keeps the value estimate error visible without a redundant pace summary', async () => {
     const renderer = await render_codex({
       quota: {
         observedAt: new Date().toISOString(),
@@ -453,7 +452,7 @@ describe('Codex weekly pace', () => {
       valueEstimateError: 'no matching local token usage',
     });
 
-    expect(rendered_text(renderer)).toContain('On track');
+    expect(rendered_text(renderer)).not.toContain('Local pace:');
     expect(rendered_text(renderer)).toContain('Weekly value unavailable');
     expect(rendered_text(renderer)).toContain('no matching local token usage');
     await unmount(renderer);
@@ -514,7 +513,7 @@ describe('Codex weekly pace', () => {
     await unmount(renderer);
   });
 
-  it('renders weekly pace on a primary-slot weekly window', async () => {
+  it('keeps only the standard pace hint on a primary-slot weekly window', async () => {
     const renderer = await render_codex({
       quota: {
         observedAt: new Date().toISOString(),
@@ -531,9 +530,9 @@ describe('Codex weekly pace', () => {
       resetsAt: 1_787_961_600,
     });
 
-    expect(rendered_text(renderer)).toContain('Local pace');
-    expect(rendered_text(renderer)).toContain('75');
-    expect(rendered_text(renderer)).toContain('% at reset');
+    expect(rendered_text(renderer)).toContain('At current pace');
+    expect(rendered_text(renderer)).not.toContain('Local pace:');
+    expect(rendered_text(renderer)).not.toContain('% at reset');
     await unmount(renderer);
   });
 

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -386,7 +386,12 @@ describe('Codex weekly pace', () => {
     expect(rendered_text(renderer)).toContain('$200.00');
     expect(rendered_text(renderer)).toContain('4M');
     expect(rendered_text(renderer)).toContain('tokens at current mix');
-    expect(rendered_text(renderer)).toContain('not an official allowance');
+    expect(rendered_text(renderer)).toContain('Local estimate');
+    expect(rendered_text(renderer)).toContain('Projected from local usage');
+    expect(rendered_text(renderer)).toContain('Not an official allowance');
+    expect(renderer.root.findByProps({
+      'aria-label': 'Estimate based on 40% used',
+    })).toBeDefined();
     expect(rendered_text(renderer)).not.toContain('Estimated depletion');
     const weekly_value_card = renderer.root.findByProps({
       className: 'quota-card weekly-value-card',

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -366,13 +366,91 @@ describe('Codex weekly pace', () => {
         projectedPctAtReset: 112.4,
         status: 'likely_exhausted',
       },
+      valueEstimate: {
+        observedAt: new Date().toISOString(),
+        windowStartedAt: '2026-08-22T00:00:00Z',
+        resetsAt: '2026-08-29T00:00:00Z',
+        usedPct: 40,
+        observedCostUsd: 80,
+        estimatedWeeklyValueUsd: 200,
+        observedTokens: 1_600_000,
+        estimatedWeeklyTokens: 4_000_000,
+      },
     });
 
     expect(rendered_text(renderer)).toContain('Likely to exhaust');
     expect(rendered_text(renderer)).toContain('projected');
     expect(rendered_text(renderer)).toContain('112');
     expect(rendered_text(renderer)).toContain('% at reset');
-    expect(rendered_text(renderer)).toContain('Estimated depletion');
+    expect(rendered_text(renderer)).toContain('API-equivalent week');
+    expect(rendered_text(renderer)).toContain('$200.00');
+    expect(rendered_text(renderer)).toContain('4M');
+    expect(rendered_text(renderer)).toContain('tokens at current mix');
+    expect(rendered_text(renderer)).toContain('not an official allowance');
+    expect(rendered_text(renderer)).not.toContain('Estimated depletion');
+    const weekly_value_card = renderer.root.findByProps({
+      className: 'quota-card weekly-value-card',
+    });
+    expect(weekly_value_card.parent?.props.className).toBe('quota-group');
+    expect(weekly_value_card.parent?.children).toHaveLength(1);
+    await unmount(renderer);
+  });
+
+  it.each([
+    ['invalid totals', { estimatedWeeklyValueUsd: 0 }, 'contains invalid totals'],
+    ['usage mismatch', { usedPct: 55 }, 'does not match the quota usage'],
+    ['reset mismatch', { resetsAt: '2026-09-05T00:00:00Z' }, 'does not match the quota reset'],
+    [
+      'stale observation',
+      { observedAt: new Date(Date.now() - 11 * 60 * 1000).toISOString() },
+      'is stale or has an invalid observation time',
+    ],
+  ])('rejects a weekly value estimate with %s', async (_case, override, expected_error) => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: new Date().toISOString(),
+        resetsAt: '2026-08-29T00:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 40,
+        remainingPct: 60,
+        projectedPctAtReset: 90,
+        status: 'on_track',
+      },
+      valueEstimate: {
+        observedAt: new Date().toISOString(),
+        windowStartedAt: '2026-08-22T00:00:00Z',
+        resetsAt: '2026-08-29T00:00:00Z',
+        usedPct: 40,
+        observedCostUsd: 80,
+        estimatedWeeklyValueUsd: 200,
+        observedTokens: 1_600_000,
+        estimatedWeeklyTokens: 4_000_000,
+        ...override,
+      },
+    });
+
+    expect(rendered_text(renderer)).toContain(expected_error);
+    expect(rendered_text(renderer)).not.toContain('API-equivalent week');
+    await unmount(renderer);
+  });
+
+  it('keeps weekly pace visible when the value estimate is unavailable', async () => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: new Date().toISOString(),
+        resetsAt: '2026-08-29T00:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 40,
+        remainingPct: 60,
+        projectedPctAtReset: 90,
+        status: 'on_track',
+      },
+      valueEstimateError: 'no matching local token usage',
+    });
+
+    expect(rendered_text(renderer)).toContain('On track');
+    expect(rendered_text(renderer)).toContain('Weekly value unavailable');
+    expect(rendered_text(renderer)).toContain('no matching local token usage');
     await unmount(renderer);
   });
 


### PR DESCRIPTION
## Summary

- Estimate the Codex weekly API-equivalent USD value and token volume from ccstats local usage and the provider-reported weekly percentage.
- Keep the expensive local scan in a cached blocking backend task, keyed to the exact quota snapshot, while isolating estimation failures from official quota and pace data.
- Render the result in a standalone card, remove the depletion timestamp, and fail closed for stale or mismatched estimates.

Closes #71

## Verification

- [x] `npm test` — 355 passed
- [x] `npm run build`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 46 passed, 2 ignored
- [x] `npm run tauri build -- --bundles app`
- [x] Installed and launched the resulting macOS app locally

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders an explicit unavailable state; it does not silently show zero usage.
- [x] The estimate is labeled as local and not an official allowance.

## Review

A pre-submit code review found no remaining blockers after cache coherency, card layout, and validation coverage fixes.