### PR TITLE
Clarify provider panel status and usage hierarchy

### DIFF
--- a/src-tauri/src/services/cursor.rs
+++ b/src-tauri/src/services/cursor.rs
@@ -134,11 +134,16 @@ fn get_stale_cached_cursor() -> Option<CursorData> {
     }
 }
 
+fn mark_cursor_data_stale(mut data: CursorData, error: String) -> CursorData {
+    data.error = Some(error);
+    data
+}
+
 fn fallback_or_disconnected(error: impl Into<String>) -> CursorData {
     let error = error.into();
     if is_transient_os_error(&error) {
         if let Some(stale) = get_stale_cached_cursor() {
-            return stale;
+            return mark_cursor_data_stale(stale, error);
         }
     }
     CursorData::disconnected(error)
@@ -305,5 +310,27 @@ mod tests {
         assert_eq!(data.fast_limit, Some(500));
         assert_eq!(data.slow_used, Some(99));
         assert!(data.percentage.unwrap() > 23.9 && data.percentage.unwrap() < 24.1);
+    }
+
+    #[test]
+    fn stale_data_keeps_usage_and_reports_refresh_error() {
+        let data = CursorData {
+            connected: true,
+            plan_type: Some("pro".to_string()),
+            email: None,
+            fast_used: Some(120),
+            fast_limit: Some(500),
+            percentage: Some(24.0),
+            slow_used: None,
+            reset_at: None,
+            error: None,
+        };
+
+        let stale = mark_cursor_data_stale(data, "Network error: timed out".to_string());
+
+        assert!(stale.connected);
+        assert_eq!(stale.fast_used, Some(120));
+        assert_eq!(stale.fast_limit, Some(500));
+        assert_eq!(stale.error.as_deref(), Some("Network error: timed out"));
     }
 }

--- a/src/components/AntigravityPanel.tsx
+++ b/src/components/AntigravityPanel.tsx
@@ -59,23 +59,30 @@ export default function AntigravityPanel({
   }, [manualRefreshNonce, fetchData]);
 
   const isConnected = data?.connected === true;
-  const hasError = Boolean(data?.error) && !loading;
+  const isPreview = data?.status === 'preview' && !isConnected;
+  const hasError = data?.status === 'error' && Boolean(data.error) && !loading;
   const headerStatus = loading && !data
     ? 'Checking'
     : hasError
       ? 'Unavailable'
       : isConnected
         ? 'CLI detected'
+        : isPreview
+          ? 'Preview'
         : 'Not connected';
   const panelTitle = hasError
     ? 'Unable to check Antigravity'
     : isConnected
       ? 'Antigravity is connected'
+      : isPreview
+        ? 'Quota tracking is in preview'
       : 'Antigravity is not connected';
   const panelHint = hasError
     ? 'Quota tracking status could not be refreshed. Try again from the footer.'
     : isConnected
       ? 'The CLI session is available. Quota tracking is waiting for provider support.'
+      : isPreview
+        ? data?.error ?? 'Quota tracking is waiting for a stable provider usage API.'
       : 'Sign in to Antigravity, then check the CLI status below.';
 
   return (
@@ -85,14 +92,14 @@ export default function AntigravityPanel({
         status={headerStatus}
         plan="Quota preview"
         usedPercent={null}
-        tone={hasError ? 'error' : loading && !data ? 'pending' : isConnected ? 'online' : 'offline'}
+        tone={hasError ? 'error' : loading && !data || isPreview ? 'pending' : isConnected ? 'online' : 'offline'}
       />
 
       <div className={`offline-panel${isConnected ? ' connected' : ''}`}>
         <div className="offline-tile">Ag</div>
         <div className="offline-title">{panelTitle}</div>
         <div className="offline-hint">{panelHint}</div>
-        {!isConnected && !hasError && <code className="offline-command">antigravity status</code>}
+        {!isConnected && !hasError && !isPreview && <code className="offline-command">antigravity status</code>}
       </div>
 
       {hasError && (

--- a/src/components/AntigravityPanel.tsx
+++ b/src/components/AntigravityPanel.tsx
@@ -58,31 +58,48 @@ export default function AntigravityPanel({
     }
   }, [manualRefreshNonce, fetchData]);
 
+  const isConnected = data?.connected === true;
+  const hasError = Boolean(data?.error) && !loading;
+  const headerStatus = loading && !data
+    ? 'Checking'
+    : hasError
+      ? 'Unavailable'
+      : isConnected
+        ? 'CLI detected'
+        : 'Not connected';
+  const panelTitle = hasError
+    ? 'Unable to check Antigravity'
+    : isConnected
+      ? 'Antigravity is connected'
+      : 'Antigravity is not connected';
+  const panelHint = hasError
+    ? 'Quota tracking status could not be refreshed. Try again from the footer.'
+    : isConnected
+      ? 'The CLI session is available. Quota tracking is waiting for provider support.'
+      : 'Sign in to Antigravity, then check the CLI status below.';
+
   return (
     <div className="codex-panel">
       <ProviderDetailHeader
         service="antigravity"
-        status={data?.connected ? 'Preview' : 'Pending'}
-        plan="Antigravity"
+        status={headerStatus}
+        plan="Quota preview"
         usedPercent={null}
+        tone={hasError ? 'error' : loading && !data ? 'pending' : isConnected ? 'online' : 'offline'}
       />
 
-      <div className="offline-panel">
+      <div className={`offline-panel${isConnected ? ' connected' : ''}`}>
         <div className="offline-tile">Ag</div>
-        <div className="offline-title">Antigravity is not connected</div>
-        <div className="offline-hint">
-          Antigravity quota tracking is pending provider support. Check sign-in status below.
-        </div>
-        <div className="offline-command">
-          <span>antigravity status</span>
-          <span className="offline-copy">⧉</span>
-        </div>
+        <div className="offline-title">{panelTitle}</div>
+        <div className="offline-hint">{panelHint}</div>
+        {!isConnected && !hasError && <code className="offline-command">antigravity status</code>}
       </div>
 
-      {data?.error && !loading && (
-        <p className="hint" style={{ marginTop: 12, fontSize: 11, opacity: 0.6 }}>
-          Backend status: {data.error}
-        </p>
+      {hasError && (
+        <div className="error-banner antigravity-error" role="alert">
+          <span className="error-icon">!</span>
+          <span className="error-text">{data?.error}</span>
+        </div>
       )}
     </div>
   );

--- a/src/components/ClaudePanel.tsx
+++ b/src/components/ClaudePanel.tsx
@@ -74,6 +74,7 @@ export default function ClaudePanel({
             status={error ? 'Stale data' : quota.connected ? 'Connected' : 'Offline'}
             plan="Claude Code"
             usedPercent={topWindow?.usedPercent ?? null}
+            usageLabel={topWindow?.label}
             tone={error ? 'pending' : quota.connected ? 'online' : 'offline'}
           />
 

--- a/src/components/ClaudePanel.tsx
+++ b/src/components/ClaudePanel.tsx
@@ -58,19 +58,23 @@ export default function ClaudePanel({
       )}
 
       {error && (
-        <div className="error-banner">
+        <div className="error-banner" role="alert">
           <span className="error-icon">!</span>
-          <span className="error-text">{error}</span>
+          <span className="error-text">
+            {error}
+            {quota && <span className="error-context">Showing last known data.</span>}
+          </span>
         </div>
       )}
 
-      {!error && quota && (
+      {quota && (
         <div className="detail-stack">
           <ProviderDetailHeader
             service="claude"
-            status={quota.connected ? 'Connected' : 'Offline'}
+            status={error ? 'Stale data' : quota.connected ? 'Connected' : 'Offline'}
             plan="Claude Code"
             usedPercent={topWindow?.usedPercent ?? null}
+            tone={error ? 'pending' : quota.connected ? 'online' : 'offline'}
           />
 
           <div className="section">
@@ -97,6 +101,7 @@ export default function ClaudePanel({
                   label="All models"
                   percentage={Math.round(quota.weeklyTotal.percentage)}
                   resetsIn={formatClaudeResetTime(quota.weeklyTotal.resetTime)}
+                  featured
                 />
               )}
 
@@ -148,10 +153,10 @@ export default function ClaudePanel({
         </div>
       )}
 
-      {!error && !quota && !loading && (
+      {!quota && !loading && (
         <div className="empty-state">
           <p>Unable to load quota data</p>
-          <button onClick={onRetry} className="retry-btn">
+          <button type="button" onClick={onRetry} className="retry-btn">
             Try Again
           </button>
         </div>

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
+import { useRef } from 'react';
 import { backend } from '../services/backend';
 import CostSummarySection from './CostSummarySection';
 import ProviderDetailHeader from './ProviderDetailHeader';
@@ -14,7 +15,7 @@ import type {
 } from '../types/models';
 import { buildCodexQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
 import { getAvailableResetCredits, getHighUsageTip } from '../services/detail_helpers';
-import { formatPaceText, formatPlanType, formatResetTime, getProgressStyle } from '../utils/quota_format';
+import { clampProgressValue, formatPaceText, formatPlanType, formatResetTime, getProgressStyle } from '../utils/quota_format';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
 import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';
 
@@ -235,6 +236,8 @@ export default function CodexPanel({
   const [weeklyQuotaError, setWeeklyQuotaError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [rateLimitsError, setRateLimitsError] = useState<string | null>(null);
+  const hasResolvedData = useRef(false);
   const request_generation = useLatestRequestGeneration();
   const weekly_request_generation = useLatestRequestGeneration();
 
@@ -259,6 +262,7 @@ export default function CodexPanel({
     try {
       setLoading(true);
       setError(null);
+      setRateLimitsError(null);
       void fetchWeeklyQuota();
 
       const [info, limits, credits] = await Promise.all([
@@ -268,6 +272,7 @@ export default function CodexPanel({
       ]);
       if (!request_generation.isCurrent(generation)) return;
 
+      hasResolvedData.current = true;
       setCodexData(info);
       setRateLimits(limits);
       onQuotaWindowsChange?.(buildCodexQuotaWindows(limits));
@@ -275,6 +280,7 @@ export default function CodexPanel({
 
       if (limits.error) {
         setError(limits.error);
+        setRateLimitsError(limits.error);
       } else if (info.error) {
         setError(info.error);
       }
@@ -287,10 +293,14 @@ export default function CodexPanel({
       onUsageChange?.(getTrayUsedPercent(limits));
     } catch (err) {
       if (!request_generation.isCurrent(generation)) return;
-      setError(err instanceof Error ? err.message : 'Failed to fetch Codex data');
-      onConnectionChange?.(false);
-      onUsageChange?.(null);
-      onQuotaWindowsChange?.([]);
+      const message = err instanceof Error ? err.message : 'Failed to fetch Codex data';
+      setError(message);
+      setRateLimitsError(message);
+      if (!hasResolvedData.current) {
+        onConnectionChange?.(false);
+        onUsageChange?.(null);
+        onQuotaWindowsChange?.([]);
+      }
     } finally {
       if (request_generation.isCurrent(generation)) {
         setLoading(false);
@@ -334,11 +344,13 @@ export default function CodexPanel({
     );
   }
 
-  const hasRateLimits = rateLimits?.primary || rateLimits?.secondary;
+  const hasRateLimits = Boolean(rateLimits?.primary || rateLimits?.secondary);
   const connected = rateLimits?.connected || codexData?.connected;
   const planType = rateLimits?.planType || codexData?.planType;
   const windows = buildCodexQuotaWindows(rateLimits);
   const topWindow = sortMostConstrained(windows)[0];
+  const showingStaleLimits = Boolean(rateLimitsError && hasRateLimits);
+  const quotaUnavailable = Boolean(rateLimitsError && !hasRateLimits);
   const availableResetCredits = getAvailableResetCredits(resetCredits);
   const bonusGrantGroups = buildBonusGrantGroups(availableResetCredits);
   const officialWeeklyWindow = selectOfficialWeeklyWindow(rateLimits, weeklyQuota);
@@ -379,7 +391,10 @@ export default function CodexPanel({
       {error && (
         <div className="error-banner">
           <span className="error-icon">!</span>
-          <span className="error-text">{error}</span>
+          <span className="error-text">
+            {error}
+            {showingStaleLimits && <span className="error-context">Showing last known data.</span>}
+          </span>
         </div>
       )}
 
@@ -387,9 +402,11 @@ export default function CodexPanel({
         <div className="codex-content">
           <ProviderDetailHeader
             service="codex"
-            status={connected ? 'Connected' : 'Offline'}
+            status={showingStaleLimits ? 'Stale data' : quotaUnavailable ? 'Quota unavailable' : connected ? 'Connected' : 'Offline'}
             plan={formatCodexPlan(planType)}
             usedPercent={topWindow?.usedPercent ?? null}
+            usageLabel={topWindow?.label}
+            tone={showingStaleLimits ? 'pending' : quotaUnavailable ? 'error' : connected ? 'online' : 'offline'}
           />
 
           {/* Rate Limits Section */}
@@ -414,7 +431,8 @@ export default function CodexPanel({
                       aria-label={`${formatWindowLabel(rateLimits.primary.windowMinutes, 'primary')} usage`}
                       aria-valuemin={0}
                       aria-valuemax={100}
-                      aria-valuenow={Math.round(rateLimits.primary.usedPercent)}
+                      aria-valuenow={clampProgressValue(rateLimits.primary.usedPercent)}
+                      aria-valuetext={`${Math.round(rateLimits.primary.usedPercent)}% used`}
                     >
                       <div
                         className="progress-fill"
@@ -459,7 +477,8 @@ export default function CodexPanel({
                       aria-label={`${formatWindowLabel(rateLimits.secondary.windowMinutes, 'secondary')} usage`}
                       aria-valuemin={0}
                       aria-valuemax={100}
-                      aria-valuenow={Math.round(rateLimits.secondary.usedPercent)}
+                      aria-valuenow={clampProgressValue(rateLimits.secondary.usedPercent)}
+                      aria-valuetext={`${Math.round(rateLimits.secondary.usedPercent)}% used`}
                     >
                       <div
                         className="progress-fill"

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -408,7 +408,14 @@ export default function CodexPanel({
                         {Math.round(rateLimits.primary.usedPercent)}%
                       </span>
                     </div>
-                    <div className="progress-bar">
+                    <div
+                      className="progress-bar"
+                      role="progressbar"
+                      aria-label={`${formatWindowLabel(rateLimits.primary.windowMinutes, 'primary')} usage`}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={Math.round(rateLimits.primary.usedPercent)}
+                    >
                       <div
                         className="progress-fill"
                         style={getProgressStyle(rateLimits.primary.usedPercent)}
@@ -446,7 +453,14 @@ export default function CodexPanel({
                         {Math.round(rateLimits.secondary.usedPercent)}%
                       </span>
                     </div>
-                    <div className="progress-bar">
+                    <div
+                      className="progress-bar"
+                      role="progressbar"
+                      aria-label={`${formatWindowLabel(rateLimits.secondary.windowMinutes, 'secondary')} usage`}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={Math.round(rateLimits.secondary.usedPercent)}
+                    >
                       <div
                         className="progress-fill"
                         style={getProgressStyle(rateLimits.secondary.usedPercent)}

--- a/src/components/CursorPanel.tsx
+++ b/src/components/CursorPanel.tsx
@@ -112,6 +112,9 @@ export default function CursorPanel({
   const resetLabel = formatResetDate(cursorData?.resetAt);
   const windows = buildCursorQuotaWindows(cursorData);
   const topWindow = sortMostConstrained(windows)[0];
+  const includedRequestValue = cursorData?.fastUsed != null && cursorData.fastLimit != null
+    ? `${cursorData.fastUsed} / ${cursorData.fastLimit}${percentage != null ? ` · ${Math.round(percentage)}%` : ''}`
+    : null;
 
   return (
     <div className="codex-panel">
@@ -139,12 +142,17 @@ export default function CursorPanel({
                 <div className="quota-card">
                   <div className="quota-header">
                     <span className="quota-label">Included requests</span>
-                    <span className="quota-value">
-                      {percentage != null ? `${Math.round(percentage)}%` : `${cursorData.fastUsed} / ${cursorData.fastLimit}`}
-                    </span>
+                    <span className="quota-value">{includedRequestValue}</span>
                   </div>
                   {percentage != null && (
-                    <div className="progress-bar">
+                    <div
+                      className="progress-bar"
+                      role="progressbar"
+                      aria-label="Cursor included request usage"
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={Math.round(percentage)}
+                    >
                       <div className="progress-fill" style={getProgressStyle(percentage)} />
                     </div>
                   )}
@@ -161,15 +169,14 @@ export default function CursorPanel({
                 </div>
               )}
 
-              {cursorData.email && (
-                <div className="quota-card">
-                  <div className="quota-header">
-                    <span className="quota-label">Account</span>
-                    <span className="quota-value email">{cursorData.email}</span>
-                  </div>
-                </div>
-              )}
             </div>
+
+            {cursorData.email && (
+              <div className="account-strip">
+                <span className="account-strip-label">Account</span>
+                <span className="account-strip-value" title={cursorData.email}>{cursorData.email}</span>
+              </div>
+            )}
           </div>
 
           {sections.tips && <SmartTip message={getHighUsageTip(windows)} />}

--- a/src/components/CursorPanel.tsx
+++ b/src/components/CursorPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
+import { useRef } from 'react';
 import { backend } from '../services/backend';
 import CostSummarySection from './CostSummarySection';
 import ProviderDetailHeader from './ProviderDetailHeader';
@@ -7,7 +8,7 @@ import SmartTip from './SmartTip';
 import type { CursorData } from '../types/models';
 import { buildCursorQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
 import { getHighUsageTip } from '../services/detail_helpers';
-import { formatPlanType, getProgressStyle } from '../utils/quota_format';
+import { clampProgressValue, formatPlanType, getProgressStyle } from '../utils/quota_format';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
 import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';
 
@@ -52,6 +53,7 @@ export default function CursorPanel({
   const [cursorData, setCursorData] = useState<CursorData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const hasResolvedData = useRef(false);
   const request_generation = useLatestRequestGeneration();
 
   const fetchData = useCallback(async () => {
@@ -62,6 +64,7 @@ export default function CursorPanel({
       const data = await backend.getCursorInfo();
       if (!request_generation.isCurrent(generation)) return;
       setCursorData(data);
+      hasResolvedData.current = true;
       if (data.error) {
         setError(data.error);
       }
@@ -72,9 +75,11 @@ export default function CursorPanel({
       if (!request_generation.isCurrent(generation)) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch Cursor data';
       setError(message);
-      onConnectionChange?.(false);
-      onUsageChange?.(null);
-      onQuotaWindowsChange?.([]);
+      if (!hasResolvedData.current) {
+        onConnectionChange?.(false);
+        onUsageChange?.(null);
+        onQuotaWindowsChange?.([]);
+      }
     } finally {
       if (request_generation.isCurrent(generation)) {
         setLoading(false);
@@ -121,7 +126,10 @@ export default function CursorPanel({
       {error && (
         <div className="error-banner">
           <span className="error-icon">!</span>
-          <span className="error-text">{error}</span>
+          <span className="error-text">
+            {error}
+            {cursorData?.connected && <span className="error-context">Showing last known data.</span>}
+          </span>
         </div>
       )}
 
@@ -129,9 +137,11 @@ export default function CursorPanel({
         <div className="codex-content">
           <ProviderDetailHeader
             service="cursor"
-            status="Connected"
+            status={error ? 'Stale data' : 'Connected'}
             plan={`Cursor ${formatPlanType(cursorData.planType, 'Unknown')}`}
             usedPercent={topWindow?.usedPercent ?? null}
+            usageLabel={topWindow?.label}
+            tone={error ? 'pending' : 'online'}
           />
 
           <div className="section">
@@ -151,7 +161,8 @@ export default function CursorPanel({
                       aria-label="Cursor included request usage"
                       aria-valuemin={0}
                       aria-valuemax={100}
-                      aria-valuenow={Math.round(percentage)}
+                      aria-valuenow={clampProgressValue(percentage)}
+                      aria-valuetext={`${Math.round(percentage)}% used`}
                     >
                       <div className="progress-fill" style={getProgressStyle(percentage)} />
                     </div>

--- a/src/components/OverviewPanel.tsx
+++ b/src/components/OverviewPanel.tsx
@@ -25,30 +25,42 @@ export default function OverviewPanel({
   onProviderSelect,
   sections = defaultPanelSections(),
 }: OverviewPanelProps) {
+  const connectedCount = summaries.filter((summary) => summary.connected).length;
+
   return (
     <div className="overview-panel">
       <ProviderDetailHeader
         service="claude"
-        status={`${summaries.filter((summary) => summary.connected).length} connected`}
+        label="Overview"
+        status={`${connectedCount} of ${summaries.length} connected`}
         plan="All providers"
         usedPercent={mostConstrained[0]?.usedPercent ?? null}
+        tone={connectedCount > 0 ? 'online' : 'offline'}
       />
 
       <div className="section">
         <div className="section-title">Most constrained</div>
         <div className="quota-group">
-          {mostConstrained.length > 0 ? mostConstrained.map((window) => (
+          {mostConstrained.length > 0 ? mostConstrained.map((window, index) => (
             <button
               type="button"
-              className="quota-card overview-quota-row"
+              className={`quota-card overview-quota-row${index === 0 ? ' primary' : ''}`}
               key={`${window.provider}-${window.label}`}
               onClick={() => onProviderSelect(window.provider)}
+              aria-label={`Open ${window.providerLabel}: ${window.label}, ${Math.round(window.usedPercent)}% used`}
             >
               <div className="quota-header">
                 <span className="quota-label">{`${window.providerLabel} · ${window.label}`}</span>
                 <span className="quota-value">{Math.round(window.usedPercent)}%</span>
               </div>
-              <div className="progress-bar">
+              <div
+                className="progress-bar"
+                role="progressbar"
+                aria-label={`${window.providerLabel} ${window.label} usage`}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={Math.round(window.usedPercent)}
+              >
                 <div className="progress-fill" style={getProgressStyle(window.usedPercent)} />
               </div>
               {window.resetLabel && <div className="reset-time">Resets in {window.resetLabel}</div>}

--- a/src/components/OverviewPanel.tsx
+++ b/src/components/OverviewPanel.tsx
@@ -1,6 +1,6 @@
 import type { ProviderSummary, QuotaWindowSummary } from '../services/provider_summary';
 import type { TrayServiceName } from '../services/tray_visibility';
-import { getProgressStyle } from '../utils/quota_format';
+import { clampProgressValue, getProgressStyle } from '../utils/quota_format';
 import CostSummarySection from './CostSummarySection';
 import ProviderDetailHeader from './ProviderDetailHeader';
 import ResetTimeline from './ResetTimeline';
@@ -35,6 +35,7 @@ export default function OverviewPanel({
         status={`${connectedCount} of ${summaries.length} connected`}
         plan="All providers"
         usedPercent={mostConstrained[0]?.usedPercent ?? null}
+        usageLabel={mostConstrained[0] ? `${mostConstrained[0].providerLabel} · ${mostConstrained[0].label}` : undefined}
         tone={connectedCount > 0 ? 'online' : 'offline'}
       />
 
@@ -59,7 +60,8 @@ export default function OverviewPanel({
                 aria-label={`${window.providerLabel} ${window.label} usage`}
                 aria-valuemin={0}
                 aria-valuemax={100}
-                aria-valuenow={Math.round(window.usedPercent)}
+                aria-valuenow={clampProgressValue(window.usedPercent)}
+                aria-valuetext={`${Math.round(window.usedPercent)}% used`}
               >
                 <div className="progress-fill" style={getProgressStyle(window.usedPercent)} />
               </div>

--- a/src/components/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader.tsx
@@ -7,6 +7,7 @@ interface ProviderDetailHeaderProps {
   status: string;
   plan?: string;
   usedPercent?: number | null;
+  usageLabel?: string;
   tone?: 'online' | 'offline' | 'pending' | 'error';
 }
 
@@ -24,11 +25,12 @@ export default function ProviderDetailHeader({
   status,
   plan,
   usedPercent,
+  usageLabel,
   tone = inferTone(status),
 }: ProviderDetailHeaderProps) {
   const meta = SERVICE_META[service];
   const usage = typeof usedPercent === 'number' && Number.isFinite(usedPercent)
-    ? `${Math.round(usedPercent)}% used`
+    ? `${usageLabel ? `${usageLabel} · ` : ''}${Math.round(usedPercent)}% used`
     : null;
 
   return (

--- a/src/components/ProviderDetailHeader.tsx
+++ b/src/components/ProviderDetailHeader.tsx
@@ -3,25 +3,49 @@ import type { TrayServiceName } from '../services/tray_visibility';
 
 interface ProviderDetailHeaderProps {
   service: TrayServiceName;
+  label?: string;
   status: string;
   plan?: string;
   usedPercent?: number | null;
+  tone?: 'online' | 'offline' | 'pending' | 'error';
+}
+
+function inferTone(status: string): NonNullable<ProviderDetailHeaderProps['tone']> {
+  const normalized = status.toLowerCase();
+  if (normalized.includes('error') || normalized.includes('unavailable')) return 'error';
+  if (normalized.includes('offline') || normalized.includes('not connected')) return 'offline';
+  if (normalized.includes('pending') || normalized.includes('checking') || normalized.includes('stale')) return 'pending';
+  return 'online';
 }
 
 export default function ProviderDetailHeader({
   service,
+  label,
   status,
   plan,
-  usedPercent: _usedPercent,
+  usedPercent,
+  tone = inferTone(status),
 }: ProviderDetailHeaderProps) {
   const meta = SERVICE_META[service];
+  const usage = typeof usedPercent === 'number' && Number.isFinite(usedPercent)
+    ? `${Math.round(usedPercent)}% used`
+    : null;
 
   return (
     <div className="provider-detail-header">
-      <span className="provider-detail-name">{meta.label}</span>
-      <span className={`provider-detail-dot ${status === 'Offline' || status === 'Pending' ? 'offline' : ''}`} />
+      <div className="provider-detail-identity">
+        <span className="provider-detail-name">{label ?? meta.label}</span>
+        <span className={`provider-detail-dot ${tone}`} aria-hidden="true" />
+        <span className="provider-detail-state">{status}</span>
+      </div>
       <span className="provider-detail-spacer" />
-      <span className="provider-detail-status">{plan || status}</span>
+      {(plan || usage) && (
+        <div className="provider-detail-meta">
+          {plan && <span className="provider-detail-plan">{plan}</span>}
+          {plan && usage && <span className="provider-detail-divider" aria-hidden="true">·</span>}
+          {usage && <span className="provider-detail-status">{usage}</span>}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/QuotaCard.tsx
+++ b/src/components/QuotaCard.tsx
@@ -5,6 +5,7 @@ interface QuotaCardProps {
   percentage: number;
   resetsIn: string;
   pace?: string | null;
+  featured?: boolean;
 }
 
 function getStatusColor(percentage: number): string {
@@ -13,17 +14,24 @@ function getStatusColor(percentage: number): string {
   return 'good';
 }
 
-export default function QuotaCard({ label, percentage, resetsIn, pace }: QuotaCardProps) {
+export default function QuotaCard({ label, percentage, resetsIn, pace, featured = false }: QuotaCardProps) {
   const status = getStatusColor(percentage);
 
   return (
-    <div className="quota-card">
+    <div className={`quota-card${featured ? ' featured' : ''}`}>
       <div className="quota-header">
         <span className="quota-label">{label}</span>
         <span className="quota-percentage">{percentage}%</span>
       </div>
 
-      <div className="progress-bar">
+      <div
+        className="progress-bar"
+        role="progressbar"
+        aria-label={`${label} usage`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={percentage}
+      >
         <div
           className={`progress-fill ${status}`}
           style={getProgressStyle(percentage)}

--- a/src/components/QuotaCard.tsx
+++ b/src/components/QuotaCard.tsx
@@ -1,4 +1,4 @@
-import { getProgressStyle } from '../utils/quota_format';
+import { clampProgressValue, getProgressStyle } from '../utils/quota_format';
 
 interface QuotaCardProps {
   label: string;
@@ -30,7 +30,8 @@ export default function QuotaCard({ label, percentage, resetsIn, pace, featured 
         aria-label={`${label} usage`}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuenow={percentage}
+        aria-valuenow={clampProgressValue(percentage)}
+        aria-valuetext={`${Math.round(percentage)}% used`}
       >
         <div
           className={`progress-fill ${status}`}

--- a/src/redesign/panels.css
+++ b/src/redesign/panels.css
@@ -11,11 +11,23 @@
 .provider-detail-header {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 8px 10px 0;
+  gap: 8px;
+  min-height: 24px;
+  padding: 9px 10px 1px;
   border: 0;
   background: transparent;
   box-shadow: none;
+}
+
+.provider-detail-identity,
+.provider-detail-meta {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.provider-detail-identity {
+  gap: 6px;
 }
 
 .provider-detail-name {
@@ -31,20 +43,64 @@
   border-radius: 50%;
   flex: 0 0 auto;
   background: var(--target-green);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--target-green) 13%, transparent);
+}
+
+.provider-detail-dot.offline,
+.provider-detail-dot.pending,
+.provider-detail-dot.error {
+  box-shadow: none;
 }
 
 .provider-detail-dot.offline {
   background: var(--track);
 }
 
+.provider-detail-dot.pending {
+  background: #ff9500;
+}
+
+.provider-detail-dot.error {
+  background: #ff3b30;
+}
+
+.provider-detail-state {
+  overflow: hidden;
+  color: var(--sub);
+  font-size: 10.5px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .provider-detail-spacer {
   flex: 1;
 }
 
-.provider-detail-status {
+.provider-detail-meta {
+  justify-content: flex-end;
+  gap: 4px;
+  max-width: 58%;
   color: var(--sub);
   font-size: 11px;
   font-weight: 500;
+  white-space: nowrap;
+}
+
+.provider-detail-plan {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.provider-detail-divider {
+  opacity: 0.55;
+}
+
+.provider-detail-status {
+  flex: 0 0 auto;
+  color: var(--text);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
 
 .section {
@@ -108,6 +164,69 @@
 .overview-quota-row:hover {
   box-shadow: none;
   border-color: var(--line);
+}
+
+.overview-quota-row {
+  position: relative;
+  cursor: pointer;
+}
+
+.overview-quota-row.primary {
+  margin: 3px 0;
+  padding: 11px 10px 10px;
+  overflow: hidden;
+  border: 0;
+  border-radius: 9px;
+  background:
+    linear-gradient(105deg, color-mix(in srgb, var(--acc) 10%, transparent), transparent 72%),
+    color-mix(in srgb, var(--card) 96%, var(--acc));
+  box-shadow: inset 0 0 0 0.5px color-mix(in srgb, var(--acc) 24%, var(--line));
+}
+
+.overview-quota-row.primary + .overview-quota-row {
+  border-top: 0;
+}
+
+.quota-card.featured {
+  margin: 3px 0;
+  padding: 11px 10px 10px;
+  border: 0;
+  border-radius: 9px;
+  background:
+    linear-gradient(105deg, color-mix(in srgb, var(--acc) 9%, transparent), transparent 72%),
+    color-mix(in srgb, var(--card) 96%, var(--acc));
+  box-shadow: inset 0 0 0 0.5px color-mix(in srgb, var(--acc) 22%, var(--line));
+}
+
+.quota-card.featured + .quota-card {
+  border-top: 0;
+}
+
+.account-strip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 6px 2px 0;
+  padding: 5px 10px;
+  color: var(--sub);
+  font-size: 10.5px;
+}
+
+.account-strip-label {
+  flex: 0 0 auto;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.account-strip-value {
+  min-width: 0;
+  margin-left: auto;
+  overflow: hidden;
+  color: var(--text);
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .quota-header {
@@ -178,6 +297,35 @@
 
 .quota-pace.warning {
   color: #e8850c;
+}
+
+.error-context {
+  display: block;
+  margin-top: 2px;
+  color: color-mix(in srgb, currentColor 72%, var(--text));
+  font-size: 10.5px;
+  font-weight: 500;
+}
+
+.offline-panel.connected {
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--target-green) 9%, transparent), transparent 66%),
+    var(--card);
+}
+
+.offline-panel.connected .offline-tile {
+  background: linear-gradient(145deg, #37c982, #0a84ff);
+}
+
+.antigravity-error {
+  margin-top: 8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-fill,
+  .budget-fill {
+    transition: none;
+  }
 }
 
 .smart-tip {

--- a/src/redesign/panels.css
+++ b/src/redesign/panels.css
@@ -97,10 +97,13 @@
 }
 
 .provider-detail-status {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
   color: var(--text);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
 }
 
 .section {

--- a/src/utils/quota_format.ts
+++ b/src/utils/quota_format.ts
@@ -103,3 +103,8 @@ export function getProgressStyle(usedPercent: number): CSSProperties {
     background: `linear-gradient(90deg, ${color}bb, ${color})`,
   } as CSSProperties;
 }
+
+export function clampProgressValue(usedPercent: number): number {
+  if (!Number.isFinite(usedPercent)) return 0;
+  return Math.min(100, Math.max(0, Math.round(usedPercent)));
+}

--- a/tests/panel_status_ui.test.tsx
+++ b/tests/panel_status_ui.test.tsx
@@ -3,6 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import AntigravityPanel from '../src/components/AntigravityPanel';
 import ClaudePanel from '../src/components/ClaudePanel';
+import CodexPanel from '../src/components/CodexPanel';
 import CursorPanel from '../src/components/CursorPanel';
 import OverviewPanel from '../src/components/OverviewPanel';
 import ProviderDetailHeader from '../src/components/ProviderDetailHeader';
@@ -35,6 +36,7 @@ describe('provider status UI', () => {
         status: 'Connected',
         plan: 'Cursor Pro',
         usedPercent: 47,
+        usageLabel: 'Fast requests',
       }));
     });
 
@@ -42,6 +44,7 @@ describe('provider status UI', () => {
     expect(text).toContain('Cursor');
     expect(text).toContain('Connected');
     expect(text).toContain('Cursor Pro');
+    expect(text).toContain('Fast requests');
     expect(text).toContain('47% used');
   });
 
@@ -105,12 +108,258 @@ describe('provider status UI', () => {
     await act(async () => renderer.unmount());
   });
 
-  it('shows Cursor request counts with the percentage and separates account metadata', async () => {
+  it('treats the Antigravity placeholder as preview rather than a refresh error', async () => {
+    vi.spyOn(backend, 'getAntigravityInfo').mockResolvedValue({
+      connected: false,
+      status: 'preview',
+      error: 'Quota tracking arrives when Google ships a stable usage API.',
+    });
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(AntigravityPanel, { autoRefreshIntervalMs: 0 }));
+      await Promise.resolve();
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Preview');
+    expect(text).toContain('Quota tracking is in preview');
+    expect(text).toContain('stable usage API');
+    expect(text).not.toContain('Unavailable');
+    expect(renderer.root.findAllByProps({ role: 'alert' })).toHaveLength(0);
+    await act(async () => renderer.unmount());
+  });
+
+  it('labels retained Codex limits as stale when the refresh carries an error', async () => {
+    vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true, planType: 'pro' });
+    vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({
+      connected: true,
+      planType: 'pro',
+      primary: { usedPercent: 64, windowMinutes: 300 },
+      error: 'Rate limit refresh failed',
+    });
+    vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({
+      connected: true,
+      availableCount: 0,
+      credits: [],
+    });
+    vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Rate limit refresh failed');
+    expect(text).toContain('Stale data');
+    expect(text).toContain('Showing last known data');
+    expect(text).toContain('5h · 64% used');
+    await act(async () => renderer.unmount());
+  });
+
+  it('does not claim last-known Codex quota when an error response has no limits', async () => {
+    vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true, planType: 'pro' });
+    vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({
+      connected: false,
+      error: 'Codex rate limit request failed: 401',
+    });
+    vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({
+      connected: true,
+      availableCount: 0,
+      credits: [],
+    });
+    vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Quota unavailable');
+    expect(text).not.toContain('Stale data');
+    expect(text).not.toContain('Showing last known data');
+    await act(async () => renderer.unmount());
+  });
+
+  it('keeps fresh Codex limits connected when only account metadata fails', async () => {
+    vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({
+      connected: false,
+      error: 'Codex ID token is unavailable',
+    });
+    vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({
+      connected: true,
+      planType: 'pro',
+      primary: { usedPercent: 64, windowMinutes: 300 },
+    });
+    vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({
+      connected: true,
+      availableCount: 0,
+      credits: [],
+    });
+    vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Codex ID token is unavailable');
+    expect(text).toContain('Connected');
+    expect(text).toContain('5h · 64% used');
+    expect(text).not.toContain('Stale data');
+    expect(text).not.toContain('Showing last known data');
+    await act(async () => renderer.unmount());
+  });
+
+  it('labels retained Cursor data as stale after a rejected refresh', async () => {
+    vi.spyOn(backend, 'getCursorInfo')
+      .mockResolvedValueOnce({ connected: true, fastUsed: 231, fastLimit: 500, percentage: 46.2 })
+      .mockRejectedValueOnce(new Error('Cursor refresh failed'));
+    const onConnectionChange = vi.fn();
+    const onUsageChange = vi.fn();
+    const onQuotaWindowsChange = vi.fn();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CursorPanel, {
+        autoRefreshIntervalMs: 0,
+        manualRefreshNonce: 0,
+        onConnectionChange,
+        onUsageChange,
+        onQuotaWindowsChange,
+        showCostSummary: false,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+    onConnectionChange.mockClear();
+    onUsageChange.mockClear();
+    onQuotaWindowsChange.mockClear();
+    await act(async () => {
+      renderer.update(createElement(CursorPanel, {
+        autoRefreshIntervalMs: 0,
+        manualRefreshNonce: 1,
+        onConnectionChange,
+        onUsageChange,
+        onQuotaWindowsChange,
+        showCostSummary: false,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Cursor refresh failed');
+    expect(text).toContain('Stale data');
+    expect(text).toContain('Showing last known data');
+    expect(text).toContain('231 / 500 · 46%');
+    expect(onConnectionChange).not.toHaveBeenCalled();
+    expect(onUsageChange).not.toHaveBeenCalled();
+    expect(onQuotaWindowsChange).not.toHaveBeenCalled();
+    await act(async () => renderer.unmount());
+  });
+
+  it('keeps parent Codex summaries after a rejected refresh', async () => {
+    vi.spyOn(backend, 'getCodexInfo')
+      .mockResolvedValueOnce({ connected: true, planType: 'pro' })
+      .mockRejectedValueOnce(new Error('Codex refresh failed'));
+    vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({
+      connected: true,
+      planType: 'pro',
+      primary: { usedPercent: 64, windowMinutes: 300 },
+    });
+    vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({
+      connected: true,
+      availableCount: 0,
+      credits: [],
+    });
+    vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
+    const onConnectionChange = vi.fn();
+    const onUsageChange = vi.fn();
+    const onQuotaWindowsChange = vi.fn();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        manualRefreshNonce: 0,
+        onConnectionChange,
+        onUsageChange,
+        onQuotaWindowsChange,
+        showCostSummary: false,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+    onConnectionChange.mockClear();
+    onUsageChange.mockClear();
+    onQuotaWindowsChange.mockClear();
+    await act(async () => {
+      renderer.update(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        manualRefreshNonce: 1,
+        onConnectionChange,
+        onUsageChange,
+        onQuotaWindowsChange,
+        showCostSummary: false,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Codex refresh failed');
+    expect(text).toContain('Stale data');
+    expect(text).toContain('5h · 64% used');
+    expect(onConnectionChange).not.toHaveBeenCalled();
+    expect(onUsageChange).not.toHaveBeenCalled();
+    expect(onQuotaWindowsChange).not.toHaveBeenCalled();
+    await act(async () => renderer.unmount());
+  });
+
+  it('labels connected Cursor fallback responses as stale', async () => {
     vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({
       connected: true,
       fastUsed: 231,
       fastLimit: 500,
       percentage: 46.2,
+      error: 'Cursor network refresh failed',
+    });
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CursorPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Cursor network refresh failed');
+    expect(text).toContain('Stale data');
+    expect(text).toContain('Showing last known data');
+    await act(async () => renderer.unmount());
+  });
+
+  it('shows Cursor request counts with the percentage and separates account metadata', async () => {
+    vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({
+      connected: true,
+      fastUsed: 615,
+      fastLimit: 500,
+      percentage: 123,
       email: 'developer@example.com',
     });
     let renderer!: ReactTestRenderer;
@@ -123,9 +372,11 @@ describe('provider status UI', () => {
       await Promise.resolve();
     });
 
-    expect(renderedText(renderer)).toContain('231 / 500 · 46%');
+    expect(renderedText(renderer)).toContain('615 / 500 · 123%');
     expect(renderer.root.findAllByProps({ className: 'account-strip' })).toHaveLength(1);
-    expect(renderer.root.findAllByProps({ role: 'progressbar' })).toHaveLength(1);
+    const progress = renderer.root.findByProps({ role: 'progressbar' });
+    expect(progress.props['aria-valuenow']).toBe(100);
+    expect(progress.props['aria-valuetext']).toBe('123% used');
     await act(async () => renderer.unmount());
   });
 });

--- a/tests/panel_status_ui.test.tsx
+++ b/tests/panel_status_ui.test.tsx
@@ -1,0 +1,131 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import AntigravityPanel from '../src/components/AntigravityPanel';
+import ClaudePanel from '../src/components/ClaudePanel';
+import CursorPanel from '../src/components/CursorPanel';
+import OverviewPanel from '../src/components/OverviewPanel';
+import ProviderDetailHeader from '../src/components/ProviderDetailHeader';
+import { backend } from '../src/services/backend';
+
+const hiddenSections = { timeline: false, cost: false, trend: false, tips: false };
+
+function renderedText(renderer: ReactTestRenderer): string {
+  return JSON.stringify(renderer.toJSON());
+}
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe('provider status UI', () => {
+  it('keeps connection, plan, and usage visible in the provider header', async () => {
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(ProviderDetailHeader, {
+        service: 'cursor',
+        status: 'Connected',
+        plan: 'Cursor Pro',
+        usedPercent: 47,
+      }));
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Cursor');
+    expect(text).toContain('Connected');
+    expect(text).toContain('Cursor Pro');
+    expect(text).toContain('47% used');
+  });
+
+  it('labels the overview independently and exposes the connected count', async () => {
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(OverviewPanel, {
+        summaries: [
+          { id: 'claude', label: 'Claude', shortLabel: 'Claude', initials: 'C', accent: '#000', connected: true, loading: false, usedPercent: 82, statusText: '82% used' },
+          { id: 'codex', label: 'Codex', shortLabel: 'Codex', initials: 'Co', accent: '#000', connected: false, loading: false, usedPercent: null, statusText: 'Offline' },
+        ],
+        mostConstrained: [{ provider: 'claude', providerLabel: 'Claude', label: '7-day usage', usedPercent: 82 }],
+        upcomingResets: [],
+        costRefreshKey: 0,
+        onProviderSelect: vi.fn(),
+        sections: hiddenSections,
+      }));
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Overview');
+    expect(text).toContain('1 of 2 connected');
+  });
+
+  it('keeps last-known Claude data visible after a refresh error', async () => {
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(ClaudePanel, {
+        quota: {
+          connected: true,
+          weeklyTotal: { used: 41, limit: 100, percentage: 41 },
+        },
+        loading: false,
+        error: 'Refresh failed',
+        windowVisible: true,
+        costRefreshKey: 0,
+        onRetry: vi.fn(),
+        sections: hiddenSections,
+      }));
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Refresh failed');
+    expect(text).toContain('Showing last known data');
+    expect(text).toContain('41%');
+  });
+
+  it('shows a connected Antigravity state without an offline contradiction', async () => {
+    vi.spyOn(backend, 'getAntigravityInfo').mockResolvedValue({ connected: true, status: 'preview' });
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(AntigravityPanel, { autoRefreshIntervalMs: 0 }));
+      await Promise.resolve();
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('CLI detected');
+    expect(text).toContain('Antigravity is connected');
+    expect(text).not.toContain('Antigravity is not connected');
+    expect(text).not.toContain('⧉');
+    await act(async () => renderer.unmount());
+  });
+
+  it('shows Cursor request counts with the percentage and separates account metadata', async () => {
+    vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({
+      connected: true,
+      fastUsed: 231,
+      fastLimit: 500,
+      percentage: 46.2,
+      email: 'developer@example.com',
+    });
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CursorPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(renderedText(renderer)).toContain('231 / 500 · 46%');
+    expect(renderer.root.findAllByProps({ className: 'account-strip' })).toHaveLength(1);
+    expect(renderer.root.findAllByProps({ role: 'progressbar' })).toHaveLength(1);
+    await act(async () => renderer.unmount());
+  });
+});


### PR DESCRIPTION
## Summary

- keep connection state, plan context, and peak usage visible together in provider headers
- give Overview an independent identity and emphasize the most constrained quota row
- preserve last-known Claude quota after transient errors and render truthful Antigravity states
- show Cursor request counts with percentage, separate account metadata, and add progress semantics

Closes #73

## Verification

- [x] `npm test` (355 passed)
- [x] `npm run build`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test` (44 passed, 2 ignored)
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

## AI assistance

AI-assisted implementation and test review were used for this change.