### PR TITLE
Refine quota panel information hierarchy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -655,11 +655,10 @@ export default function App() {
   const nonClaudeRefreshIntervalMs = windowVisible
     ? AUTO_REFRESH_INTERVAL_MS
     : BACKGROUND_REFRESH_INTERVAL_MS;
-  // Keep this short: the footer status slot only fits ~8 characters.
   const footerStatus = activeLoading
     ? 'Updating...'
     : lastUpdatedAt != null
-      ? `Upd. ${formatEventTime(new Date(lastUpdatedAt).toISOString())}`
+      ? `Updated ${formatEventTime(new Date(lastUpdatedAt).toISOString())}`
       : '';
   const footerStatusTitle = lastUpdatedAt != null
     ? `Last updated ${new Date(lastUpdatedAt).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`
@@ -782,6 +781,7 @@ export default function App() {
               loading={activeLoading}
               statusText={footerStatus}
               statusTitle={footerStatusTitle}
+              showDashboard={providerViewActive}
             />
           </>
         )}

--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -1,5 +1,3 @@
-import type { CSSProperties } from 'react';
-
 interface ActionButtonsProps {
   onRefresh: () => void;
   onDashboard: () => void;
@@ -9,84 +7,8 @@ interface ActionButtonsProps {
   settingsActive?: boolean;
   statusText?: string;
   statusTitle?: string;
+  showDashboard?: boolean;
 }
-
-const footerDividerStyle: CSSProperties = {
-  height: '1px',
-  background: 'var(--line,rgba(0,0,0,0.08))',
-  margin: '6px 4px 0',
-};
-
-const footerStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: '4px',
-  padding: '7px 6px 4px',
-  flexWrap: 'nowrap',
-  overflow: 'hidden',
-};
-
-const baseButtonStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flex: '0 0 auto',
-  border: 0,
-  appearance: 'none',
-  boxShadow: 'none',
-  cursor: 'pointer',
-  color: 'var(--text)',
-  background: 'transparent',
-  fontFamily: 'inherit',
-};
-
-const refreshButtonStyle: CSSProperties = {
-  ...baseButtonStyle,
-  gap: '5px',
-  padding: '5px 11px',
-  borderRadius: '7px',
-  fontSize: '12px',
-  fontWeight: 600,
-  background: 'rgba(10,132,255,0.12)',
-  color: 'var(--acc,#0A6DDB)',
-};
-
-const refreshIconStyle: CSSProperties = {
-  display: 'inline-block',
-  fontSize: '13px',
-};
-
-const dashboardButtonStyle: CSSProperties = {
-  ...baseButtonStyle,
-  gap: '5px',
-  padding: '5px 9px',
-  borderRadius: '7px',
-  fontSize: '12px',
-  fontWeight: 500,
-};
-
-const statusStyle: CSSProperties = {
-  flex: '1 1 76px',
-  minWidth: '76px',
-  textAlign: 'right',
-  fontSize: '11px',
-  lineHeight: '14px',
-  color: 'var(--sub,rgba(60,60,67,0.6))',
-  paddingRight: '4px',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-};
-
-const iconButtonStyle: CSSProperties = {
-  ...baseButtonStyle,
-  width: '26px',
-  height: '26px',
-  flexBasis: '26px',
-  padding: 0,
-  borderRadius: '7px',
-  color: 'var(--sub,rgba(60,60,67,0.7))',
-};
 
 export default function ActionButtons({
   onRefresh,
@@ -97,43 +19,51 @@ export default function ActionButtons({
   settingsActive = false,
   statusText,
   statusTitle,
+  showDashboard = true,
 }: ActionButtonsProps) {
   return (
     <>
-      <div className="footer-divider" style={footerDividerStyle} />
-      <div className="action-buttons" style={footerStyle}>
+      <div className="footer-divider" />
+      <div className="action-buttons" aria-busy={loading}>
         <button
+          type="button"
           className="action-btn refresh-btn"
-          style={refreshButtonStyle}
           onClick={onRefresh}
           disabled={loading}
           title="Refresh"
           aria-label="Refresh current provider"
         >
-          <span className="btn-icon" style={refreshIconStyle}>{loading ? '...' : '↻'}</span>
+          <span className="btn-icon">{loading ? '...' : '↻'}</span>
           <span className="btn-text">{loading ? 'Loading' : 'Refresh'}</span>
         </button>
 
-        <button
-          className="action-btn dashboard-btn"
-          style={dashboardButtonStyle}
-          onClick={onDashboard}
-          title="Open dashboard"
-          aria-label="Open provider dashboard"
-        >
-          <span className="btn-text">Dashboard</span>
-          <span className="btn-icon dashboard-arrow">↗</span>
-        </button>
+        {showDashboard && (
+          <button
+            type="button"
+            className="action-btn dashboard-btn"
+            onClick={onDashboard}
+            title="Open dashboard"
+            aria-label="Open provider dashboard"
+          >
+            <span className="btn-text">Dashboard</span>
+            <span className="btn-icon dashboard-arrow">↗</span>
+          </button>
+        )}
 
         {statusText && (
-          <span className="action-status" style={statusStyle} title={statusTitle ?? statusText}>
+          <span
+            className="action-status"
+            role="status"
+            aria-live="polite"
+            title={statusTitle ?? statusText}
+          >
             {statusText}
           </span>
         )}
 
         <button
+          type="button"
           className={`action-btn icon-action settings-btn ${settingsActive ? 'active' : ''}`}
-          style={iconButtonStyle}
           onClick={onSettings}
           title="Settings"
           aria-label="Open settings"
@@ -146,8 +76,8 @@ export default function ActionButtons({
         </button>
 
         <button
+          type="button"
           className="action-btn icon-action quit-btn"
-          style={iconButtonStyle}
           onClick={onQuit}
           title="Quit"
           aria-label="Quit QuotaBar"

--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -25,6 +25,11 @@ export default function ActionButtons({
     <>
       <div className="footer-divider" />
       <div className="action-buttons" aria-busy={loading}>
+        {loading && (
+          <span className="action-announcement" role="status" aria-live="polite">
+            Updating quota data
+          </span>
+        )}
         <button
           type="button"
           className="action-btn refresh-btn"
@@ -53,8 +58,7 @@ export default function ActionButtons({
         {statusText && (
           <span
             className="action-status"
-            role="status"
-            aria-live="polite"
+            aria-live="off"
             title={statusTitle ?? statusText}
           >
             {statusText}

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -297,8 +297,11 @@ export default function CostSummarySection({
   return (
     <div className="section cost-section">
       <div className="cost-title-row">
-        <span className="section-title">Local cost</span>
-        {overview && <span className="cost-note">{formatCostNote(primaryRange)}</span>}
+        <span className="section-title">API-equivalent usage</span>
+        <span className="cost-title-meta">
+          <span className="cost-estimate-badge">Local estimate</span>
+          {overview && <span className="cost-note">{formatCostNote(primaryRange)}</span>}
+        </span>
       </div>
 
       {loading && !overview && (
@@ -337,7 +340,15 @@ export default function CostSummarySection({
                       {formatMoney(monthlyBudget, monthRange?.currency ?? 'USD')}
                     </strong>
                   </div>
-                  <div className="budget-track">
+                  <div
+                    className="budget-track"
+                    role="progressbar"
+                    aria-label="Monthly API-equivalent budget used"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={Math.min(100, Math.round(budgetPercent))}
+                    aria-valuetext={`${Math.round(budgetPercent)}% of monthly budget used`}
+                  >
                     <div className="budget-fill" style={getProgressStyle(budgetPercent)} />
                   </div>
                 </div>
@@ -355,16 +366,20 @@ export default function CostSummarySection({
                           const height = maxCost > 0 ? Math.max(8, (value / maxCost) * 100) : 8;
                           const isHovered = hoveredDay?.date === day.date;
                           return (
-                            <div
+                            <button
+                              type="button"
                               className={`spark-bar-hit ${isHovered ? 'hovered' : ''}`}
                               key={day.date}
                               onMouseEnter={() => setHoveredDay(day)}
+                              onFocus={() => setHoveredDay(day)}
+                              onBlur={() => setHoveredDay(null)}
+                              aria-label={`${day.date}: ${formatMoney(value, primaryRange.currency)}`}
                             >
                               <div
                                 className={`spark-bar ${index === sparkDays.length - 1 ? 'latest' : ''} ${isHovered ? 'hovered' : ''}`}
                                 style={{ height: `${height}%` }}
                               />
-                            </div>
+                            </button>
                           );
                         })}
                       </div>

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -212,6 +212,7 @@ export default function CostSummarySection({
   const [daily, setDaily] = useState<CostDailyPoint[] | null>(null);
   const [sparkRange, setSparkRange] = useState<SparkRange>('7d');
   const [hoveredDay, setHoveredDay] = useState<CostDailyPoint | null>(null);
+  const [focusedDay, setFocusedDay] = useState<CostDailyPoint | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const sourceKey = Array.isArray(source) ? source.join(',') : source;
@@ -358,35 +359,71 @@ export default function CostSummarySection({
                 (() => {
                   const sparkDays = sliceSparkDays(daily, sparkRange);
                   const maxCost = Math.max(...sparkDays.map((day) => day.costUsd ?? day.cost ?? 0), 0);
+                  const focusedIndex = focusedDay
+                    ? sparkDays.findIndex((day) => day.date === focusedDay.date)
+                    : -1;
+                  const inspectedCandidate = hoveredDay ?? focusedDay;
+                  const inspectedIndex = inspectedCandidate
+                    ? sparkDays.findIndex((day) => day.date === inspectedCandidate.date)
+                    : -1;
+                  const inspectedDay = inspectedIndex >= 0 ? sparkDays[inspectedIndex] : null;
+                  const activeIndex = inspectedIndex >= 0 ? inspectedIndex : sparkDays.length - 1;
+                  const activeDay = sparkDays[activeIndex];
+                  const activeValue = activeDay?.costUsd ?? activeDay?.cost ?? 0;
+                  const focusDay = (index: number) => {
+                    const day = sparkDays[index];
+                    if (day) setFocusedDay(day);
+                  };
                   return (
                     <>
-                      <div className="spark-bars" onMouseLeave={() => setHoveredDay(null)}>
+                      <div
+                        className="spark-bars"
+                        role="slider"
+                        tabIndex={0}
+                        aria-label="Daily API-equivalent usage trend"
+                        aria-valuemin={1}
+                        aria-valuemax={sparkDays.length}
+                        aria-valuenow={activeIndex + 1}
+                        aria-valuetext={`${activeDay.date}: ${formatMoney(activeValue, primaryRange.currency)}`}
+                        onFocus={() => focusDay(activeIndex)}
+                        onBlur={() => setFocusedDay(null)}
+                        onMouseLeave={() => setHoveredDay(null)}
+                        onKeyDown={(event) => {
+                          const keyboardIndex = focusedIndex >= 0 ? focusedIndex : activeIndex;
+                          let nextIndex = keyboardIndex;
+                          if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') nextIndex = Math.max(0, keyboardIndex - 1);
+                          else if (event.key === 'ArrowRight' || event.key === 'ArrowUp') nextIndex = Math.min(sparkDays.length - 1, keyboardIndex + 1);
+                          else if (event.key === 'Home') nextIndex = 0;
+                          else if (event.key === 'End') nextIndex = sparkDays.length - 1;
+                          else return;
+                          event.preventDefault();
+                          setHoveredDay(null);
+                          focusDay(nextIndex);
+                        }}
+                      >
                         {sparkDays.map((day, index) => {
                           const value = day.costUsd ?? day.cost ?? 0;
                           const height = maxCost > 0 ? Math.max(8, (value / maxCost) * 100) : 8;
-                          const isHovered = hoveredDay?.date === day.date;
+                          const isHovered = inspectedDay?.date === day.date;
                           return (
-                            <button
-                              type="button"
+                            <span
                               className={`spark-bar-hit ${isHovered ? 'hovered' : ''}`}
                               key={day.date}
                               onMouseEnter={() => setHoveredDay(day)}
-                              onFocus={() => setHoveredDay(day)}
-                              onBlur={() => setHoveredDay(null)}
-                              aria-label={`${day.date}: ${formatMoney(value, primaryRange.currency)}`}
+                              aria-hidden="true"
                             >
-                              <div
+                              <span
                                 className={`spark-bar ${index === sparkDays.length - 1 ? 'latest' : ''} ${isHovered ? 'hovered' : ''}`}
                                 style={{ height: `${height}%` }}
                               />
-                            </button>
+                            </span>
                           );
                         })}
                       </div>
                       <div className="cost-footer">
-                        <span className={hoveredDay ? 'spark-hover-label' : undefined}>
-                          {hoveredDay
-                            ? `${hoveredDay.date} · ${formatMoney(hoveredDay.costUsd ?? hoveredDay.cost ?? 0, primaryRange.currency)}`
+                        <span className={inspectedDay ? 'spark-hover-label' : undefined}>
+                          {inspectedDay
+                            ? `${inspectedDay.date} · ${formatMoney(inspectedDay.costUsd ?? inspectedDay.cost ?? 0, primaryRange.currency)}`
                             : `${sparkRange === '7d' ? 'Past 7 days' : 'Past 30 days'} · ${formatMoney(sumDailyCost(sparkDays), primaryRange.currency)}`}
                         </span>
                         <span className="spark-range-chips">

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -162,6 +162,9 @@ export default function SettingsView({
             const panelEnabled = switcherVisibility[service];
             const panelLocked = panelEnabled && enabledSwitcherCount === 1;
             const trayLocked = !trayEntry || (trayEntry.enabled && !trayEntry.canDisable);
+            const connectionHint = trayEntry?.connected
+              ? trayEntry.connectedHint ?? 'Connected'
+              : trayEntry?.disconnectedHint ?? 'Offline';
             return (
               <div className="provider-visibility-row" key={service}>
                 <span className="provider-visibility-service">
@@ -171,7 +174,7 @@ export default function SettingsView({
                   <span>
                     <strong>{meta.label}</strong>
                     <small className={trayEntry?.connected ? 'connected' : ''}>
-                      {trayEntry?.connected ? 'Connected' : 'Offline'}
+                      {connectionHint}
                     </small>
                   </span>
                 </span>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import ThemeSelector, { type ThemeName } from './ThemeSelector';
-import TrayToggles, { type TrayToggleEntry } from './TrayToggles';
+import type { TrayToggleEntry } from './TrayToggles';
+import ProviderIcon from './ProviderIcon';
 import type { TrayServiceName } from '../services/tray_visibility';
 import {
   BUDGET_SOURCES,
@@ -69,6 +70,8 @@ export default function SettingsView({
   onSwitcherToggle,
 }: SettingsViewProps) {
   const [budgets, setBudgets] = useState<MonthlyBudgets>(getSavedMonthlyBudgets);
+  const enabledSwitcherCount = SERVICES.filter((service) => switcherVisibility[service]).length;
+  const trayByService = new Map(trayEntries.map((entry) => [entry.service, entry]));
 
   const handleBudgetChange = (source: CostSource, raw: string) => {
     setBudgets((prev) => {
@@ -101,13 +104,16 @@ export default function SettingsView({
         </div>
       </div>
 
-      <div className="settings-block">
-        <div className="settings-section-title">Appearance</div>
+      <section className="settings-group" aria-labelledby="settings-appearance-title">
+        <div className="settings-group-header">
+          <span className="settings-group-index">01</span>
+          <div>
+            <h2 id="settings-appearance-title">Appearance</h2>
+            <p>Theme and menu bar presentation</p>
+          </div>
+        </div>
         <ThemeSelector currentTheme={theme} onThemeChange={onThemeChange} />
-      </div>
-
-      <div className="settings-block">
-        <div className="settings-section-title">Menu bar style</div>
+        <div className="settings-subsection-title">Menu bar style</div>
         <div className="settings-seg">
           {TRAY_STYLE_OPTIONS.map((option) => (
             <button
@@ -115,6 +121,7 @@ export default function SettingsView({
               type="button"
               className={`settings-seg-btn ${trayStyle === option.id ? 'active' : ''}`}
               onClick={() => onTrayStyleChange(option.id)}
+              aria-pressed={trayStyle === option.id}
             >
               {option.label}
             </button>
@@ -133,43 +140,106 @@ export default function SettingsView({
             <span />
           </button>
         </div>
-      </div>
+      </section>
 
-      <div className="settings-block">
-        <div className="settings-section-title">Switcher providers</div>
-        {SERVICES.map((service) => (
-          <label className="settings-line" key={service}>
-            <span>{SERVICE_META[service].label}</span>
-            <input
-              className="native-switch-input"
-              type="checkbox"
-              checked={switcherVisibility[service]}
-              onChange={() => onSwitcherToggle(service)}
-            />
-            <span className={`target-switch ${switcherVisibility[service] ? 'on' : ''}`}><span /></span>
-          </label>
-        ))}
-        <div className="settings-hint">Hidden providers keep refreshing; at least one stays visible.</div>
-      </div>
+      <section className="settings-group" aria-labelledby="settings-providers-title">
+        <div className="settings-group-header">
+          <span className="settings-group-index">02</span>
+          <div>
+            <h2 id="settings-providers-title">Providers</h2>
+            <p>Choose where each service appears</p>
+          </div>
+        </div>
+        <div className="provider-visibility-grid">
+          <div className="provider-visibility-head" aria-hidden="true">
+            <span>Service</span>
+            <span>Panel</span>
+            <span>Menu</span>
+          </div>
+          {SERVICES.map((service) => {
+            const meta = SERVICE_META[service];
+            const trayEntry = trayByService.get(service);
+            const panelEnabled = switcherVisibility[service];
+            const panelLocked = panelEnabled && enabledSwitcherCount === 1;
+            const trayLocked = !trayEntry || (trayEntry.enabled && !trayEntry.canDisable);
+            return (
+              <div className="provider-visibility-row" key={service}>
+                <span className="provider-visibility-service">
+                  <span className={`provider-mini-icon provider-${service}`} aria-hidden="true">
+                    <ProviderIcon service={service} />
+                  </span>
+                  <span>
+                    <strong>{meta.label}</strong>
+                    <small className={trayEntry?.connected ? 'connected' : ''}>
+                      {trayEntry?.connected ? 'Connected' : 'Offline'}
+                    </small>
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={panelEnabled}
+                  aria-disabled={panelLocked}
+                  aria-label={`Show ${meta.label} in panel`}
+                  className={`target-switch compact ${panelEnabled ? 'on' : ''}`}
+                  disabled={panelLocked}
+                  onClick={() => onSwitcherToggle(service)}
+                >
+                  <span />
+                </button>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={trayEntry?.enabled ?? false}
+                  aria-disabled={trayLocked}
+                  aria-label={`Show ${meta.label} in menu bar`}
+                  className={`target-switch compact ${trayEntry?.enabled ? 'on' : ''}`}
+                  disabled={trayLocked}
+                  onClick={() => onTrayToggle(service)}
+                >
+                  <span />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+        <div className="settings-hint">Hidden panel providers still refresh in the background.</div>
+      </section>
 
-      <div className="settings-block">
-        <div className="settings-section-title">Panel sections</div>
+      <section className="settings-group" aria-labelledby="settings-sections-title">
+        <div className="settings-group-header">
+          <span className="settings-group-index">03</span>
+          <div>
+            <h2 id="settings-sections-title">Panel content</h2>
+            <p>Show only the sections you use</p>
+          </div>
+        </div>
         {PANEL_SECTION_ORDER.map((key) => (
-          <label className="settings-line" key={key}>
+          <div className="settings-line" key={key}>
             <span>{PANEL_SECTION_LABELS[key]}</span>
-            <input
-              className="native-switch-input"
-              type="checkbox"
-              checked={panelSections[key]}
-              onChange={() => onPanelSectionToggle(key)}
-            />
-            <span className={`target-switch ${panelSections[key] ? 'on' : ''}`}><span /></span>
-          </label>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={panelSections[key]}
+              aria-label={`Show ${PANEL_SECTION_LABELS[key]}`}
+              className={`target-switch ${panelSections[key] ? 'on' : ''}`}
+              onClick={() => onPanelSectionToggle(key)}
+            >
+              <span />
+            </button>
+          </div>
         ))}
-      </div>
+      </section>
 
-      <div className="settings-block">
-        <div className="settings-section-title">Monthly budgets</div>
+      <section className="settings-group" aria-labelledby="settings-alerts-title">
+        <div className="settings-group-header">
+          <span className="settings-group-index">04</span>
+          <div>
+            <h2 id="settings-alerts-title">Limits & alerts</h2>
+            <p>Budgets and usage notifications</p>
+          </div>
+        </div>
+        <div className="settings-subsection-title">Monthly budgets</div>
         {BUDGET_SOURCES.map((source) => (
           <label className="settings-line" key={source}>
             <span>{SERVICE_META[source].label}</span>
@@ -188,32 +258,34 @@ export default function SettingsView({
             </span>
           </label>
         ))}
-        <div className="settings-hint">Shown as a budget bar in the Local cost section.</div>
-      </div>
-
-      <div className="settings-block">
-        <div className="settings-section-title">Notifications</div>
+        <div className="settings-hint">Shown in the API-equivalent usage section.</div>
+        <div className="settings-subsection-title settings-subsection-divider">Notifications</div>
         {NOTIFICATION_ROWS.map(({ key, label }) => (
-          <label className="settings-line" key={key}>
+          <div className="settings-line" key={key}>
             <span>{label}</span>
-            <input
-              className="native-switch-input"
-              type="checkbox"
-              checked={notificationSettings[key]}
-              onChange={() => onNotificationToggle(key)}
-            />
-            <span className={`target-switch ${notificationSettings[key] ? 'on' : ''}`}><span /></span>
-          </label>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={notificationSettings[key]}
+              aria-label={label}
+              className={`target-switch ${notificationSettings[key] ? 'on' : ''}`}
+              onClick={() => onNotificationToggle(key)}
+            >
+              <span />
+            </button>
+          </div>
         ))}
-      </div>
+      </section>
 
-      <div className="settings-block">
-        <div className="settings-section-title">Menu bar items</div>
-        <TrayToggles entries={trayEntries} onToggle={onTrayToggle} />
-      </div>
-
-      <div className="settings-block">
-        <div className="settings-section-title">Recent events</div>
+      <section className="settings-group" aria-labelledby="settings-system-title">
+        <div className="settings-group-header">
+          <span className="settings-group-index">05</span>
+          <div>
+            <h2 id="settings-system-title">Activity & system</h2>
+            <p>Recent status changes and app behavior</p>
+          </div>
+        </div>
+        <div className="settings-subsection-title">Recent events</div>
         {events.length > 0 ? (
           <div className="event-list">
             {events.slice(0, 6).map((event) => (
@@ -227,23 +299,26 @@ export default function SettingsView({
         ) : (
           <div className="settings-hint">No events yet.</div>
         )}
-      </div>
 
-      {isMacOS && (
-        <div className="settings-block">
-          <div className="settings-section-title">Dock</div>
-          <label className="settings-line">
-            <span>Hide Dock icon</span>
-            <input
-              className="native-switch-input"
-              type="checkbox"
-              checked={dockHidden}
-              onChange={onDockToggle}
-            />
-            <span className={`target-switch ${dockHidden ? 'on' : ''}`}><span /></span>
-          </label>
-        </div>
-      )}
+        {isMacOS && (
+          <>
+            <div className="settings-subsection-title settings-subsection-divider">Dock</div>
+            <div className="settings-line">
+              <span>Hide Dock icon</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={dockHidden}
+                aria-label="Hide Dock icon"
+                className={`target-switch ${dockHidden ? 'on' : ''}`}
+                onClick={onDockToggle}
+              >
+                <span />
+              </button>
+            </div>
+          </>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/components/TabSwitcher.tsx
+++ b/src/components/TabSwitcher.tsx
@@ -15,7 +15,7 @@ export default function TabSwitcher({
   summaries,
 }: TabSwitcherProps) {
   return (
-    <div className="provider-grid" role="tablist" aria-label="Provider views">
+    <nav className="provider-grid" aria-label="Provider views">
       {[
         {
           id: 'all' as const,
@@ -42,9 +42,7 @@ export default function TabSwitcher({
             type="button"
             className={`provider-card ${isActive ? 'active' : ''} ${summary.connected ? 'connected' : 'disconnected'}`}
             data-provider={summary.id}
-            role="tab"
-            aria-selected={isActive}
-            tabIndex={isActive ? 0 : -1}
+            aria-current={isActive ? 'page' : undefined}
             aria-label={`${summary.label}: ${statusText}`}
             title={`${summary.label} · ${statusText}`}
             onClick={() => onTabChange(summary.id)}
@@ -66,6 +64,6 @@ export default function TabSwitcher({
           </button>
         );
       })}
-    </div>
+    </nav>
   );
 }

--- a/src/components/TabSwitcher.tsx
+++ b/src/components/TabSwitcher.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from 'react';
 import type { AppTabName, ProviderSummary } from '../services/provider_summary';
 import ProviderIcon from './ProviderIcon';
 
@@ -10,35 +9,13 @@ interface TabSwitcherProps {
   summaries: ProviderSummary[];
 }
 
-const TILE_GRADIENTS: Record<AppTabName, string> = {
-  all: 'linear-gradient(145deg,#8e9bb3,#4a5568)',
-  claude: 'linear-gradient(145deg,#E8916C,#C4552F)',
-  codex: 'linear-gradient(145deg,#2ec59a,#0d8a6a)',
-  cursor: 'linear-gradient(145deg,#52525e,#17171d)',
-  antigravity: 'linear-gradient(145deg,#5a9cff,#8a63f0)',
-};
-
-const providerGridStyle: CSSProperties = {
-  display: 'flex',
-  background: 'var(--track,rgba(0,0,0,0.07))',
-  borderRadius: '10px',
-  padding: '2px',
-};
-
-const iconSvgStyle: CSSProperties = {
-  width: '12px',
-  height: '12px',
-  fill: '#fff',
-  display: 'block',
-};
-
 export default function TabSwitcher({
   activeTab,
   onTabChange,
   summaries,
 }: TabSwitcherProps) {
   return (
-    <div className="provider-grid" style={providerGridStyle} aria-label="Providers">
+    <div className="provider-grid" role="tablist" aria-label="Provider views">
       {[
         {
           id: 'all' as const,
@@ -55,67 +32,37 @@ export default function TabSwitcher({
       ].map((summary) => {
         const isActive = activeTab === summary.id;
         const usageLabel = summary.usedPercent == null ? '—' : `${Math.round(summary.usedPercent)}%`;
-        const rowStyle: CSSProperties = {
-          flex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          padding: '7px 0 6px',
-          border: 0,
-          borderRadius: '8px',
-          cursor: 'pointer',
-          background: isActive ? 'var(--seg)' : 'transparent',
-          boxShadow: isActive ? '0 1px 4px rgba(0,0,0,0.14), 0 0 0 0.5px var(--line)' : 'none',
-          opacity: isActive ? 1 : 0.75,
-          transition: 'background 0.2s, box-shadow 0.2s, opacity 0.2s',
-          appearance: 'none',
-          color: 'var(--text)',
-          font: 'inherit',
-          margin: 0,
-          minWidth: 0,
-          textAlign: 'center',
-        };
-        const glyphStyle: CSSProperties = {
-          width: '22px',
-          height: '22px',
-          borderRadius: '6px',
-          background: TILE_GRADIENTS[summary.id],
-          opacity: summary.connected ? 1 : 0.45,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: '#fff',
-          flex: 'none',
-          boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.3), 0 1px 2px rgba(0,0,0,0.15)',
-        };
-        const pctStyle: CSSProperties = {
-          fontSize: '11px',
-          fontWeight: 600,
-          fontVariantNumeric: 'tabular-nums',
-          marginTop: '5px',
-        };
+        const statusText = 'statusText' in summary
+          ? summary.statusText
+          : summary.connected ? 'Providers connected' : 'No providers connected';
 
         return (
           <button
             key={summary.id}
             type="button"
-            className={`provider-card ${isActive ? 'active' : ''}`}
+            className={`provider-card ${isActive ? 'active' : ''} ${summary.connected ? 'connected' : 'disconnected'}`}
             data-provider={summary.id}
-            style={rowStyle}
-            aria-current={isActive ? 'page' : undefined}
-            title={summary.label}
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            aria-label={`${summary.label}: ${statusText}`}
+            title={`${summary.label} · ${statusText}`}
             onClick={() => onTabChange(summary.id)}
           >
-            <span className="provider-card-icon" style={glyphStyle} aria-hidden="true">
+            <span className="provider-card-topline">
+              <span className="provider-card-icon" aria-hidden="true">
               {summary.id === 'all' ? (
-                <svg className="provider-card-svg" style={iconSvgStyle} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <svg className="provider-card-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                   <path d="M3 3h8v8H3Zm10 0h8v8h-8ZM3 13h8v8H3Zm10 0h8v8h-8Z" />
                 </svg>
               ) : (
-                <ProviderIcon service={summary.id} className="provider-card-svg" style={iconSvgStyle} />
+                <ProviderIcon service={summary.id} className="provider-card-svg" />
               )}
+              </span>
+              <span className="provider-card-status" aria-hidden="true" />
             </span>
-            <span className="provider-card-percent" style={pctStyle}>{usageLabel}</span>
+            <span className="provider-card-label">{summary.shortLabel}</span>
+            <span className="provider-card-percent">{usageLabel}</span>
           </button>
         );
       })}

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -3,16 +3,17 @@ export type ThemeName = 'light' | 'dark' | 'claude' | 'claude-dark' | 'minimal' 
 interface Theme {
   id: ThemeName;
   name: string;
+  shortName: string;
 }
 
 const themes: Theme[] = [
-  { id: 'light', name: 'Light' },
-  { id: 'dark', name: 'Dark' },
-  { id: 'claude', name: 'Claude' },
-  { id: 'claude-dark', name: 'Claude Dark' },
-  { id: 'minimal', name: 'Minimal' },
-  { id: 'minimal-dark', name: 'Minimal Dark' },
-  { id: 'ocean', name: 'Ocean' },
+  { id: 'light', name: 'Light', shortName: 'Light' },
+  { id: 'dark', name: 'Dark', shortName: 'Dark' },
+  { id: 'claude', name: 'Claude', shortName: 'Claude' },
+  { id: 'claude-dark', name: 'Claude Dark', shortName: 'C. Dark' },
+  { id: 'minimal', name: 'Minimal', shortName: 'Minimal' },
+  { id: 'minimal-dark', name: 'Minimal Dark', shortName: 'M. Dark' },
+  { id: 'ocean', name: 'Ocean', shortName: 'Ocean' },
 ];
 
 interface ThemeSelectorProps {
@@ -25,13 +26,18 @@ export default function ThemeSelector({ currentTheme, onThemeChange }: ThemeSele
     <div className="theme-selector">
       {themes.map((theme) => (
         <button
+          type="button"
           key={theme.id}
           className={`theme-btn ${currentTheme === theme.id ? 'active' : ''}`}
           data-theme={theme.id}
           onClick={() => onThemeChange(theme.id)}
           title={theme.name}
           aria-label={`Switch to ${theme.name} theme`}
-        />
+          aria-pressed={currentTheme === theme.id}
+        >
+          <span className="theme-swatch" aria-hidden="true" />
+          <span className="theme-option-label">{theme.shortName}</span>
+        </button>
       ))}
     </div>
   );

--- a/src/redesign-settings.css
+++ b/src/redesign-settings.css
@@ -270,9 +270,18 @@
 }
 
 .settings-group .settings-line {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   min-height: 32px;
   padding: 0;
+  color: var(--text);
   font-size: 12px;
+}
+
+.settings-group .settings-line > span:first-child {
+  flex: 1;
+  min-width: 0;
 }
 
 .settings-group .settings-line + .settings-line {
@@ -282,14 +291,28 @@
 .settings-group .target-switch {
   width: 34px;
   height: 20px;
+  flex: none;
   padding: 2px;
+  border: 0;
   border-radius: 10px;
+  background: var(--track);
+  cursor: pointer;
+  appearance: none;
 }
 
 .settings-group .target-switch span {
+  display: block;
   width: 16px;
   height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  transform: translateX(0);
   transition: transform 0.14s ease;
+}
+
+.settings-group .target-switch.on {
+  background: #34c759;
 }
 
 .settings-group .target-switch.on span {
@@ -412,11 +435,39 @@
 .provider-mini-icon.provider-antigravity { background: linear-gradient(145deg, #5a9cff, #8a63f0); }
 
 .settings-group .budget-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--sub);
   font-size: 11px;
+  font-variant-numeric: tabular-nums;
 }
 
 .settings-group .budget-input {
+  width: 64px;
+  padding: 4px 7px;
+  border: 0;
+  border-radius: 7px;
+  background: var(--track);
+  box-shadow: 0 0 0 0.5px var(--line);
+  color: var(--text);
+  font: inherit;
   font-size: 11px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+.settings-group .budget-input::-webkit-outer-spin-button,
+.settings-group .budget-input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+}
+
+.settings-group .budget-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 1.5px var(--acc, #0a6ddb);
 }
 
 .settings-group .settings-hint {
@@ -425,9 +476,31 @@
   line-height: 13px;
 }
 
+.settings-group .settings-seg {
+  display: flex;
+  padding: 2px;
+  border-radius: 8px;
+  background: var(--track);
+}
+
 .settings-group .settings-seg-btn {
+  flex: 1;
+  padding: 5px 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--sub);
+  font: inherit;
   font-size: 11px;
   font-weight: 650;
+  text-align: center;
+  cursor: pointer;
+}
+
+.settings-group .settings-seg-btn.active {
+  background: var(--seg);
+  color: var(--text);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
 .settings-group .event-list {
@@ -438,13 +511,47 @@
 }
 
 .settings-group .event-row {
+  display: flex;
+  align-items: center;
   gap: 7px;
   padding: 6px 0;
+  color: var(--text);
   font-size: 10.5px;
 }
 
+.settings-group .event-row + .event-row {
+  border-top: 0.5px solid var(--line);
+}
+
+.settings-group .event-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: #34c759;
+}
+
+.settings-group .event-dot.warning {
+  background: #ff9500;
+}
+
+.settings-group .event-dot.critical {
+  background: #ff3b30;
+}
+
+.settings-group .event-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .settings-group .event-time {
+  flex: none;
+  color: var(--sub);
   font-size: 9px;
+  font-variant-numeric: tabular-nums;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/redesign-settings.css
+++ b/src/redesign-settings.css
@@ -33,256 +33,6 @@
   font-size: 17px;
 }
 
-.settings-block {
-  padding: 2px 10px 4px;
-}
-
-.settings-section-title {
-  margin: 12px 0 8px;
-  color: var(--sub);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.settings-block:first-of-type .settings-section-title {
-  margin-top: 6px;
-}
-
-.theme-selector {
-  display: flex;
-  gap: 0;
-  padding: 2px;
-  border-radius: 8px;
-  background: var(--track);
-}
-
-.theme-btn {
-  flex: 1;
-  width: auto;
-  height: 24px;
-  border: 0;
-  border-radius: 6px;
-  box-shadow: none;
-}
-
-.theme-btn.active {
-  background: var(--seg);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
-}
-
-.settings-line {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 7px 0;
-  color: var(--text);
-  font-size: 13px;
-}
-
-.settings-line > span:first-child {
-  flex: 1;
-}
-
-.target-switch {
-  width: 36px;
-  height: 22px;
-  flex: none;
-  padding: 2px;
-  border-radius: 11px;
-  background: var(--track);
-}
-
-.target-switch span {
-  display: block;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
-  transform: translateX(0);
-}
-
-.target-switch.on {
-  background: #34c759;
-}
-
-.target-switch.on span {
-  transform: translateX(14px);
-}
-
-.native-switch-input {
-  display: none;
-}
-
-.budget-input-wrap {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  color: var(--sub);
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-}
-
-.budget-input {
-  width: 64px;
-  padding: 4px 7px;
-  border: 0;
-  border-radius: 7px;
-  background: var(--track);
-  box-shadow: 0 0 0 0.5px var(--line);
-  color: var(--text);
-  font: inherit;
-  font-size: 12px;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-  appearance: textfield;
-  -moz-appearance: textfield;
-}
-
-.budget-input::-webkit-outer-spin-button,
-.budget-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-.budget-input:focus {
-  outline: none;
-  box-shadow: 0 0 0 1.5px var(--acc, #0a6ddb);
-}
-
-.settings-hint {
-  margin-top: 4px;
-  color: var(--sub);
-  font-size: 11px;
-}
-
-.settings-seg {
-  display: flex;
-  padding: 2px;
-  border-radius: 8px;
-  background: var(--track);
-}
-
-.settings-seg-btn {
-  flex: 1;
-  padding: 5px 0;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--sub);
-  font: inherit;
-  font-size: 12px;
-  font-weight: 600;
-  text-align: center;
-  cursor: pointer;
-}
-
-.settings-seg-btn.active {
-  background: var(--seg);
-  color: var(--text);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
-}
-
-.target-switch {
-  border: 0;
-  cursor: pointer;
-}
-
-.event-list {
-  padding: 3px 12px;
-  border-radius: 11px;
-  background: var(--card);
-  box-shadow: 0 0 0 0.5px var(--line), inset 0 0.5px 0 var(--inner);
-}
-
-.event-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 0;
-  font-size: 11.5px;
-  color: var(--text);
-}
-
-.event-row + .event-row {
-  border-top: 0.5px solid var(--line);
-}
-
-.event-dot {
-  width: 6px;
-  height: 6px;
-  flex: none;
-  border-radius: 50%;
-  background: #34c759;
-}
-
-.event-dot.warning {
-  background: #ff9500;
-}
-
-.event-dot.critical {
-  background: #ff3b30;
-}
-
-.event-text {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.event-time {
-  flex: none;
-  color: var(--sub);
-  font-size: 10px;
-  font-variant-numeric: tabular-nums;
-}
-
-.tray-settings {
-  gap: 0;
-  padding: 0;
-  border-top: 0;
-}
-
-.tray-toggle-list {
-  gap: 0;
-}
-
-.tray-toggle {
-  padding: 7px 0;
-}
-
-.tray-toggle-button {
-  width: 36px;
-  height: 22px;
-  padding: 2px;
-  border: 0;
-  border-radius: 11px;
-  background: var(--track);
-}
-
-.tray-toggle-button.checked {
-  background: #34c759;
-}
-
-.tray-toggle-thumb {
-  top: 2px;
-  left: 2px;
-  width: 18px;
-  height: 18px;
-}
-
-.tray-toggle-button.checked .tray-toggle-thumb {
-  transform: translateX(14px);
-}
-
-.tray-toggle-status,
-.tray-settings > .settings-title {
-  display: none;
-}
 
 .offline-panel {
   margin: 8px 2px 2px;
@@ -361,4 +111,344 @@
   box-shadow: 0 0 0 0.5px var(--line);
   text-align: center;
   font-size: 12px;
+}
+
+/* Task-oriented settings layout. Offline provider panels above continue to
+   share this stylesheet without inheriting the settings card treatment. */
+.settings-view {
+  padding: 4px 5px 8px 2px;
+}
+
+.settings-view-header {
+  gap: 3px;
+  padding: 1px 2px 7px;
+}
+
+.settings-view-header .overview-kicker {
+  display: block;
+  color: var(--sub);
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-view-header h1 {
+  margin-top: 1px;
+  font-size: 15px;
+  line-height: 17px;
+  font-weight: 700;
+}
+
+.settings-back-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  font-size: 19px;
+}
+
+.settings-back-btn:hover {
+  color: var(--text);
+  background: var(--hover);
+}
+
+.settings-group {
+  margin-bottom: 8px;
+  padding: 11px;
+  border-radius: 13px;
+  background: var(--card);
+  box-shadow: 0 0 0 0.5px var(--line), inset 0 0.5px 0 var(--inner);
+  backdrop-filter: blur(14px) saturate(1.35);
+  -webkit-backdrop-filter: blur(14px) saturate(1.35);
+}
+
+.settings-group-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.settings-group-index {
+  flex: none;
+  padding-top: 1px;
+  color: var(--acc);
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 15px;
+}
+
+.settings-group-header h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 15px;
+  font-weight: 700;
+}
+
+.settings-group-header p {
+  margin: 2px 0 0;
+  color: var(--sub);
+  font-size: 10.5px;
+  line-height: 13px;
+}
+
+.settings-subsection-title {
+  margin: 11px 0 5px;
+  color: var(--sub);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.settings-subsection-divider {
+  padding-top: 10px;
+  border-top: 0.5px solid var(--line);
+}
+
+.settings-view .theme-selector {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 4px;
+  padding: 0;
+  background: transparent;
+}
+
+.settings-view .theme-btn,
+.settings-view .theme-btn[data-theme] {
+  width: auto;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 0 5px;
+  border: 0;
+  border-radius: 8px;
+  color: var(--sub);
+  background: var(--track);
+  box-shadow: none;
+  cursor: pointer;
+}
+
+.settings-view .theme-btn.active,
+.settings-view .theme-btn.active[data-theme] {
+  color: var(--text);
+  background: var(--seg);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.14), 0 0 0 0.5px var(--line);
+}
+
+.settings-view .theme-btn.active::after {
+  display: none;
+}
+
+.theme-swatch {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  border-radius: 50%;
+  box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.18);
+}
+
+.theme-btn[data-theme="light"] .theme-swatch { background: #f8f8f8; }
+.theme-btn[data-theme="dark"] .theme-swatch { background: #202026; }
+.theme-btn[data-theme="claude"] .theme-swatch { background: #d97757; }
+.theme-btn[data-theme="claude-dark"] .theme-swatch { background: #7a4736; }
+.theme-btn[data-theme="minimal"] .theme-swatch { background: #a1a1aa; }
+.theme-btn[data-theme="minimal-dark"] .theme-swatch { background: #09090b; }
+.theme-btn[data-theme="ocean"] .theme-swatch { background: #0284c7; }
+
+.theme-option-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 9px;
+  font-weight: 650;
+}
+
+.settings-group .settings-line {
+  min-height: 32px;
+  padding: 0;
+  font-size: 12px;
+}
+
+.settings-group .settings-line + .settings-line {
+  border-top: 0.5px solid var(--line);
+}
+
+.settings-group .target-switch {
+  width: 34px;
+  height: 20px;
+  padding: 2px;
+  border-radius: 10px;
+}
+
+.settings-group .target-switch span {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.14s ease;
+}
+
+.settings-group .target-switch.on span {
+  transform: translateX(14px);
+}
+
+.settings-group .target-switch.compact {
+  width: 30px;
+  height: 18px;
+  padding: 2px;
+  border-radius: 9px;
+}
+
+.settings-group .target-switch.compact span {
+  width: 14px;
+  height: 14px;
+}
+
+.settings-group .target-switch.compact.on span {
+  transform: translateX(12px);
+}
+
+.settings-group .target-switch:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.provider-visibility-grid {
+  overflow: hidden;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--track) 65%, transparent);
+}
+
+.provider-visibility-head,
+.provider-visibility-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 42px 42px;
+  align-items: center;
+}
+
+.provider-visibility-head {
+  padding: 5px 7px 4px;
+  color: var(--sub);
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.provider-visibility-head span:not(:first-child) {
+  text-align: center;
+}
+
+.provider-visibility-row {
+  min-height: 39px;
+  padding: 0 7px;
+}
+
+.provider-visibility-row + .provider-visibility-row {
+  border-top: 0.5px solid var(--line);
+}
+
+.provider-visibility-row > .target-switch {
+  justify-self: center;
+}
+
+.provider-visibility-service {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.provider-visibility-service > span:last-child {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.provider-visibility-service strong {
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11.5px;
+  line-height: 13px;
+}
+
+.provider-visibility-service small {
+  color: var(--sub);
+  font-size: 9px;
+  line-height: 11px;
+}
+
+.provider-visibility-service small.connected {
+  color: var(--target-green);
+}
+
+.provider-mini-icon {
+  width: 20px;
+  height: 20px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  color: #fff;
+  background: linear-gradient(145deg, #8e9bb3, #4a5568);
+}
+
+.provider-mini-icon svg {
+  width: 11px;
+  height: 11px;
+  fill: currentColor;
+}
+
+.provider-mini-icon.provider-claude { background: linear-gradient(145deg, #e8916c, #c4552f); }
+.provider-mini-icon.provider-codex { background: linear-gradient(145deg, #2ec59a, #0d8a6a); }
+.provider-mini-icon.provider-cursor { background: linear-gradient(145deg, #52525e, #17171d); }
+.provider-mini-icon.provider-antigravity { background: linear-gradient(145deg, #5a9cff, #8a63f0); }
+
+.settings-group .budget-input-wrap {
+  font-size: 11px;
+}
+
+.settings-group .budget-input {
+  font-size: 11px;
+}
+
+.settings-group .settings-hint {
+  margin-top: 6px;
+  font-size: 10px;
+  line-height: 13px;
+}
+
+.settings-group .settings-seg-btn {
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.settings-group .event-list {
+  padding: 2px 8px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--track) 65%, transparent);
+  box-shadow: none;
+}
+
+.settings-group .event-row {
+  gap: 7px;
+  padding: 6px 0;
+  font-size: 10.5px;
+}
+
+.settings-group .event-time {
+  font-size: 9px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-group .target-switch span {
+    transition: none;
+  }
 }

--- a/src/redesign/panels.css
+++ b/src/redesign/panels.css
@@ -530,7 +530,8 @@
 .cost-title-row {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
+  gap: 8px;
 }
 
 .cost-title-row .section-title {
@@ -538,9 +539,30 @@
 }
 
 .cost-note {
-  margin: 10px 10px 6px;
+  margin: 0;
   color: var(--sub);
-  font-size: 11px;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.cost-title-meta {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.cost-estimate-badge {
+  flex: none;
+  padding: 2px 5px;
+  border-radius: 5px;
+  color: var(--acc);
+  background: color-mix(in srgb, var(--acc) 10%, transparent);
+  font-size: 8px;
+  line-height: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .cost-panel {
@@ -565,7 +587,8 @@
 }
 
 .cost-range.active {
-  box-shadow: 0 0 0 0.5px var(--line);
+  background: color-mix(in srgb, var(--acc) 8%, var(--card));
+  box-shadow: 0 0 0 0.75px color-mix(in srgb, var(--acc) 34%, var(--line));
 }
 
 .cost-range-label {
@@ -639,7 +662,12 @@
   align-items: flex-end;
   align-self: stretch;
   min-width: 0;
+  padding: 0;
+  border: 0;
   border-radius: 2px;
+  background: transparent;
+  cursor: default;
+  appearance: none;
 }
 
 .spark-bar-hit.hovered {
@@ -719,6 +747,9 @@
 
 .action-btn {
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   min-height: 26px;
   padding: 5px 9px;
   border: 0;
@@ -727,8 +758,14 @@
   background: transparent;
   box-shadow: none;
   cursor: pointer;
+  font-family: inherit;
   font-size: 12px;
   font-weight: 500;
+}
+
+.action-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .action-btn:hover {
@@ -751,8 +788,6 @@
 }
 
 .action-btn.dashboard-btn {
-  display: flex;
-  align-items: center;
   gap: 5px;
 }
 
@@ -779,6 +814,11 @@
   padding: 0;
   color: var(--sub);
   font-size: 14px;
+}
+
+.settings-btn.active {
+  color: var(--acc);
+  background: color-mix(in srgb, var(--acc) 12%, transparent);
 }
 
 .quit-btn {

--- a/src/redesign/panels.css
+++ b/src/redesign/panels.css
@@ -658,6 +658,11 @@
   padding: 0 2px;
 }
 
+.spark-bars:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--acc) 72%, transparent);
+  outline-offset: 3px;
+}
+
 /* Full-height hit target so short bars are still hoverable. */
 .spark-bar-hit {
   flex: 1;
@@ -805,6 +810,17 @@
   white-space: nowrap;
   font-size: 11px;
   line-height: 14px;
+}
+
+.action-announcement {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .icon-action {

--- a/src/redesign/shell.css
+++ b/src/redesign/shell.css
@@ -82,33 +82,6 @@
   flex: 0 0 auto;
 }
 
-/* Neutralize the legacy styles.css provider grid/card chrome; the redesigned
-   switcher styles itself inline to match the HTML spec. */
-.provider-grid {
-  border: 0;
-  box-shadow: none;
-}
-
-.provider-card {
-  min-height: 0;
-  gap: 0;
-}
-
-.provider-card::before {
-  display: none;
-}
-
-.provider-card:hover,
-.provider-card.active {
-  border-color: transparent;
-  transform: none;
-  box-shadow: none;
-}
-
-.provider-card.active {
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.14), 0 0 0 0.5px var(--line);
-}
-
 .panel-scroll {
   min-height: 128px;
   padding: 0 3px 0 0;
@@ -140,31 +113,39 @@
 }
 
 .provider-grid {
-  display: flex;
-  gap: 0;
-  padding: 2px;
+  display: grid;
+  grid-template-columns: none;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  gap: 2px;
+  padding: 3px;
   border: 0;
-  border-radius: 10px;
+  border-radius: 12px;
   background: var(--track);
   box-shadow: none;
 }
 
 .provider-card {
-  flex: 1;
   min-width: 0;
   min-height: 0;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 0;
-  padding: 7px 0 6px;
+  justify-content: center;
+  column-gap: 4px;
+  row-gap: 2px;
+  padding: 5px 2px 4px;
   border: 0;
-  border-radius: 8px;
+  border-radius: 9px;
   background: transparent;
   color: var(--text);
-  opacity: 0.75;
+  opacity: 0.72;
   box-shadow: none;
   cursor: pointer;
+  font: inherit;
+  text-align: center;
+  transition: background 0.14s ease, box-shadow 0.14s ease, opacity 0.14s ease;
 }
 
 .provider-card:hover {
@@ -186,15 +167,28 @@
   display: none;
 }
 
+.provider-card-topline {
+  position: relative;
+  flex: 0 0 18px;
+}
+
 .provider-card-icon {
-  width: 22px;
-  height: 22px;
-  border-radius: 6px;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
   color: #fff;
   background: linear-gradient(145deg, #8e9bb3, #4a5568);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.3),
     0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.provider-card.disconnected .provider-card-icon {
+  filter: saturate(0.35);
+  opacity: 0.56;
 }
 
 .provider-card[data-provider="claude"] .provider-card-icon { background: linear-gradient(145deg, #e8916c, #c4552f); }
@@ -204,20 +198,60 @@
 .provider-card[data-provider="all"] .provider-card-icon { background: linear-gradient(145deg, #8e9bb3, #4a5568); }
 
 .provider-card-svg {
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   fill: currentColor;
+  display: block;
 }
 
-.provider-card .status-dot {
-  display: none;
+.provider-card-status {
+  position: absolute;
+  right: -2px;
+  bottom: -1px;
+  width: 5px;
+  height: 5px;
+  border: 1.5px solid var(--track);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--sub) 70%, transparent);
+}
+
+.provider-card.connected .provider-card-status {
+  background: var(--target-green);
+}
+
+.provider-card.active .provider-card-status {
+  border-color: var(--seg);
+}
+
+.provider-card-label {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 9.5px;
+  line-height: 11px;
+  font-weight: 600;
 }
 
 .provider-card-percent {
-  margin-top: 5px;
+  flex-basis: 100%;
+  margin-top: 1px;
   color: var(--text);
-  font-size: 11px;
-  line-height: 1;
-  font-weight: 600;
+  font-size: 10.5px;
+  line-height: 12px;
+  font-weight: 650;
   font-variant-numeric: tabular-nums;
+}
+
+.app button:focus-visible,
+.app input:focus-visible {
+  outline: 2px solid var(--acc);
+  outline-offset: 1px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .provider-card {
+    transition: none;
+  }
 }

--- a/src/services/panel_sections.ts
+++ b/src/services/panel_sections.ts
@@ -8,7 +8,7 @@ export const PANEL_SECTION_ORDER: PanelSectionKey[] = ['timeline', 'cost', 'tren
 
 export const PANEL_SECTION_LABELS: Record<PanelSectionKey, string> = {
   timeline: 'Reset timeline',
-  cost: 'Local cost',
+  cost: 'API-equivalent usage',
   trend: 'Usage trend',
   tips: 'Smart tips',
 };

--- a/tests/panel_shell_ui.test.tsx
+++ b/tests/panel_shell_ui.test.tsx
@@ -1,4 +1,5 @@
 import { createElement } from 'react';
+import { readFileSync } from 'node:fs';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -16,7 +17,7 @@ const summaries: ProviderSummary[] = [
 ];
 
 const trayEntries: TrayToggleEntry[] = [
-  { service: 'claude', label: 'Claude Tray', enabled: true, canDisable: true, connected: true, disconnectedHint: 'Sign in' },
+  { service: 'claude', label: 'Claude Tray', enabled: true, canDisable: true, connected: true, connectedHint: 'Ready', disconnectedHint: 'Sign in' },
   { service: 'codex', label: 'Codex Tray', enabled: true, canDisable: true, connected: false, disconnectedHint: 'Sign in' },
   { service: 'cursor', label: 'Cursor Tray', enabled: false, canDisable: true, connected: false, disconnectedHint: 'Sign in' },
   { service: 'antigravity', label: 'Antigravity Tray', enabled: false, canDisable: true, connected: false, disconnectedHint: 'Preview' },
@@ -44,20 +45,22 @@ afterAll(() => {
 });
 
 describe('panel shell UI', () => {
-  it('shows recognizable provider labels and tab semantics', () => {
+  it('shows recognizable provider labels as native navigation buttons', () => {
     const html = renderToStaticMarkup(
       <TabSwitcher activeTab="claude" summaries={summaries} onTabChange={() => {}} />,
     );
 
-    expect(html).toContain('role="tablist"');
-    expect(html).toContain('role="tab"');
-    expect(html).toContain('aria-selected="true"');
+    expect(html).toContain('<nav');
+    expect(html).toContain('aria-label="Provider views"');
+    expect(html).toContain('aria-current="page"');
+    expect(html).not.toContain('role="tab"');
+    expect(html).not.toContain('tabindex="-1"');
     expect(html).toContain('provider-card-label">Claude');
     expect(html).toContain('provider-card-label">Codex');
     expect(html).toContain('48%');
   });
 
-  it('hides the provider dashboard action on Overview and announces refresh status', () => {
+  it('hides the provider dashboard action and keeps passive timestamps quiet', () => {
     const html = renderToStaticMarkup(
       <ActionButtons
         onRefresh={() => {}}
@@ -71,9 +74,38 @@ describe('panel shell UI', () => {
     );
 
     expect(html).not.toContain('Dashboard');
-    expect(html).toContain('role="status"');
-    expect(html).toContain('aria-live="polite"');
+    expect(html).not.toContain('role="status"');
+    expect(html).toContain('aria-live="off"');
     expect(html).toContain('Updated now');
+  });
+
+  it('announces refresh loading without guessing its outcome', async () => {
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(ActionButtons, {
+        onRefresh: vi.fn(),
+        onDashboard: vi.fn(),
+        onSettings: vi.fn(),
+        onQuit: vi.fn(),
+        loading: true,
+        statusText: 'Updating...',
+      }));
+    });
+
+    expect(renderer.root.findByProps({ role: 'status' }).children).toContain('Updating quota data');
+    await act(async () => {
+      renderer.update(createElement(ActionButtons, {
+        onRefresh: vi.fn(),
+        onDashboard: vi.fn(),
+        onSettings: vi.fn(),
+        onQuit: vi.fn(),
+        loading: false,
+        statusText: 'Updated now',
+      }));
+    });
+    expect(renderer.root.findAllByProps({ role: 'status' })).toHaveLength(0);
+    expect(renderer.root.findByProps({ className: 'action-status' }).props['aria-live']).toBe('off');
+    await act(async () => renderer.unmount());
   });
 
   it('groups settings by task and combines panel and menu visibility', () => {
@@ -108,6 +140,21 @@ describe('panel shell UI', () => {
     expect(html).toContain('aria-label="Show Claude in panel"');
     expect(html).toContain('aria-label="Show Claude in menu bar"');
     expect(html).toContain('theme-option-label">Light');
+    expect(html).toContain('>Ready<');
+    expect(html).toContain('>Sign in<');
+    expect(html).toContain('>Preview<');
+  });
+
+  it('keeps compact settings controls visually self-contained at panel width', () => {
+    const css = readFileSync(new URL('../src/redesign-settings.css', import.meta.url), 'utf8');
+
+    expect(css).toMatch(/\.settings-group \.settings-line \{[^}]*display: flex;/s);
+    expect(css).toMatch(/\.settings-group \.target-switch \{[^}]*background: var\(--track\);/s);
+    expect(css).toMatch(/\.settings-group \.target-switch span \{[^}]*border-radius: 50%;/s);
+    expect(css).toMatch(/\.settings-group \.target-switch\.on \{[^}]*background: #34c759;/s);
+    expect(css).toMatch(/\.settings-group \.settings-seg \{[^}]*display: flex;/s);
+    expect(css).toMatch(/\.settings-group \.budget-input \{[^}]*width: 64px;/s);
+    expect(css).toMatch(/\.settings-group \.event-row \{[^}]*display: flex;/s);
   });
 
   it('labels local cost as an estimate and makes the daily trend keyboard accessible', async () => {
@@ -146,7 +193,12 @@ describe('panel shell UI', () => {
       currency: 'USD',
       generatedAt: '2026-08-24T08:00:00Z',
       cached: false,
-      days: [{ date: '2026-08-24', cost: 12, costUsd: 12, totalTokens: 30 }],
+      days: Array.from({ length: 30 }, (_, index) => ({
+        date: `2026-08-${String(index + 1).padStart(2, '0')}`,
+        cost: index + 1,
+        costUsd: index + 1,
+        totalTokens: 30,
+      })),
     });
 
     let renderer!: ReactTestRenderer;
@@ -164,7 +216,46 @@ describe('panel shell UI', () => {
       && typeof node.props.className === 'string'
       && node.props.className.includes('spark-bar-hit')
     ));
-    expect(trendButtons).toHaveLength(1);
+    expect(trendButtons).toHaveLength(0);
+    const thirtyDayButton = renderer.root.findAllByType('button').find((node) => (
+      typeof node.props.className === 'string'
+      && node.props.className.includes('spark-chip')
+      && node.children.includes('30D')
+    ));
+    expect(thirtyDayButton).toBeDefined();
+    await act(async () => thirtyDayButton?.props.onClick());
+    let trend = renderer.root.findByProps({ role: 'slider' });
+    expect(trend.props.tabIndex).toBe(0);
+    expect(trend.props['aria-valuemax']).toBe(30);
+    await act(async () => trend.props.onFocus());
+    trend = renderer.root.findByProps({ role: 'slider' });
+    await act(async () => trend.props.onKeyDown({ key: 'ArrowLeft', preventDefault: vi.fn() }));
+    trend = renderer.root.findByProps({ role: 'slider' });
+    expect(trend.props['aria-valuenow']).toBe(29);
+    expect(trend.props['aria-valuetext']).toContain('2026-08-29');
+    const tenthBar = renderer.root.findAll((node) => (
+      node.type === 'span'
+      && typeof node.props.className === 'string'
+      && node.props.className.includes('spark-bar-hit')
+    ))[9];
+    await act(async () => tenthBar.props.onMouseEnter());
+    trend = renderer.root.findByProps({ role: 'slider' });
+    expect(trend.props['aria-valuenow']).toBe(10);
+    expect(trend.props['aria-valuetext']).toContain('2026-08-10');
+    await act(async () => trend.props.onKeyDown({ key: 'ArrowDown', preventDefault: vi.fn() }));
+    trend = renderer.root.findByProps({ role: 'slider' });
+    expect(trend.props['aria-valuenow']).toBe(28);
+    await act(async () => trend.props.onMouseLeave());
+    trend = renderer.root.findByProps({ role: 'slider' });
+    expect(trend.props['aria-valuenow']).toBe(28);
+    await act(async () => trend.props.onKeyDown({ key: 'ArrowUp', preventDefault: vi.fn() }));
+    trend = renderer.root.findByProps({ role: 'slider' });
+    expect(trend.props['aria-valuenow']).toBe(29);
+    await act(async () => trend.props.onKeyDown({ key: 'Home', preventDefault: vi.fn() }));
+    expect(renderer.root.findByProps({ role: 'slider' }).props['aria-valuenow']).toBe(1);
+    trend = renderer.root.findByProps({ role: 'slider' });
+    await act(async () => trend.props.onKeyDown({ key: 'End', preventDefault: vi.fn() }));
+    expect(renderer.root.findByProps({ role: 'slider' }).props['aria-valuenow']).toBe(30);
     expect(renderer.root.findAllByProps({ role: 'progressbar' })).toHaveLength(1);
     await act(async () => renderer.unmount());
   });

--- a/tests/panel_shell_ui.test.tsx
+++ b/tests/panel_shell_ui.test.tsx
@@ -1,0 +1,171 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import ActionButtons from '../src/components/ActionButtons';
+import CostSummarySection from '../src/components/CostSummarySection';
+import SettingsView from '../src/components/SettingsView';
+import TabSwitcher from '../src/components/TabSwitcher';
+import { backend } from '../src/services/backend';
+import type { ProviderSummary } from '../src/services/provider_summary';
+import type { TrayToggleEntry } from '../src/components/TrayToggles';
+
+const summaries: ProviderSummary[] = [
+  { id: 'claude', label: 'Claude', shortLabel: 'Claude', initials: 'C', accent: '#d97757', connected: true, loading: false, usedPercent: 48, statusText: '48% used' },
+  { id: 'codex', label: 'Codex', shortLabel: 'Codex', initials: 'Co', accent: '#10a37f', connected: false, loading: false, usedPercent: null, statusText: 'Offline' },
+];
+
+const trayEntries: TrayToggleEntry[] = [
+  { service: 'claude', label: 'Claude Tray', enabled: true, canDisable: true, connected: true, disconnectedHint: 'Sign in' },
+  { service: 'codex', label: 'Codex Tray', enabled: true, canDisable: true, connected: false, disconnectedHint: 'Sign in' },
+  { service: 'cursor', label: 'Cursor Tray', enabled: false, canDisable: true, connected: false, disconnectedHint: 'Sign in' },
+  { service: 'antigravity', label: 'Antigravity Tray', enabled: false, canDisable: true, connected: false, disconnectedHint: 'Preview' },
+];
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+  const values = new Map<string, string>();
+  values.set('claude-quota-monthly-budgets', JSON.stringify({ claude: 100 }));
+  (globalThis as Record<string, unknown>).localStorage = {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() { return values.size; },
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+  delete (globalThis as Record<string, unknown>).localStorage;
+});
+
+describe('panel shell UI', () => {
+  it('shows recognizable provider labels and tab semantics', () => {
+    const html = renderToStaticMarkup(
+      <TabSwitcher activeTab="claude" summaries={summaries} onTabChange={() => {}} />,
+    );
+
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain('role="tab"');
+    expect(html).toContain('aria-selected="true"');
+    expect(html).toContain('provider-card-label">Claude');
+    expect(html).toContain('provider-card-label">Codex');
+    expect(html).toContain('48%');
+  });
+
+  it('hides the provider dashboard action on Overview and announces refresh status', () => {
+    const html = renderToStaticMarkup(
+      <ActionButtons
+        onRefresh={() => {}}
+        onDashboard={() => {}}
+        onSettings={() => {}}
+        onQuit={() => {}}
+        loading={false}
+        statusText="Updated now"
+        showDashboard={false}
+      />,
+    );
+
+    expect(html).not.toContain('Dashboard');
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain('Updated now');
+  });
+
+  it('groups settings by task and combines panel and menu visibility', () => {
+    const html = renderToStaticMarkup(
+      <SettingsView
+        isMacOS
+        theme="light"
+        dockHidden
+        trayEntries={trayEntries}
+        panelSections={{ timeline: true, cost: true, trend: true, tips: false }}
+        trayStyle="percent"
+        trayCycle={false}
+        events={[]}
+        notificationSettings={{ q80: true, q95: true, bonus: false }}
+        switcherVisibility={{ claude: true, codex: true, cursor: true, antigravity: true }}
+        onClose={() => {}}
+        onThemeChange={() => {}}
+        onDockToggle={() => {}}
+        onTrayToggle={() => {}}
+        onPanelSectionToggle={() => {}}
+        onTrayStyleChange={() => {}}
+        onTrayCycleToggle={() => {}}
+        onNotificationToggle={() => {}}
+        onSwitcherToggle={() => {}}
+      />,
+    );
+
+    expect((html.match(/class="settings-group"/g) ?? [])).toHaveLength(5);
+    expect(html).toContain('>Providers<');
+    expect(html).toContain('>Panel<');
+    expect(html).toContain('>Menu<');
+    expect(html).toContain('aria-label="Show Claude in panel"');
+    expect(html).toContain('aria-label="Show Claude in menu bar"');
+    expect(html).toContain('theme-option-label">Light');
+  });
+
+  it('labels local cost as an estimate and makes the daily trend keyboard accessible', async () => {
+    vi.spyOn(backend, 'getCostOverview').mockResolvedValue({
+      source: 'claude',
+      displayName: 'Claude',
+      currency: 'USD',
+      generatedAt: '2026-08-24T08:00:00Z',
+      cached: false,
+      ranges: [{
+        range: 'today',
+        label: 'Today',
+        currency: 'USD',
+        cost: 12,
+        costUsd: 12,
+        tokens: { inputTokens: 10, outputTokens: 20, reasoningTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 30 },
+        models: [],
+        validEntries: 1,
+        skippedEntries: 0,
+        elapsedMs: 1,
+      }, {
+        range: 'month',
+        label: 'Month',
+        currency: 'USD',
+        cost: 25,
+        costUsd: 25,
+        tokens: { inputTokens: 10, outputTokens: 20, reasoningTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 30 },
+        models: [],
+        validEntries: 1,
+        skippedEntries: 0,
+        elapsedMs: 1,
+      }],
+    });
+    vi.spyOn(backend, 'getCostDaily').mockResolvedValue({
+      source: 'claude',
+      currency: 'USD',
+      generatedAt: '2026-08-24T08:00:00Z',
+      cached: false,
+      days: [{ date: '2026-08-24', cost: 12, costUsd: 12, totalTokens: 30 }],
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CostSummarySection, { source: 'claude', autoRefreshIntervalMs: 0 }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const text = JSON.stringify(renderer.toJSON());
+    expect(text).toContain('API-equivalent usage');
+    expect(text).toContain('Local estimate');
+    const trendButtons = renderer.root.findAll((node) => (
+      node.type === 'button'
+      && typeof node.props.className === 'string'
+      && node.props.className.includes('spark-bar-hit')
+    ));
+    expect(trendButtons).toHaveLength(1);
+    expect(renderer.root.findAllByProps({ role: 'progressbar' })).toHaveLength(1);
+    await act(async () => renderer.unmount());
+  });
+});


### PR DESCRIPTION
## Summary

- Make provider views recognizable at the fixed 340 px popover width with visible labels, usage, connection state, and tab semantics.
- Clarify primary versus supporting information across API-equivalent usage, footer actions, and live refresh status.
- Reorganize settings into five task-oriented groups and combine panel/menu visibility into one provider matrix.
- Add keyboard-accessible trend controls, progress semantics, visible theme names, and focused UI regression coverage.

Closes #75

## Dependency

- Stacked on #74; the base is `feat/provider-status-ui` so this PR only shows the panel-wide UI refinement.
- #72 remains independent and is not included in this diff.

## Verification

- [x] `npm test` — 359 passed
- [x] `npm run build`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test` — 44 passed, 2 ignored
- [x] 340 × 620 visual QA for Overview and Settings

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

## AI assistance

- Implementation and UI copy were developed with Codex assistance; all listed verification was executed locally.