### PR TITLE
Keep multiple provider trays visible on macOS 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Keep enabled provider trays as independent macOS menu-bar extras instead of collapsing them into one Codex slot on macOS 26.
 - Added Grok Build quota tracking: SuperGrok weekly/monthly pool, product mix, extra credits, and a per-provider tray.
 - Estimate SuperGrok pool USD value from Grok's own `costUsdTicks` on completed turns, scaled by the official used percent.
 - Added Codex weekly API-equivalent USD and token estimates from the ccstats SDK,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3295,6 +3295,8 @@ dependencies = [
  "dirs 5.0.1",
  "image",
  "libc",
+ "objc2-app-kit",
+ "objc2-foundation",
  "once_cell",
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,3 +35,7 @@ tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSStatusItem"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString", "NSUserDefaults"] }

--- a/src-tauri/src/services/tray.rs
+++ b/src-tauri/src/services/tray.rs
@@ -12,7 +12,6 @@ use tauri::{
 
 const ICON_SIZE: u32 = 44;
 const TRAY_SERVICE_ACTIVATED_EVENT: &str = "tray-service-activated";
-const TRAY_HIDDEN_TOOLTIP_SUFFIX: &str = "hidden";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct TraySnapshot {
@@ -138,6 +137,28 @@ impl TrayService {
         }
     }
 
+    fn extra_title(self) -> &'static str {
+        // Unique invisible titles keep macOS from coalescing extras.
+        match self {
+            Self::Claude => "\u{200b}",
+            Self::Codex => "\u{200b}\u{200b}",
+            Self::Cursor => "\u{200b}\u{200b}\u{200b}",
+            Self::Grok => "\u{200b}\u{200b}\u{200b}\u{200b}",
+            Self::Antigravity => "\u{200b}\u{200b}\u{200b}\u{200b}\u{200b}",
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn preferred_position(self) -> f64 {
+        match self {
+            Self::Claude => 10004.0,
+            Self::Codex => 10003.0,
+            Self::Cursor => 10002.0,
+            Self::Grok => 10001.0,
+            Self::Antigravity => 10000.0,
+        }
+    }
+
     fn show_menu_id(self) -> &'static str {
         match self {
             Self::Claude => "claude-show",
@@ -256,6 +277,35 @@ fn toggle_main_window(app: &AppHandle) {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn seed_status_item_defaults(service: TrayService) {
+    use objc2_foundation::{NSString, NSUserDefaults};
+
+    let defaults = NSUserDefaults::standardUserDefaults();
+    let autosave = service.tray_id();
+    let position_key = NSString::from_str(&format!("NSStatusItem Preferred Position {autosave}"));
+    let visible_key = NSString::from_str(&format!("NSStatusItem Visible {autosave}"));
+    defaults.setDouble_forKey(service.preferred_position(), &position_key);
+    defaults.setBool_forKey(true, &visible_key);
+}
+
+#[cfg(target_os = "macos")]
+fn apply_status_item_autosave(app: AppHandle, tray_id: &'static str) {
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(16));
+        let Some(tray) = app.tray_by_id(tray_id) else {
+            return;
+        };
+        let _ = tray.with_inner_tray_icon(move |inner| {
+            use objc2_foundation::NSString;
+            if let Some(item) = inner.ns_status_item() {
+                item.setAutosaveName(Some(&NSString::from_str(tray_id)));
+                item.setVisible(true);
+            }
+        });
+    });
+}
+
 fn format_tooltip(service: TrayService, percentage: Option<u8>) -> String {
     match percentage {
         Some(value) => format!("{}: {}% used", service.label(), value),
@@ -264,6 +314,9 @@ fn format_tooltip(service: TrayService, percentage: Option<u8>) -> String {
 }
 
 fn build_service_tray(app: &AppHandle, service: TrayService) -> tauri::Result<()> {
+    #[cfg(target_os = "macos")]
+    seed_status_item_defaults(service);
+
     let show_item =
         MenuItemBuilder::with_id(service.show_menu_id(), "Show / Hide Window").build(app)?;
     let quit_item = MenuItemBuilder::with_id(service.quit_menu_id(), "Quit").build(app)?;
@@ -283,6 +336,7 @@ fn build_service_tray(app: &AppHandle, service: TrayService) -> tauri::Result<()
     let tray = TrayIconBuilder::with_id(service.tray_id())
         .icon(icon)
         .icon_as_template(false)
+        .title(service.extra_title())
         .tooltip(service.label())
         .menu(&menu)
         .show_menu_on_left_click(false)
@@ -327,19 +381,17 @@ fn build_service_tray(app: &AppHandle, service: TrayService) -> tauri::Result<()
         })
         .build(app)?;
 
+    // Keep the NSStatusItem alive. On macOS 26, set_visible(false) removes the
+    // status item; recreating it later parks the icon under the notch instead of
+    // in the extras region, so only one provider tray remains usable.
     let _ = tray.set_visible(true);
     let _ = tray.set_icon_as_template(false);
-    let _ = tray.set_visible(false);
+    #[cfg(target_os = "macos")]
+    apply_status_item_autosave(app.clone(), service.tray_id());
     Ok(())
 }
 
 pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
-    build_service_tray(app, TrayService::Antigravity)?;
-    build_service_tray(app, TrayService::Grok)?;
-    build_service_tray(app, TrayService::Cursor)?;
-    build_service_tray(app, TrayService::Codex)?;
-    build_service_tray(app, TrayService::Claude)?;
-
     if let Some(window) = app.get_webview_window("main") {
         let window_clone = window.clone();
         window.on_window_event(move |event| {
@@ -349,7 +401,7 @@ pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
         });
     }
 
-    println!("[Tray] Ready: claude/codex/cursor/grok/antigravity trays created");
+    println!("[Tray] Ready: provider trays are created on first show");
     Ok(())
 }
 
@@ -395,15 +447,7 @@ pub async fn update_tray_icon(
             }
 
             if !visible {
-                if let Some(tray) = app_handle.tray_by_id(service.tray_id()) {
-                    tray.set_visible(false).map_err(|e| e.to_string())?;
-                    tray.set_tooltip(Some(format!(
-                        "{}: {}",
-                        service.label(),
-                        TRAY_HIDDEN_TOOLTIP_SUFFIX
-                    )))
-                    .map_err(|e| e.to_string())?;
-                }
+                let _ = app_handle.remove_tray_by_id(service.tray_id());
                 {
                     let mut state = runtime
                         .lock()
@@ -434,6 +478,8 @@ pub async fn update_tray_icon(
 
             tray.set_icon(Some(icon)).map_err(|e| e.to_string())?;
             tray.set_icon_as_template(false)
+                .map_err(|e| e.to_string())?;
+            tray.set_title(Some(service.extra_title()))
                 .map_err(|e| e.to_string())?;
             tray.set_tooltip(Some(format!(
                 "{}\nUpdated: {}",
@@ -514,5 +560,25 @@ mod tests {
 
         assert!(state.should_skip_update(TrayService::Claude, snapshot, false));
         assert!(!state.should_skip_update(TrayService::Claude, snapshot, true));
+    }
+
+    #[test]
+    fn extra_titles_are_unique_per_service() {
+        let titles = [
+            TrayService::Claude.extra_title(),
+            TrayService::Codex.extra_title(),
+            TrayService::Cursor.extra_title(),
+            TrayService::Grok.extra_title(),
+            TrayService::Antigravity.extra_title(),
+        ];
+        for (index, title) in titles.iter().enumerate() {
+            assert!(
+                titles
+                    .iter()
+                    .enumerate()
+                    .all(|(other, other_title)| other == index || other_title != title),
+                "tray extra titles must stay unique"
+            );
+        }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import AntigravityPanel from './components/AntigravityPanel';
 import type { TrayToggleEntry } from './components/TrayToggles';
 import { backend, hasTauriBackend } from './services/backend';
 import { SERVICE_META, SERVICES } from './services/service_meta';
-import { saveTrayEnabled, shouldShowTray, type TrayServiceName } from './services/tray_visibility';
+import { resolveTrayVisible, saveTrayEnabled, shouldShowTray, type TrayServiceName } from './services/tray_visibility';
 import {
   getSavedPanelSections,
   savePanelSections,
@@ -339,15 +339,10 @@ export default function App() {
       const isConnected = svc === 'claude' ? quota?.connected ?? false : connected[svc];
       return shouldShowTray(trayEnabled[svc], isConnected);
     });
-    // Cycle mode keeps a single menu bar item, rotating through the candidates.
-    const cycled = trayCycle && candidates.length > 1
-      ? candidates[trayCycleIndex % candidates.length]
-      : null;
 
     for (const svc of SERVICES) {
       const pct = svc === 'claude' ? getClaudeTrayUsedPercent(quota) : usedPercent[svc];
-      const showable = candidates.includes(svc);
-      const visible = cycled ? svc === cycled : showable;
+      const visible = resolveTrayVisible(svc, candidates, trayCycle, trayCycleIndex);
       updateTrayIcon(svc, pct, visible, force, trayStyle);
     }
   }, [quota, connected, usedPercent, trayEnabled, trayCycle, trayCycleIndex, trayStyle, updateTrayIcon]);

--- a/src/services/tray_visibility.ts
+++ b/src/services/tray_visibility.ts
@@ -37,3 +37,18 @@ export function saveTrayEnabled(service: TrayServiceName, enabled: boolean): boo
 export function shouldShowTray(enabled: boolean, _connected: boolean): boolean {
   return enabled;
 }
+
+export function resolveTrayVisible(
+  service: TrayServiceName,
+  candidates: readonly TrayServiceName[],
+  cycle: boolean,
+  cycleIndex: number,
+): boolean {
+  if (!candidates.includes(service)) {
+    return false;
+  }
+  if (cycle && candidates.length > 1) {
+    return service === candidates[cycleIndex % candidates.length];
+  }
+  return true;
+}

--- a/tests/tray_sync.test.tsx
+++ b/tests/tray_sync.test.tsx
@@ -1,0 +1,111 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { backend } from '../src/services/backend';
+import { SERVICES } from '../src/services/service_meta';
+import type { TrayServiceName } from '../src/services/tray_visibility';
+
+vi.mock('../src/hooks/use_popover_window', () => ({
+  usePopoverWindow: () => false,
+}));
+
+import App from '../src/App';
+
+function memoryStorage(initial: Record<string, string>) {
+  const values = new Map(Object.entries(initial));
+  return {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() {
+      return values.size;
+    },
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+}
+
+async function render_app(): Promise<ReactTestRenderer> {
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(createElement(App));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return renderer;
+}
+
+async function unmount(renderer: ReactTestRenderer): Promise<void> {
+  await act(async () => renderer.unmount());
+}
+
+function visible_calls(update: ReturnType<typeof vi.spyOn>) {
+  const visible = new Map<TrayServiceName, boolean>();
+  for (const args of update.mock.calls) {
+    const service = args[0] as TrayServiceName;
+    visible.set(service, args[2] as boolean);
+  }
+  return visible;
+}
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  (globalThis as Record<string, unknown>).localStorage = memoryStorage({
+    'claude-tray-enabled': 'false',
+    'codex-tray-enabled': 'true',
+    'cursor-tray-enabled': 'false',
+    'grok-tray-enabled': 'true',
+    'antigravity-tray-enabled': 'false',
+    'claude-quota-tray-cycle': 'false',
+  });
+
+  vi.spyOn(backend, 'getQuota').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({
+    connected: true,
+    availableCount: 0,
+    credits: [],
+  });
+  vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
+  vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({ connected: true });
+  vi.spyOn(backend, 'getGrokInfo').mockResolvedValue({ connected: true, percentage: 39, products: [] });
+  vi.spyOn(backend, 'getAntigravityInfo').mockResolvedValue({ connected: false, status: 'pending' });
+  vi.spyOn(backend, 'setDockVisibility').mockResolvedValue(undefined);
+  vi.spyOn(backend, 'updateTrayIcon').mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete (globalThis as Record<string, unknown>).localStorage;
+});
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe('tray icon sync', () => {
+  test('keeps every enabled provider tray visible when cycle is off', async () => {
+    const renderer = await render_app();
+    const visible = visible_calls(backend.updateTrayIcon as unknown as ReturnType<typeof vi.spyOn>);
+
+    expect(visible.get('codex')).toBe(true);
+    expect(visible.get('grok')).toBe(true);
+    expect(visible.get('claude')).toBe(false);
+    expect(visible.get('cursor')).toBe(false);
+    expect(visible.get('antigravity')).toBe(false);
+    expect(SERVICES.every((service) => visible.has(service))).toBe(true);
+
+    await unmount(renderer);
+  });
+});

--- a/tests/tray_visibility.test.ts
+++ b/tests/tray_visibility.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { shouldShowTray } from '../src/services/tray_visibility';
+import { resolveTrayVisible, shouldShowTray } from '../src/services/tray_visibility';
+import type { TrayServiceName } from '../src/services/tray_visibility';
 
 describe('shouldShowTray', () => {
   test('shows tray whenever it is enabled', () => {
@@ -7,5 +8,26 @@ describe('shouldShowTray', () => {
     expect(shouldShowTray(true, false)).toBe(true);
     expect(shouldShowTray(false, true)).toBe(false);
     expect(shouldShowTray(false, false)).toBe(false);
+  });
+});
+
+describe('resolveTrayVisible', () => {
+  const enabled: TrayServiceName[] = ['codex', 'grok'];
+
+  test('keeps every enabled provider visible when cycle is off', () => {
+    expect(resolveTrayVisible('codex', enabled, false, 0)).toBe(true);
+    expect(resolveTrayVisible('grok', enabled, false, 0)).toBe(true);
+    expect(resolveTrayVisible('claude', enabled, false, 0)).toBe(false);
+  });
+
+  test('cycle mode shows only one candidate at a time', () => {
+    expect(resolveTrayVisible('codex', enabled, true, 0)).toBe(true);
+    expect(resolveTrayVisible('grok', enabled, true, 0)).toBe(false);
+    expect(resolveTrayVisible('codex', enabled, true, 1)).toBe(false);
+    expect(resolveTrayVisible('grok', enabled, true, 1)).toBe(true);
+  });
+
+  test('a single candidate stays visible even when cycle is on', () => {
+    expect(resolveTrayVisible('codex', ['codex'], true, 4)).toBe(true);
   });
 });


### PR DESCRIPTION
macOS 26 was collapsing enabled provider trays into one Codex extras slot. Create trays on first show and give each a unique autosave name.

Tested: npm test; npm run build; cargo fmt --check; cargo check; cargo test; local app bundle reinstall