### PR TITLE
Refactor footer status updates into a focused hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import {
   saveTrayStyle,
   type TrayStyle,
 } from './services/tray_style';
-import { formatEventTime, getSavedEvents, recordEvent, type AppEvent, type EventLevel } from './services/event_log';
+import { getSavedEvents, recordEvent, type AppEvent, type EventLevel } from './services/event_log';
 import {
   getSavedSwitcherVisibility,
   saveSwitcherVisibility,
@@ -94,6 +94,7 @@ import {
 import { useServiceEvents } from './hooks/use_service_events';
 import { usePopoverWindow } from './hooks/use_popover_window';
 import { useLatestRequestGeneration } from './hooks/use_latest_request_generation';
+import { useFooterStatus } from './hooks/use_footer_status';
 
 // Re-exported for existing tests/importers.
 export {
@@ -171,7 +172,6 @@ export default function App() {
     return isProviderTab(saved) ? saved : 'claude';
   });
   const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
-  const [, setStatusTick] = useState(0);
   const [panelSections, setPanelSections] = useState<PanelSectionVisibility>(getSavedPanelSections);
   const [trayStyle, setTrayStyle] = useState<TrayStyle>(getSavedTrayStyle);
   const [trayCycle, setTrayCycle] = useState<boolean>(getSavedTrayCycle);
@@ -636,14 +636,6 @@ export default function App() {
     prevLoadingRef.current = activeLoading;
   }, [activeLoading]);
 
-  // Keep the relative "updated" label fresh while the panel is open.
-  useEffect(() => {
-    if (!windowVisible) return;
-    const interval = setInterval(() => setStatusTick((tick) => tick + 1), 30 * 1000);
-    return () => clearInterval(interval);
-  }, [windowVisible]);
-
-
   const serviceUsage: ServiceMap<number | null> = {
     ...usedPercent,
     claude: getClaudeTrayUsedPercent(quota),
@@ -655,14 +647,7 @@ export default function App() {
   const nonClaudeRefreshIntervalMs = windowVisible
     ? AUTO_REFRESH_INTERVAL_MS
     : BACKGROUND_REFRESH_INTERVAL_MS;
-  const footerStatus = activeLoading
-    ? 'Updating...'
-    : lastUpdatedAt != null
-      ? `Updated ${formatEventTime(new Date(lastUpdatedAt).toISOString())}`
-      : '';
-  const footerStatusTitle = lastUpdatedAt != null
-    ? `Last updated ${new Date(lastUpdatedAt).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`
-    : 'Not updated yet';
+  const { footerStatus, footerStatusTitle } = useFooterStatus(windowVisible, activeLoading, lastUpdatedAt);
   const providerSummaries = buildProviderSummaries(tabConnected, serviceLoading, serviceUsage);
   const switcherSummaries = providerSummaries.filter((summary) => switcherVisibility[summary.id]);
   const allQuotaWindows = [

--- a/src/hooks/use_footer_status.ts
+++ b/src/hooks/use_footer_status.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { formatEventTime } from '../services/event_log';
+
+export function useFooterStatus(
+  windowVisible: boolean,
+  activeLoading: boolean,
+  lastUpdatedAt: number | null,
+): { footerStatus: string; footerStatusTitle: string } {
+  const [, setStatusTick] = useState(0);
+
+  useEffect(() => {
+    if (!windowVisible) return;
+    const interval = setInterval(() => setStatusTick((tick) => tick + 1), 30 * 1000);
+    return () => clearInterval(interval);
+  }, [windowVisible]);
+
+  return {
+    footerStatus: activeLoading
+      ? 'Updating...'
+      : lastUpdatedAt != null
+        ? `Updated ${formatEventTime(new Date(lastUpdatedAt).toISOString())}`
+        : '',
+    footerStatusTitle: lastUpdatedAt != null
+      ? `Last updated ${new Date(lastUpdatedAt).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`
+      : 'Not updated yet',
+  };
+}

--- a/tests/footer_status.test.tsx
+++ b/tests/footer_status.test.tsx
@@ -1,0 +1,97 @@
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFooterStatus } from '../src/hooks/use_footer_status';
+
+type FooterStatus = ReturnType<typeof useFooterStatus>;
+
+let latestStatus: FooterStatus | undefined;
+
+function FooterStatusHarness({
+  visible,
+  loading,
+  lastUpdatedAt,
+}: {
+  visible: boolean;
+  loading: boolean;
+  lastUpdatedAt: number | null;
+}) {
+  latestStatus = useFooterStatus(visible, loading, lastUpdatedAt);
+  return null;
+}
+
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-26T12:00:00Z'));
+  latestStatus = undefined;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe('useFooterStatus', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(async () => {
+    if (renderer) await act(async () => renderer?.unmount());
+    renderer = undefined;
+  });
+
+  it('reports loading and not-yet-updated states', async () => {
+    await act(async () => {
+      renderer = create(
+        <FooterStatusHarness visible loading lastUpdatedAt={null} />,
+      );
+    });
+    expect(latestStatus).toEqual({
+      footerStatus: 'Updating...',
+      footerStatusTitle: 'Not updated yet',
+    });
+  });
+
+  it('refreshes relative time while the popover is visible', async () => {
+    const lastUpdatedAt = Date.now() - 30_000;
+    await act(async () => {
+      renderer = create(
+        <FooterStatusHarness visible loading={false} lastUpdatedAt={lastUpdatedAt} />,
+      );
+    });
+    expect(latestStatus?.footerStatus).toBe('Updated now');
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(latestStatus?.footerStatus).toBe('Updated 1m ago');
+  });
+
+  it('runs and cleans up the timer only while visible', async () => {
+    await act(async () => {
+      renderer = create(
+        <FooterStatusHarness visible={false} loading={false} lastUpdatedAt={Date.now()} />,
+      );
+    });
+    expect(vi.getTimerCount()).toBe(0);
+
+    await act(async () => {
+      renderer?.update(
+        <FooterStatusHarness visible loading={false} lastUpdatedAt={Date.now()} />,
+      );
+    });
+    expect(vi.getTimerCount()).toBe(1);
+
+    await act(async () => {
+      renderer?.update(
+        <FooterStatusHarness visible={false} loading={false} lastUpdatedAt={Date.now()} />,
+      );
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Move footer relative-time rendering and its visibility-gated refresh timer out of `App.tsx` into `useFooterStatus`.
- Add focused coverage for loading labels, relative-time refreshes, and timer cleanup.
- Preserve the existing polling cadence and user-visible footer text.

Closes #84

## Verification

- [x] `npm test` — 32 files, 404 tests passed
- [x] `npm run build`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 70 passed, 2 ignored

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data behavior is unchanged.
- [x] No provider data flow or background polling interval changes.