### PR TITLE
release: publish Intel and Apple Silicon DMGs

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -23,10 +23,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: macOS
+          - name: macOS Apple Silicon
             runner: macos-15
             bundles: dmg
-            artifact_name: quotabar-macos-dmg
+            artifact_name: quotabar-macos-aarch64-dmg
+            artifact_paths: |
+              src-tauri/target/release/bundle/dmg/*.dmg
+          - name: macOS Intel
+            runner: macos-15-intel
+            bundles: dmg
+            artifact_name: quotabar-macos-x64-dmg
             artifact_paths: |
               src-tauri/target/release/bundle/dmg/*.dmg
           - name: Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Build separate macOS DMGs for Apple Silicon and Intel runners.
+
 ## 0.4.0 - 2026-08-31
 
 - Keep enabled provider trays as independent macOS menu-bar extras instead of collapsing them into one Codex slot on macOS 26.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ npm run tauri build -- --bundles app
 Downloadable release bundles:
 
 ```bash
-# macOS
+# macOS, for the current host architecture
 npm run tauri build -- --bundles dmg
 
 # Windows
@@ -139,7 +139,7 @@ Expected output locations:
 
 The latest published release is available from [GitHub Releases](https://github.com/majiayu000/quotabar/releases/latest).
 
-The v0.4.0 macOS artifact is unsigned and not notarized. macOS may require users to approve the app in Privacy & Security before first launch.
+The v0.4.0 Apple Silicon and Intel macOS artifacts are unsigned and not notarized. macOS may require users to approve the app in Privacy & Security before first launch.
 
 Release candidates should be built by the `release-artifacts` GitHub Actions workflow or from a clean checkout, then attached manually to the matching GitHub release only after final human approval. The workflow uploads build artifacts for inspection; it does not publish a GitHub Release. See [docs/release.md](docs/release.md) for the release checklist.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -60,7 +60,8 @@ publish GitHub Releases, or attach files to a public release.
 
 Expected artifact contents:
 
-- macOS: `src-tauri/target/release/bundle/dmg/*.dmg`
+- macOS Apple Silicon: `src-tauri/target/release/bundle/dmg/*_aarch64.dmg`
+- macOS Intel: `src-tauri/target/release/bundle/dmg/*_x64.dmg`
 - Windows: `src-tauri/target/release/bundle/msi/*.msi`
 - Windows: `src-tauri/target/release/bundle/nsis/*.exe`
 


### PR DESCRIPTION
## Summary

- build macOS DMGs on separate Apple Silicon and Intel GitHub runners
- keep distinct architecture-specific artifact names
- document both macOS release assets

## Verification

- workflow YAML parsed locally
- `git diff --check`