### PR TITLE
release: build Linux x64 AppImage

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -42,10 +42,32 @@ jobs:
             artifact_paths: |
               src-tauri/target/release/bundle/msi/*.msi
               src-tauri/target/release/bundle/nsis/*.exe
+          - name: Linux x64
+            runner: ubuntu-22.04
+            bundles: appimage
+            artifact_name: quotabar-linux-x64-appimage
+            artifact_paths: |
+              src-tauri/target/release/bundle/appimage/*.AppImage
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            curl \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            libssl-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libfuse2 \
+            file
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 ## Unreleased
 
 - Build separate macOS DMGs for Apple Silicon and Intel runners.
+- Build a Linux x64 AppImage on Ubuntu 22.04.
 
 ## 0.4.0 - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This `v0.4.0` screenshot was refreshed on 2026-08-31 from the production React U
 
 ## Requirements
 
-- macOS or Windows
+- macOS, Windows, or Linux
 - Node.js with npm
 - Rust toolchain
 - Tauri prerequisites installed
@@ -127,6 +127,9 @@ npm run tauri build -- --bundles dmg
 
 # Windows
 npm run tauri build -- --bundles msi,nsis
+
+# Linux
+npm run tauri build -- --bundles appimage
 ```
 
 Expected output locations:
@@ -134,6 +137,7 @@ Expected output locations:
 `src-tauri/target/release/bundle/dmg/`
 `src-tauri/target/release/bundle/msi/`
 `src-tauri/target/release/bundle/nsis/`
+`src-tauri/target/release/bundle/appimage/`
 
 ## Release Artifacts
 
@@ -166,6 +170,12 @@ Windows:
 - Download the `.msi` or `.exe` from GitHub Releases.
 - Build installer: `npm run tauri build -- --bundles msi,nsis`
 - Install from the generated `.msi` or `.exe`
+
+Linux x64:
+
+- Download the `.AppImage` from GitHub Releases.
+- Make it executable: `chmod +x QuotaBar_*.AppImage`
+- Run it: `./QuotaBar_*.AppImage`
 
 ## Verification
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -64,6 +64,7 @@ Expected artifact contents:
 - macOS Intel: `src-tauri/target/release/bundle/dmg/*_x64.dmg`
 - Windows: `src-tauri/target/release/bundle/msi/*.msi`
 - Windows: `src-tauri/target/release/bundle/nsis/*.exe`
+- Linux x64: `src-tauri/target/release/bundle/appimage/*.AppImage`
 
 For a local macOS smoke test, build the app bundle and install it:
 


### PR DESCRIPTION
## Summary

- add an Ubuntu 22.04 Linux x64 AppImage build to the release artifact matrix
- install the official Tauri Linux system dependencies in CI
- document Linux build, artifact, and run instructions

## Verification

- parsed the workflow with Ruby YAML
- ran `git diff --check`
- GitHub Actions will build and upload all supported platform artifacts

This only expands release packaging. It does not change application code or publish assets automatically.