### PR TITLE
fix(grok): use inference pricing for pool value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 - Keep enabled provider trays as independent macOS menu-bar extras instead of collapsing them into one Codex slot on macOS 26.
 - Added Grok Build quota tracking: SuperGrok weekly/monthly pool, product mix, extra credits, and a per-provider tray.
-- Estimate SuperGrok pool USD value from Grok's own `costUsdTicks` on completed turns, scaled by the official used percent.
+- Estimate SuperGrok pool API-equivalent value from ccstats inference pricing over the exact official window, rejecting malformed or partially priced local usage.
 - Added Codex weekly API-equivalent USD and token estimates from the ccstats SDK,
   while keeping estimate failures isolated from official quota and pace data.
 - Show the Codex weekly value estimate against the official 7-day window even

--- a/specs/grok-build/product.md
+++ b/specs/grok-build/product.md
@@ -11,7 +11,7 @@ QuotaBar tracks Claude Code, Codex, Cursor, and Antigravity. SuperGrok / X Premi
 - Show the unified weekly/monthly pool used percent and reset time as the tray value and primary panel bar.
 - Show `productUsage` as a composition of that same pool (not independent remaining quotas).
 - Show Extra credits (`onDemandUsed` / `onDemandCap` / `prepaidBalance`) only when any value is non-zero.
-- Estimate the shared pool's USD value from Grok session `costUsdTicks` (not public API list rates), scaled by `creditUsagePercent`. Fail closed when local usage is missing or does not match the official period.
+- Estimate the shared pool's API-equivalent USD value from ccstats per-inference pricing over the exact official period, scaled by `creditUsagePercent`. Fail closed when local usage is missing, malformed, partially priced, or outside the official period.
 - Wire Grok into the switcher, overview, settings trays, and per-provider tray icon.
 
 ## Non-Goals

--- a/specs/grok-build/tech.md
+++ b/specs/grok-build/tech.md
@@ -6,7 +6,7 @@
 
 - Identity: `email`, `planType` from billing `subscriptionTier` (not `auth_mode`).
 - Pool: `percentage` (`creditUsagePercent`, else sum of product percents), `resetAt` (`currentPeriod.end` then `billingPeriodEnd`), `periodStartedAt` (`currentPeriod.start`), `periodType` / `periodLabel`.
-- `valueEstimate` / `valueEstimateError`: sum `turn_completed.usage.costUsdTicks` in `[period start, now]` from `sessions/**/updates.jsonl` (1 USD = 10^10 ticks), then scale by official used percent. Isolated from pool % rendering. Does not use ccstats or public list rates.
+- `valueEstimate` / `valueEstimateError`: ask the ccstats SDK for Grok usage in the exact inclusive `[period start, observed at]` UTC window. ccstats prices `shell.turn.inference_done` requests with cache and long-context tiers and reports coverage against complete turn usage; QuotaBar rejects parse errors or partial pricing before scaling by the official used percent. Isolated from pool % rendering.
 - `products[]`: `{ product, label, usagePercent }` mapped from `GrokBuild` / `PRODUCT_GROK_BUILD` / etc.
 - `extra`: cents for on-demand used/cap and prepaid remaining; UI hides when all zero.
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -475,13 +475,14 @@ dependencies = [
 [[package]]
 name = "ccstats"
 version = "0.5.0"
-source = "git+https://github.com/majiayu000/ccstats.git?rev=2c67efd32508bd7e0e7c5605c9ac4ba989632818#2c67efd32508bd7e0e7c5605c9ac4ba989632818"
+source = "git+https://github.com/majiayu000/ccstats.git?rev=b15465265a72d072ec496a9b14c68d83703b253c#b15465265a72d072ec496a9b14c68d83703b253c"
 dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
  "comfy-table",
  "dirs 6.0.0",
+ "fs4",
  "glob",
  "rayon",
  "serde",
@@ -1266,6 +1267,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ dirs = "5"
 image = { version = "0.25", default-features = false, features = ["png"] }
 once_cell = "1.19"
 ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "7dbfad0ffc29277da22cd095db067e88982f3f12" }
-ccstats-quota = { package = "ccstats", git = "https://github.com/majiayu000/ccstats.git", rev = "2c67efd32508bd7e0e7c5605c9ac4ba989632818" }
+ccstats-quota = { package = "ccstats", git = "https://github.com/majiayu000/ccstats.git", rev = "b15465265a72d072ec496a9b14c68d83703b253c" }
 tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/src/services/grok.rs
+++ b/src-tauri/src/services/grok.rs
@@ -316,8 +316,7 @@ fn estimate_grok_period_value(
     if started > observed_at {
         return Err("The official Grok period window is invalid.".to_string());
     }
-    let home = grok_home().ok_or_else(|| "Could not find home directory".to_string())?;
-    let usage = grok_local::sum_period(&home, started, observed_at)?;
+    let usage = grok_local::sum_period(started, observed_at)?;
     let (period_usd, period_tokens) =
         scale_observed_usage(usage.observed_cost_usd, usage.observed_tokens, used_pct)?;
     Ok(GrokValueEstimate {

--- a/src-tauri/src/services/grok_local.rs
+++ b/src-tauri/src/services/grok_local.rs
@@ -1,177 +1,78 @@
-//! Local Grok period totals from session `turn_completed.usage`.
-//!
-//! SuperGrok billing is not the public API list price. Grok records
-//! `costUsdTicks` on each completed turn, where 1 USD = 10_000_000_000 ticks
-//! (xAI cost tracking). This module sums those ticks inside the official
-//! billing window. It does not use ccstats.
+//! Exact-window Grok usage totals from the `ccstats` SDK.
 
+use ccstats_quota::{summarize_cost, CostSummary, SummaryOptions, UsageRange, UsageSource};
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
-use serde_json::Value;
-use std::fs::{self, File};
-use std::io::{BufRead, BufReader};
-use std::path::Path;
-
-const TICKS_PER_USD: f64 = 10_000_000_000.0;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(super) struct LocalPeriodUsage {
     pub observed_cost_usd: f64,
     pub observed_tokens: i64,
-    pub valid_entries: i64,
-}
-
-#[derive(Debug, Deserialize)]
-struct UpdateLine {
-    timestamp: Option<f64>,
-    params: Option<UpdateParams>,
-}
-
-#[derive(Debug, Deserialize)]
-struct UpdateParams {
-    update: Option<Value>,
 }
 
 pub(super) fn sum_period(
-    grok_home: &Path,
     started: DateTime<Utc>,
     until: DateTime<Utc>,
 ) -> Result<LocalPeriodUsage, String> {
-    let sessions = grok_home.join("sessions");
-    if !sessions.is_dir() {
+    let summary = summarize_cost(SummaryOptions {
+        source: UsageSource::Grok,
+        range: UsageRange::TimestampRange {
+            since: started,
+            until,
+        },
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        strict_pricing: false,
+        currency: None,
+    })
+    .map_err(|error| format!("Could not summarize Grok usage: {error}"))?;
+
+    usage_from_summary(summary)
+}
+
+fn usage_from_summary(summary: CostSummary) -> Result<LocalPeriodUsage, String> {
+    if summary.parse_error_entries > 0 {
+        return Err(format!(
+            "Grok usage contains {} malformed record(s) in the active billing period",
+            summary.parse_error_entries
+        ));
+    }
+
+    let coverage = summary
+        .api_equivalent_cost_coverage
+        .ok_or_else(|| "no Grok inference pricing matched the active billing period".to_string())?;
+    if !coverage.complete {
+        return Err(format!(
+            "Grok API-equivalent pricing covers only {} of {} tokens in the active billing period",
+            coverage.priced_tokens, coverage.total_tokens
+        ));
+    }
+
+    let observed_cost_usd = summary
+        .cost_usd
+        .filter(|cost| cost.is_finite() && *cost > 0.0)
+        .ok_or_else(|| {
+            "no positive API-equivalent cost was available for the active Grok period".to_string()
+        })?;
+    if summary.valid_entries <= 0 || summary.tokens.total_tokens <= 0 {
         return Err("no Grok token usage matched the active billing period".to_string());
     }
 
-    let mut observed_cost_usd = 0.0;
-    let mut observed_tokens: i64 = 0;
-    let mut valid_entries: i64 = 0;
-    visit_updates(&sessions, started, until, &mut |usage| {
-        let ticks = usage
-            .get("costUsdTicks")
-            .and_then(Value::as_f64)
-            .filter(|ticks| ticks.is_finite() && *ticks > 0.0)
-            .ok_or_else(|| "a Grok turn_completed record has invalid costUsdTicks".to_string())?;
-        let tokens = positive_token_total(usage)?;
-        observed_cost_usd += ticks / TICKS_PER_USD;
-        observed_tokens = observed_tokens.saturating_add(tokens);
-        valid_entries += 1;
-        Ok(())
-    })?;
-
-    if valid_entries == 0 || observed_cost_usd <= 0.0 || observed_tokens <= 0 {
-        return Err("no Grok token usage matched the active billing period".to_string());
-    }
     Ok(LocalPeriodUsage {
         observed_cost_usd,
-        observed_tokens,
-        valid_entries,
+        observed_tokens: summary.tokens.total_tokens,
     })
-}
-
-fn positive_token_total(usage: &Value) -> Result<i64, String> {
-    if let Some(total) = usage.get("totalTokens") {
-        return total
-            .as_i64()
-            .filter(|tokens| *tokens > 0)
-            .ok_or_else(|| "a Grok turn_completed record has invalid totalTokens".to_string());
-    }
-
-    let input = usage
-        .get("inputTokens")
-        .and_then(Value::as_i64)
-        .filter(|tokens| *tokens >= 0)
-        .ok_or_else(|| "a Grok turn_completed record has invalid inputTokens".to_string())?;
-    let output = usage
-        .get("outputTokens")
-        .and_then(Value::as_i64)
-        .filter(|tokens| *tokens >= 0)
-        .ok_or_else(|| "a Grok turn_completed record has invalid outputTokens".to_string())?;
-    input
-        .checked_add(output)
-        .filter(|tokens| *tokens > 0)
-        .ok_or_else(|| "a Grok turn_completed record has no positive token usage".to_string())
-}
-
-fn visit_updates(
-    dir: &Path,
-    started: DateTime<Utc>,
-    until: DateTime<Utc>,
-    on_usage: &mut dyn FnMut(&Value) -> Result<(), String>,
-) -> Result<(), String> {
-    let entries = fs::read_dir(dir)
-        .map_err(|error| format!("Could not read Grok session directory: {error}"))?;
-    for entry in entries {
-        let entry =
-            entry.map_err(|error| format!("Could not read a Grok session entry: {error}"))?;
-        let path = entry.path();
-        let file_type = entry
-            .file_type()
-            .map_err(|error| format!("Could not inspect a Grok session entry: {error}"))?;
-        if file_type.is_symlink() {
-            continue;
-        }
-        if file_type.is_dir() {
-            visit_updates(&path, started, until, on_usage)?;
-            continue;
-        }
-        if path.file_name().and_then(|name| name.to_str()) != Some("updates.jsonl") {
-            continue;
-        }
-        let file = File::open(&path)
-            .map_err(|error| format!("Could not open Grok session updates: {error}"))?;
-        for line in BufReader::new(file).lines() {
-            let line =
-                line.map_err(|error| format!("Could not read Grok session updates: {error}"))?;
-            if !line.contains("turn_completed") {
-                continue;
-            }
-            let record = serde_json::from_str::<UpdateLine>(&line)
-                .map_err(|error| format!("Could not parse Grok session updates: {error}"))?;
-            let update = record
-                .params
-                .and_then(|params| params.update)
-                .ok_or_else(|| "a Grok update record is missing update data".to_string())?;
-            if update.get("sessionUpdate").and_then(Value::as_str) != Some("turn_completed") {
-                continue;
-            }
-            let ts = record.timestamp.and_then(unix_to_utc).ok_or_else(|| {
-                "a Grok turn_completed record has an invalid timestamp".to_string()
-            })?;
-            if ts < started || ts > until {
-                continue;
-            }
-            let usage = update
-                .get("usage")
-                .ok_or_else(|| "a Grok turn_completed record is missing usage data".to_string())?;
-            on_usage(usage)?;
-        }
-    }
-    Ok(())
-}
-
-fn unix_to_utc(timestamp: f64) -> Option<DateTime<Utc>> {
-    let seconds = if timestamp > 1_000_000_000_000.0 {
-        timestamp / 1000.0
-    } else {
-        timestamp
-    } as i64;
-    DateTime::from_timestamp(seconds, 0)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use std::ffi::OsString;
     use std::fs;
-    use std::io::Write;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
 
-    fn write_session(dir: &Path, body: &str) {
-        let session = dir.join("sessions").join("proj").join("sid1");
-        fs::create_dir_all(&session).expect("session dir");
-        let mut file = fs::File::create(session.join("updates.jsonl")).expect("updates");
-        file.write_all(body.as_bytes()).expect("write");
-    }
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn window() -> (DateTime<Utc>, DateTime<Utc>) {
         (
@@ -180,65 +81,102 @@ mod tests {
         )
     }
 
-    #[test]
-    fn sums_completed_turn_ticks_inside_window() {
-        let dir = tempfile_dir("valid");
-        let (started, until) = window();
-        let inside = started.timestamp() + 3600;
-        let outside = started.timestamp() - 3600;
-        write_session(
-            &dir,
-            &format!(
-                "{}\n{}\n{}\n",
-                r#"{"timestamp":1,"params":{"update":{"sessionUpdate":"tool_call"}}}"#,
-                format!(
-                    r#"{{"timestamp":{inside},"params":{{"update":{{"sessionUpdate":"turn_completed","usage":{{"costUsdTicks":10000000000,"totalTokens":50,"inputTokens":40,"outputTokens":10}}}}}}}}"#
-                ),
-                format!(
-                    r#"{{"timestamp":{outside},"params":{{"update":{{"sessionUpdate":"turn_completed","usage":{{"costUsdTicks":10000000000,"totalTokens":50}}}}}}}}"#
-                ),
-            ),
-        );
-        let usage = sum_period(&dir, started, until).expect("sum");
-        assert_eq!(usage.valid_entries, 1);
-        assert!((usage.observed_cost_usd - 1.0).abs() < 1e-9);
-        assert_eq!(usage.observed_tokens, 50);
+    fn write_fixture(dir: &Path, updates: &str, unified: &str) {
+        let session = dir.join("sessions").join("proj").join("sid1");
+        fs::create_dir_all(&session).expect("session dir");
+        fs::write(session.join("updates.jsonl"), updates).expect("updates");
+        fs::write(
+            session.join("summary.json"),
+            r#"{"current_model_id":"grok-4.6","git_root_dir":"/tmp/project"}"#,
+        )
+        .expect("summary");
+        let logs = dir.join("logs");
+        fs::create_dir_all(&logs).expect("logs");
+        fs::write(logs.join("unified.jsonl"), unified).expect("unified log");
+    }
+
+    fn with_grok_home(
+        dir: &Path,
+        started: DateTime<Utc>,
+        until: DateTime<Utc>,
+    ) -> Result<LocalPeriodUsage, String> {
+        let _guard = ENV_LOCK.lock().expect("environment lock");
+        let previous = std::env::var_os("GROK_HOME");
+        std::env::set_var("GROK_HOME", dir);
+        let result = sum_period(started, until);
+        restore_env("GROK_HOME", previous);
+        result
+    }
+
+    fn restore_env(name: &str, previous: Option<OsString>) {
+        match previous {
+            Some(value) => std::env::set_var(name, value),
+            None => std::env::remove_var(name),
+        }
     }
 
     #[test]
-    fn malformed_completed_turn_fails_closed() {
-        let dir = tempfile_dir("malformed");
+    fn uses_inference_pricing_instead_of_turn_cost_ticks() {
+        let dir = tempfile_dir("inference-pricing");
         let (started, until) = window();
-        let inside = started.timestamp() + 3600;
-        write_session(
+        let inside = started + chrono::Duration::hours(1);
+        write_fixture(
             &dir,
             &format!(
-                "{}\n{}\n",
-                format!(
-                    r#"{{"timestamp":{inside},"params":{{"update":{{"sessionUpdate":"turn_completed","usage":{{"costUsdTicks":10000000000,"totalTokens":50}}}}}}}}"#
-                ),
-                r#"{"sessionUpdate":"turn_completed"#,
+                r#"{{"timestamp":{},"params":{{"update":{{"sessionUpdate":"turn_completed","usage":{{"totalTokens":110,"inputTokens":100,"outputTokens":10}}}}}}}}"#,
+                inside.timestamp()
+            ),
+            &format!(
+                r#"{{"ts":"{}","sid":"sid1","msg":"shell.turn.inference_done","ctx":{{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":40,"completion_tokens":10,"reasoning_tokens":0}}}}"#,
+                inside.to_rfc3339()
             ),
         );
 
-        let error = sum_period(&dir, started, until).expect_err("malformed update");
-        assert!(error.contains("Could not parse Grok session updates"));
+        let usage = with_grok_home(&dir, started, until).expect("sum");
+
+        assert!((usage.observed_cost_usd - 0.000_2).abs() < 1e-12);
+        assert_eq!(usage.observed_tokens, 110);
     }
 
     #[test]
-    fn completed_turn_without_cost_fails_closed() {
-        let dir = tempfile_dir("missing-cost");
+    fn rejects_incomplete_inference_pricing_coverage() {
+        let dir = tempfile_dir("partial-coverage");
         let (started, until) = window();
-        let inside = started.timestamp() + 3600;
-        write_session(
+        let inside = started + chrono::Duration::hours(1);
+        write_fixture(
             &dir,
             &format!(
-                r#"{{"timestamp":{inside},"params":{{"update":{{"sessionUpdate":"turn_completed","usage":{{"totalTokens":50}}}}}}}}"#
+                r#"{{"timestamp":{},"params":{{"update":{{"sessionUpdate":"turn_completed","usage":{{"totalTokens":220,"inputTokens":200,"outputTokens":20}}}}}}}}"#,
+                inside.timestamp()
+            ),
+            &format!(
+                r#"{{"ts":"{}","sid":"sid1","msg":"shell.turn.inference_done","ctx":{{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":0,"completion_tokens":10,"reasoning_tokens":0}}}}"#,
+                inside.to_rfc3339()
             ),
         );
 
-        let error = sum_period(&dir, started, until).expect_err("missing cost");
-        assert!(error.contains("invalid costUsdTicks"));
+        let error = with_grok_home(&dir, started, until).expect_err("partial coverage");
+
+        assert!(error.contains("covers only 110 of 220 tokens"));
+    }
+
+    #[test]
+    fn malformed_inference_record_fails_closed() {
+        let dir = tempfile_dir("malformed-inference");
+        let (started, until) = window();
+        let inside = started + chrono::Duration::hours(1);
+        write_fixture(
+            &dir,
+            &format!(
+                r#"{{"timestamp":{},"params":{{"update":{{"sessionUpdate":"turn_completed","usage":{{"totalTokens":110,"inputTokens":100,"outputTokens":10}}}}}}}}"#,
+                inside.timestamp()
+            ),
+            r#"{"msg":"shell.turn.inference_done""#,
+        );
+
+        let error = with_grok_home(&dir, started, until).expect_err("malformed inference");
+
+        assert!(error.contains("malformed record"));
     }
 
     fn tempfile_dir(label: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- replace QuotaBar's `costUsdTicks` parser with ccstats exact-window Grok summaries
- use per-inference cache and long-context pricing from ccstats PR #118 at commit `b154652`
- fail closed on malformed telemetry or incomplete API-equivalent cost coverage
- update Grok value-estimate documentation and regression coverage

Fixes #86

Upstream dependency: https://github.com/majiayu000/ccstats/pull/118

## Verification

- [x] `npm test`
- [x] `npm run build`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed; partial pricing is never shown as a complete estimate.