### PR TITLE
fix(grok): stop empty turns from poisoning pool estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
+
 ## 0.4.1 - 2026-09-01
 
 - Build separate macOS DMGs for Apple Silicon and Intel runners.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "ccstats"
 version = "0.5.1"
-source = "git+https://github.com/majiayu000/ccstats.git?rev=2bfaf3ac1e4a377e994fc2e19739cb5ed00e76fc#2bfaf3ac1e4a377e994fc2e19739cb5ed00e76fc"
+source = "git+https://github.com/majiayu000/ccstats.git?rev=6bec20d035a10efbc8914d36001c7621570d1066#6bec20d035a10efbc8914d36001c7621570d1066"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -4749,7 +4749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ dirs = "5"
 rusqlite = { version = "0.40", features = ["bundled"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 once_cell = "1.19"
-ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "2bfaf3ac1e4a377e994fc2e19739cb5ed00e76fc" }
+ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "6bec20d035a10efbc8914d36001c7621570d1066" }
 ccstats-quota = { package = "ccstats", git = "https://github.com/majiayu000/ccstats.git", rev = "2c67efd32508bd7e0e7c5605c9ac4ba989632818" }
 tauri-plugin-notification = "2.3.3"
 


### PR DESCRIPTION
## What
- pin the general ccstats SDK to merged main commit `6bec20d`
- stop valid Grok `turn_completed` records without usage from counting as malformed
- keep incomplete API-pricing coverage fail-closed

## Verification
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm test`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `npm run tauri build -- --bundles app`

Upstream: majiayu000/ccstats#128