### PR TITLE
feat(codex): notify on exhausted quota and unused bonus resets

### DIFF
--- a/specs/GH94/product.md
+++ b/specs/GH94/product.md
@@ -1,0 +1,72 @@
+# GH-94 Product Spec：打满与「有券却被挡住」通知
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/94
+- `complexity: medium`
+- Analysis: `docs/product/codex-exhausted-and-settings-analysis.md`
+- Upstream language: #93（面板文案）。本 issue 不改面板布局。
+- Follow-up: #95 只做设置分组，不改本 issue 的 key 语义。
+
+## Problem
+
+通知停在 used% 跨越 80 / 95，以及 Bonus 三天内过期。跨越 100%、或已经 100% 且手里还有 unused gifted reset，系统不响。80→95 已经吵过，到不可用反而静音。
+
+现有 key：`q80` / `q95` / `bonus`。12 小时按 **body 文本** 去重，成功送达后才 commit（GH-48）。
+
+## Goals
+
+- 补齐告警生命周期的两端：Exhausted，以及「打满且有未用券」。
+- 新档默认开，旧档语义、阈值、12 小时去重、failure-options helper 不变。
+- Settings 里能关掉新档；缺省 key 视为 true（与现有未知 key 兼容方式一致）。
+- 不在通知里核销、不深链进 ChatGPT（点通知仍只是系统通知；打开 app 是 OS 行为）。
+
+## Non-Goals
+
+- 不改 Codex 面板层级、估值、Tip（#93）。
+- 不按 provider / 窗口自定义百分比。
+- 不新增 100% 以外的阈值（例如 99）。
+- 不改 12 小时窗口、标题 `QuotaBar`、dedupe 实现。
+- 不做 Launch at Login、设置重排（#95）。
+
+## Behavior Invariants
+
+1. `B-001` `NotificationKey` 增加 `q100` 与 `bonusReady`。`NOTIFICATION_ROWS` 顺序：80 → 95 → 100 → bonus ready → bonus expiry。默认五档均为 `true`。旧 storage 只有三 key 时，两档新 key 读成 `true`。
+2. `B-002` 任一 provider 的 tray used% 从 `< 100` 跨越到 `≥ 100` 时，若 `q100` 开：event `critical` + 通知 body 固定为 `{Label} usage reached 100%`。未跨越（刷新仍是 100%）不重复（除 12 小时窗口过期后的正常再评）。
+3. `B-003` Codex 在「官方 weekly used% ≥ 100」且 `getAvailableResetCredits` 长度从 0 变为 > 0，或 used% 跨越 100 的同时已有 available credit：若 `bonusReady` 开，event `warning` + 通知 body 固定为 `Codex weekly is at 100%. {n} bonus reset available.`（n 为 available 数，1 时用单数 reset）。其它 provider 不发 `bonusReady`。
+4. `B-004` `bonus`（过期提醒）继续只由现有 `onBonusExpiring` / 3 天窗口触发，文案不变。不得用 `bonusReady` 取代它。
+5. `B-005` `q80` / `q95` 跨越逻辑、body、level 保持精确不变。一次刷新同时跨 80 与 95 时仍只发 95（现有 if/else）。一次刷新同时跨 95 与 100 时：先保持现有 95 分支，**另发** 100（100 不是 95 的 else）。测试锁顺序：95 的 log/notify 仍发生，100 随后发生。
+6. `B-006` 所有新 notify callsite 第三参数必须是 `createNotificationFailureOptions(logEvent)`。body 为固定模板，不含 email、token、路径。
+7. `B-007` Settings 用现有 toggle 行渲染新档，label 固定：`Alert at 100% used`、`Alert when a bonus reset is unused at 100%`。关 `q100` / `bonusReady` 后对应跨越零通知，仍写 event feed（与现有 80/95 一致：现有是关了就不 notify，但仍 `logEvent`——保持同一模式：log 始终写，notify 看开关）。
+
+核对现有 80/95：log 始终写，notify 看开关。100 / bonusReady 必须相同。
+
+## Acceptance Criteria
+
+- 默认设置对象含五 key 全 true；只存了 `{q80,q95,bonus}` 的旧 JSON 读出来两新 key 为 true。
+- Codex used 99 → 100、无 bonus：一条 100% 通知，零 `bonusReady`。
+- Codex used 99 → 100、已有 1 available：100% 通知 + `Codex weekly is at 100%. 1 bonus reset available.`
+- Codex 已 100%、credits 从 0 张变为 1 张：只发 `bonusReady`，不因「仍是 100」再发 q100。
+- Codex 已 100%、credits 保持 1 张、反复 refresh：两档都不因同 body 在 12 小时内再送。
+- Claude 99 → 100：只有 `{Claude} usage reached 100%`，零 bonusReady。
+- 关 q100：跨越仍有 critical event，无 notify。
+- Settings 五行 label exact。
+- GH-48 delivery-first dedupe 与 failure helper 不被绕过。
+
+## Boundary Checklist
+
+| 边界 | 结论 |
+| --- | --- |
+| 旧三 key storage | 新 key default true |
+| 99→100 无券 | q100 only |
+| 99→100 有券 | q100 + bonusReady |
+| 已 100 后才到券 | bonusReady only |
+| 已 100 且券不变 | 不因 refresh 再送 |
+| 95 与 100 同帧 | 95 仍发，100 另发 |
+| 非 Codex | 无 bonusReady |
+| 开关关 | log 在，notify 不在 |
+| body 去重 | 12h，成功后才 commit |
+
+## Open Questions
+
+- 无。通知不承担打开面板；#93 负责点开后的首屏。

--- a/specs/GH94/tasks.md
+++ b/specs/GH94/tasks.md
@@ -1,0 +1,24 @@
+# GH-94 Tasks：quota lifecycle alerts
+
+## Delivery Contract
+
+- Base: then-latest `origin/main`。可与 #93 平行；不要在本 PR 改 exhausted 布局。
+- Commit policy: `per_step`。
+- Scope: 通知 schema、100% 跨越、Codex bonusReady、Settings 行。
+- Compatibility: 80/95/bonus expiry body、12h dedupe、GH-48 helper 不变。
+
+## Implementation Tasks
+
+- [x] `SP94-T1` Owner: impl. Dependencies: this spec. Covers: `B-001`, `B-007`. Done when: 五 key defaults、旧 JSON 兼容、NOTIFICATION_ROWS 五行、夹具补全。 Verify: `tests/notifications.test.ts` + tsc。
+- [x] `SP94-T2` Owner: impl. Dependencies: T1. Covers: `B-002`, `B-005`, `B-006`. Done when: used% 跨越 100 独立于 80/95；同帧 95+100；关 q100 仍 log；notify helper exact。 Verify: service events tests。
+- [x] `SP94-T3` Owner: impl. Dependencies: T1. Covers: `B-003`, `B-004`. Done when: Codex exhausted∧availableCount 边沿触发 bonusReady；稳定 refresh 不重复；expiry 路径与文案不变。 Verify: Codex/App bonusReady tests。
+- [x] `SP94-T4` Owner: impl. Dependencies: T1-T3. Covers: `B-001`~`B-007`. Done when: allowlist 外无面板层级 diff；`npx tsc --noEmit && npm test && npm run build`。 Verify: tech Test Plan。
+
+## Handoff
+
+- [x] `SP94-T5` Owner: impl. Dependencies: T4. Done when: implementation PR `Closes #94`，写明启动时已 100% 有券不补发（无 prev）。
+
+## Handoff Notes
+
+- Invariants: `{B-001 … B-007}`。
+- 禁止自定义阈值、禁止改 12h 窗口、禁止在本 PR 做 #93 UI。

--- a/specs/GH94/tech.md
+++ b/specs/GH94/tech.md
@@ -1,0 +1,121 @@
+# GH-94 Tech Spec：notification keys 与跨越检测
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/94
+- Product spec: `specs/GH94/product.md`
+
+## Current Mechanism
+
+`NotificationKey = 'q80' | 'q95' | 'bonus'`。`getSavedNotificationSettings` 对未知 / 缺失 key 保留 `defaultNotificationSettings()` 里的值，因此加 key 并写入 defaults 即可兼容旧 JSON。
+
+`useServiceEvents` 在 `before.used < 95 && after.used >= 95` 与 else-if 80 上 log + 条件 notify。没有 100 档。
+
+`App.handleBonusExpiring` 只处理过期。`CodexPanel` 已计算 `availableResetCredits`，但只回调 `onBonusExpiring(daysLeft)`。
+
+## Proposed Design
+
+### 1. Schema
+
+```ts
+export type NotificationKey = 'q80' | 'q95' | 'q100' | 'bonusReady' | 'bonus';
+```
+
+`defaultNotificationSettings()` 五档 true。`NOTIFICATION_ROWS` 按 product 顺序。`getSavedNotificationSettings` 循环 `NOTIFICATION_ROWS` 的既有逻辑自动给缺失 key 留下 default。
+
+更新所有构造 `NotificationSettings` 的测试夹具，补上新 key，避免多余属性检查失败。
+
+### 2. 100% 跨越
+
+在 `useServiceEvents` 的 used 比较里，**独立于** 80/95 的 if/else：
+
+```ts
+if (before.used < 100 && after.used >= 100) {
+  logEvent('critical', `${label} usage reached 100%`);
+  if (notifSettings.q100) void notify('QuotaBar', `${label} usage reached 100%`, opts);
+}
+```
+
+95 分支保持原样。同一次 effect 可以先走 95 再走 100。
+
+### 3. bonusReady
+
+不要把 reset-credit 列表塞进 `useServiceEvents`（它现在只吃 used%）。在 `App` 增加窄回调，由 `CodexPanel` 在算完 `availableResetCredits` 与官方 weekly 后调用，例如：
+
+`onBonusReadyChange?(ready: { exhausted: boolean; availableCount: number })`
+
+`App` 用 ref 记住上一拍 `{ exhausted, availableCount }`：
+
+- `exhausted && availableCount > 0` 且上一拍不满足该合取 → 触发 bonusReady log/notify
+- 进入条件包括：`!prev.exhausted && exhausted && count>0`，或 `exhausted && prev.count===0 && count>0`
+
+body：`Codex weekly is at 100%. ${n} bonus reset${n === 1 ? '' : 's'} available.`
+
+n=1 产品句是 `1 bonus reset available`（单数）。
+
+首次 mount 的上一拍为 null：不把「打开 app 时已经 100% 且有券」当成跨越（与 `useServiceEvents` 对 used% 的 `if (!prev) return` 一致）。若产品以后要「启动补发」，另开 issue。
+
+### 4. Settings
+
+`SettingsView` 已 map `NOTIFICATION_ROWS`，无需新 UI 组件。label 锁在 `NOTIFICATION_ROWS`。
+
+### 5. Tests
+
+- `tests/notifications.test.ts`：defaults 五 key；旧三 key JSON 读出新 key true；round-trip 含新 key。
+- `tests/service_events.test.ts`（新建或扩展现有）：99→100、95 与 100 同帧、关 q100、Claude 无 bonusReady。
+- App/Codex 回调测试：0→1 credit 于已 100%；99→100 同时有券；refresh 稳定态不重复。
+- 夹具 `notificationSettings={{ q80, q95, bonus }}` 全部补全。
+
+保持 GH-48 AST / helper 约定：每个 notify 第三参是 `createNotificationFailureOptions(logEvent)`。
+
+## Affected Files / Allowlist
+
+- `src/services/notifications.ts`
+- `src/hooks/use_service_events.ts`
+- `src/App.tsx`（bonusReady 上一拍 + 开关）
+- `src/components/CodexPanel.tsx`（只加 ready 回调，不改 #93 布局）
+- `tests/notifications.test.ts`
+- `tests/service_events.test.ts` 或现有 events 测试
+- `tests/storage_write_failures.test.ts`
+- `tests/storage_read_failures.test.ts`
+- `tests/panel_shell_ui.test.tsx`
+- 其它因 `NotificationSettings` 缺字段而必须补 key 的测试夹具
+- `specs/GH94/tasks.md`
+
+若 #93 尚未合入，`CodexPanel` 回调加在现有 Bonus 计算旁，不要顺手改层级。
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| 打开 app 就推 100% | 与 used% 一样，无 prev 不发 |
+| 12h 内 refresh 刷屏 | body 固定 + 现有 dedupe |
+| 95 被 100 吃掉 | 100 独立 if，测试同帧两者 |
+| Settings 夹具漏 key | 全仓搜 `q80:` 补全 |
+| 做成 #93 的面板 PR | allowlist 禁止 exhausted 层级 / Tip / 估值改动 |
+
+## Product-to-Test Mapping
+
+| Invariant | Verification |
+| --- | --- |
+| `B-001` | defaults + old JSON |
+| `B-002` | 99→100 各 provider |
+| `B-003` | Codex 合取矩阵 |
+| `B-004` | bonus expiry 文案/入口不变 |
+| `B-005` | 同帧 95+100 |
+| `B-006` | helper 第三参 |
+| `B-007` | rows label + 开关关仍 log |
+
+## Test Plan
+
+```bash
+set -euo pipefail
+npx tsc --noEmit
+npx vitest run tests/notifications.test.ts tests/storage_read_failures.test.ts tests/storage_write_failures.test.ts
+npm test
+npm run build
+```
+
+## Rollback Plan
+
+回滚 implementation PR。旧三 key JSON 仍合法。用户在新版本关掉的 `q100` / `bonusReady` 回滚后 key 被忽略。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,7 @@ import {
   subscribeStorageReadFailures,
   subscribeStorageWriteFailures,
 } from './services/storage';
+import { bonusReadyEntered, formatBonusReadyMessage } from './services/bonus_ready';
 import { useServiceEvents } from './hooks/use_service_events';
 import { usePopoverWindow } from './hooks/use_popover_window';
 import { useLatestRequestGeneration } from './hooks/use_latest_request_generation';
@@ -178,6 +179,7 @@ export default function App() {
   const [trayCycleIndex, setTrayCycleIndex] = useState(0);
   const [events, setEvents] = useState<AppEvent[]>(getSavedEvents);
   const [notifSettings, setNotifSettings] = useState<NotificationSettings>(getSavedNotificationSettings);
+  const bonusReadyPrevRef = useRef<{ exhausted: boolean; availableCount: number } | null>(null);
   const [switcherVisibility, setSwitcherVisibility] = useState<SwitcherVisibility>(getSavedSwitcherVisibility);
   const containerRef = useRef<HTMLDivElement>(null);
   const windowVisible = usePopoverWindow(containerRef, [activeView, quota, connected]);
@@ -425,6 +427,17 @@ export default function App() {
       void notify('QuotaBar', text, createNotificationFailureOptions(logEvent));
     }
   }, [logEvent, notifSettings.bonus]);
+
+  const handleBonusReadyChange = useCallback((ready: { exhausted: boolean; availableCount: number }) => {
+    const prev = bonusReadyPrevRef.current;
+    bonusReadyPrevRef.current = ready;
+    if (!bonusReadyEntered(prev, ready)) return;
+    const text = formatBonusReadyMessage(ready.availableCount);
+    logEvent('warning', text);
+    if (notifSettings.bonusReady) {
+      void notify('QuotaBar', text, createNotificationFailureOptions(logEvent));
+    }
+  }, [logEvent, notifSettings.bonusReady]);
 
   const handleTrayStyleChange = useCallback((style: TrayStyle) => {
     saveTrayStyle(style);
@@ -723,6 +736,7 @@ export default function App() {
                   showCostSummary={windowVisible && activeView === 'codex'}
                   sections={panelSections}
                   onBonusExpiring={handleBonusExpiring}
+                  onBonusReadyChange={handleBonusReadyChange}
                 />
               </div>
 

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -14,6 +14,7 @@ import type {
   CodexWeeklyValueEstimate,
 } from '../types/models';
 import { buildCodexQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
+import { canReportBonusReady } from '../services/bonus_ready';
 import { getAvailableResetCredits, getHighUsageTip } from '../services/detail_helpers';
 import { clampProgressValue, formatPaceText, formatPlanType, formatResetTime, getProgressStyle } from '../utils/quota_format';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
@@ -384,12 +385,18 @@ export default function CodexPanel({
   const availableResetCreditsForReady = getAvailableResetCredits(resetCredits);
 
   useEffect(() => {
-    if (!onBonusReadyChange || !rateLimits) return;
+    if (!onBonusReadyChange || !rateLimits || !canReportBonusReady(resetCredits)) return;
     onBonusReadyChange({
       exhausted: weeklyExhaustedForReady,
       availableCount: availableResetCreditsForReady.length,
     });
-  }, [availableResetCreditsForReady.length, onBonusReadyChange, rateLimits, weeklyExhaustedForReady]);
+  }, [
+    availableResetCreditsForReady.length,
+    onBonusReadyChange,
+    rateLimits,
+    resetCredits,
+    weeklyExhaustedForReady,
+  ]);
 
   if (loading && !codexData && !rateLimits) {
     return (

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -29,6 +29,7 @@ interface CodexPanelProps {
   showCostSummary?: boolean;
   sections?: PanelSectionVisibility;
   onBonusExpiring?: (daysLeft: number) => void;
+  onBonusReadyChange?: (ready: { exhausted: boolean; availableCount: number }) => void;
 }
 
 function formatSubscriptionDate(dateStr?: string): string {
@@ -262,6 +263,7 @@ export default function CodexPanel({
   showCostSummary = true,
   sections = defaultPanelSections(),
   onBonusExpiring,
+  onBonusReadyChange,
 }: CodexPanelProps) {
   const [codexData, setCodexData] = useState<CodexData | null>(null);
   const [rateLimits, setRateLimits] = useState<CodexRateLimits | null>(null);
@@ -375,6 +377,19 @@ export default function CodexPanel({
       }
     }
   }, [resetCredits, onBonusExpiring]);
+
+  const officialWeeklyLimitForReady = selectOfficialWeeklyLimitWindow(rateLimits);
+  const weeklyExhaustedForReady = typeof officialWeeklyLimitForReady?.usedPercent === 'number'
+    && officialWeeklyLimitForReady.usedPercent >= 100;
+  const availableResetCreditsForReady = getAvailableResetCredits(resetCredits);
+
+  useEffect(() => {
+    if (!onBonusReadyChange || !rateLimits) return;
+    onBonusReadyChange({
+      exhausted: weeklyExhaustedForReady,
+      availableCount: availableResetCreditsForReady.length,
+    });
+  }, [availableResetCreditsForReady.length, onBonusReadyChange, rateLimits, weeklyExhaustedForReady]);
 
   if (loading && !codexData && !rateLimits) {
     return (

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -385,13 +385,21 @@ export default function CodexPanel({
   const availableResetCreditsForReady = getAvailableResetCredits(resetCredits);
 
   useEffect(() => {
-    if (!onBonusReadyChange || !rateLimits || !canReportBonusReady(resetCredits)) return;
+    if (
+      !onBonusReadyChange
+      || !canReportBonusReady(
+        resetCredits,
+        officialWeeklyLimitForReady?.usedPercent,
+        availableResetCreditsForReady.length,
+      )
+    ) return;
     onBonusReadyChange({
       exhausted: weeklyExhaustedForReady,
       availableCount: availableResetCreditsForReady.length,
     });
   }, [
     availableResetCreditsForReady.length,
+    officialWeeklyLimitForReady?.usedPercent,
     onBonusReadyChange,
     rateLimits,
     resetCredits,

--- a/src/hooks/use_service_events.ts
+++ b/src/hooks/use_service_events.ts
@@ -73,7 +73,17 @@ export function useServiceEvents(
             );
           }
         }
+        if (before.used < 100 && after.used >= 100) {
+          logEvent('critical', `${label} usage reached 100%`);
+          if (notifSettings.q100) {
+            void notify(
+              'QuotaBar',
+              `${label} usage reached 100%`,
+              createNotificationFailureOptions(logEvent),
+            );
+          }
+        }
       }
     }
-  }, [quota, connected, usedPercent, logEvent, notifSettings.q80, notifSettings.q95]);
+  }, [quota, connected, usedPercent, logEvent, notifSettings.q80, notifSettings.q95, notifSettings.q100]);
 }

--- a/src/services/bonus_ready.ts
+++ b/src/services/bonus_ready.ts
@@ -4,9 +4,22 @@ export interface BonusReadySnapshot {
 }
 
 export function canReportBonusReady(
-  resetCredits: { connected: boolean } | null,
+  resetCredits: { connected: boolean; availableCount?: number } | null,
+  officialWeeklyUsedPercent?: number,
+  filteredAvailableCount?: number,
 ): boolean {
-  return Boolean(resetCredits?.connected);
+  if (!resetCredits?.connected) return false;
+  if (typeof officialWeeklyUsedPercent !== 'number' || !Number.isFinite(officialWeeklyUsedPercent)) {
+    return false;
+  }
+  if (
+    typeof resetCredits.availableCount === 'number'
+    && resetCredits.availableCount > 0
+    && filteredAvailableCount === 0
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function bonusReadyEntered(

--- a/src/services/bonus_ready.ts
+++ b/src/services/bonus_ready.ts
@@ -3,6 +3,12 @@ export interface BonusReadySnapshot {
   availableCount: number;
 }
 
+export function canReportBonusReady(
+  resetCredits: { connected: boolean } | null,
+): boolean {
+  return Boolean(resetCredits?.connected);
+}
+
 export function bonusReadyEntered(
   prev: BonusReadySnapshot | null,
   next: BonusReadySnapshot,

--- a/src/services/bonus_ready.ts
+++ b/src/services/bonus_ready.ts
@@ -1,0 +1,19 @@
+export interface BonusReadySnapshot {
+  exhausted: boolean;
+  availableCount: number;
+}
+
+export function bonusReadyEntered(
+  prev: BonusReadySnapshot | null,
+  next: BonusReadySnapshot,
+): boolean {
+  if (!prev) return false;
+  const nowReady = next.exhausted && next.availableCount > 0;
+  const wasReady = prev.exhausted && prev.availableCount > 0;
+  return nowReady && !wasReady;
+}
+
+export function formatBonusReadyMessage(availableCount: number): string {
+  const noun = availableCount === 1 ? 'bonus reset' : 'bonus resets';
+  return `Codex weekly is at 100%. ${availableCount} ${noun} available.`;
+}

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,7 +1,7 @@
 import { hasTauriBackend } from './backend';
 import { readStorageValue, writeStorageItem } from './storage';
 
-export type NotificationKey = 'q80' | 'q95' | 'bonus';
+export type NotificationKey = 'q80' | 'q95' | 'q100' | 'bonusReady' | 'bonus';
 
 export type NotificationSettings = Record<NotificationKey, boolean>;
 
@@ -26,6 +26,8 @@ const NOTIFICATION_FAILURE_REPORTING_MESSAGE =
 export const NOTIFICATION_ROWS: Array<{ key: NotificationKey; label: string }> = [
   { key: 'q80', label: 'Alert at 80% used' },
   { key: 'q95', label: 'Critical alert at 95%' },
+  { key: 'q100', label: 'Alert at 100% used' },
+  { key: 'bonusReady', label: 'Alert when a bonus reset is unused at 100%' },
   { key: 'bonus', label: 'Bonus expiry reminders' },
 ];
 
@@ -39,7 +41,7 @@ type NotificationPlugin = typeof import('@tauri-apps/plugin-notification');
 let notificationPluginPromise: Promise<NotificationPlugin> | undefined;
 
 export function defaultNotificationSettings(): NotificationSettings {
-  return { q80: true, q95: true, bonus: true };
+  return { q80: true, q95: true, q100: true, bonusReady: true, bonus: true };
 }
 
 export function getSavedNotificationSettings(): NotificationSettings {

--- a/tests/bonus_ready.test.ts
+++ b/tests/bonus_ready.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from 'vitest';
-import { bonusReadyEntered, formatBonusReadyMessage } from '../src/services/bonus_ready';
+import { bonusReadyEntered, canReportBonusReady, formatBonusReadyMessage } from '../src/services/bonus_ready';
+
+describe('canReportBonusReady', () => {
+  test('waits for a connected credits snapshot', () => {
+    expect(canReportBonusReady(null)).toBe(false);
+    expect(canReportBonusReady({ connected: false })).toBe(false);
+    expect(canReportBonusReady({ connected: true })).toBe(true);
+  });
+});
 
 describe('bonusReadyEntered', () => {
   test('does not fire on the first snapshot', () => {

--- a/tests/bonus_ready.test.ts
+++ b/tests/bonus_ready.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { bonusReadyEntered, formatBonusReadyMessage } from '../src/services/bonus_ready';
+
+describe('bonusReadyEntered', () => {
+  test('does not fire on the first snapshot', () => {
+    expect(bonusReadyEntered(null, { exhausted: true, availableCount: 1 })).toBe(false);
+  });
+
+  test('fires when usage crosses 100% with an existing credit', () => {
+    expect(bonusReadyEntered(
+      { exhausted: false, availableCount: 1 },
+      { exhausted: true, availableCount: 1 },
+    )).toBe(true);
+  });
+
+  test('fires when a credit arrives while already exhausted', () => {
+    expect(bonusReadyEntered(
+      { exhausted: true, availableCount: 0 },
+      { exhausted: true, availableCount: 1 },
+    )).toBe(true);
+  });
+
+  test('does not fire when exhausted with an unchanged credit', () => {
+    expect(bonusReadyEntered(
+      { exhausted: true, availableCount: 1 },
+      { exhausted: true, availableCount: 1 },
+    )).toBe(false);
+  });
+
+  test('does not fire at 100% with zero credits', () => {
+    expect(bonusReadyEntered(
+      { exhausted: false, availableCount: 0 },
+      { exhausted: true, availableCount: 0 },
+    )).toBe(false);
+  });
+});
+
+describe('formatBonusReadyMessage', () => {
+  test('uses singular copy for one credit', () => {
+    expect(formatBonusReadyMessage(1)).toBe('Codex weekly is at 100%. 1 bonus reset available.');
+  });
+
+  test('uses plural copy for multiple credits', () => {
+    expect(formatBonusReadyMessage(2)).toBe('Codex weekly is at 100%. 2 bonus resets available.');
+  });
+});

--- a/tests/bonus_ready.test.ts
+++ b/tests/bonus_ready.test.ts
@@ -2,10 +2,19 @@ import { describe, expect, test } from 'vitest';
 import { bonusReadyEntered, canReportBonusReady, formatBonusReadyMessage } from '../src/services/bonus_ready';
 
 describe('canReportBonusReady', () => {
-  test('waits for a connected credits snapshot', () => {
-    expect(canReportBonusReady(null)).toBe(false);
-    expect(canReportBonusReady({ connected: false })).toBe(false);
-    expect(canReportBonusReady({ connected: true })).toBe(true);
+  test('waits for connected credits and a readable official weekly window', () => {
+    expect(canReportBonusReady(null, 100)).toBe(false);
+    expect(canReportBonusReady({ connected: false }, 100)).toBe(false);
+    expect(canReportBonusReady({ connected: true })).toBe(false);
+    expect(canReportBonusReady({ connected: true }, Number.NaN)).toBe(false);
+    expect(canReportBonusReady({ connected: true }, 40)).toBe(true);
+    expect(canReportBonusReady({ connected: true }, 100)).toBe(true);
+  });
+
+  test('waits when the API count and filtered credits disagree', () => {
+    expect(canReportBonusReady({ connected: true, availableCount: 1 }, 100, 0)).toBe(false);
+    expect(canReportBonusReady({ connected: true, availableCount: 1 }, 100, 1)).toBe(true);
+    expect(canReportBonusReady({ connected: true, availableCount: 0 }, 100, 0)).toBe(true);
   });
 });
 

--- a/tests/bonus_ready_panel.test.tsx
+++ b/tests/bonus_ready_panel.test.tsx
@@ -1,0 +1,128 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import CodexPanel from '../src/components/CodexPanel';
+import { backend } from '../src/services/backend';
+import type { CodexResetCredits } from '../src/types/models';
+
+const hiddenSections = { timeline: false, cost: false, trend: false, tips: false };
+
+const exhaustedLimits = {
+  connected: true,
+  planType: 'plus',
+  secondary: {
+    usedPercent: 100,
+    windowMinutes: 10_080,
+    resetsAt: 1_787_961_600,
+  },
+};
+
+const leftoverCredits: CodexResetCredits = {
+  connected: true,
+  availableCount: 1,
+  credits: [{ status: 'available', expiresAt: '2026-09-10T00:00:00Z' }],
+};
+
+const disconnectedCredits: CodexResetCredits = {
+  connected: false,
+  availableCount: 0,
+  credits: [],
+  error: 'Network error',
+};
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+});
+
+async function render_panel(
+  credits: CodexResetCredits,
+  onBonusReadyChange: (ready: { exhausted: boolean; availableCount: number }) => void,
+  manualRefreshNonce = 0,
+): Promise<ReactTestRenderer> {
+  vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true, planType: 'plus' });
+  vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue(exhaustedLimits);
+  vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue(credits);
+  vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(createElement(CodexPanel, {
+      autoRefreshIntervalMs: 0,
+      showCostSummary: false,
+      sections: hiddenSections,
+      manualRefreshNonce,
+      onBonusReadyChange,
+    }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return renderer;
+}
+
+describe('Codex bonusReady reporting', () => {
+  it('does not report a snapshot while reset credits are disconnected', async () => {
+    const onBonusReadyChange = vi.fn();
+    const renderer = await render_panel(disconnectedCredits, onBonusReadyChange);
+    expect(onBonusReadyChange).not.toHaveBeenCalled();
+    await act(async () => renderer.unmount());
+  });
+
+  it('does not treat a later leftover reset as a first connected snapshot after fail-soft credits', async () => {
+    const onBonusReadyChange = vi.fn();
+    const renderer = await render_panel(disconnectedCredits, onBonusReadyChange);
+    expect(onBonusReadyChange).not.toHaveBeenCalled();
+
+    vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue(leftoverCredits);
+    await act(async () => {
+      renderer.update(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+        manualRefreshNonce: 1,
+        onBonusReadyChange,
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onBonusReadyChange).toHaveBeenCalledTimes(1);
+    expect(onBonusReadyChange).toHaveBeenCalledWith({
+      exhausted: true,
+      availableCount: 1,
+    });
+    await act(async () => renderer.unmount());
+  });
+
+  it('does not overwrite a connected leftover snapshot when credits later fail-soft', async () => {
+    const onBonusReadyChange = vi.fn();
+    const renderer = await render_panel(leftoverCredits, onBonusReadyChange);
+    expect(onBonusReadyChange).toHaveBeenCalledTimes(1);
+    expect(onBonusReadyChange).toHaveBeenCalledWith({
+      exhausted: true,
+      availableCount: 1,
+    });
+
+    vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue(disconnectedCredits);
+    await act(async () => {
+      renderer.update(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+        manualRefreshNonce: 1,
+        onBonusReadyChange,
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onBonusReadyChange).toHaveBeenCalledTimes(1);
+    await act(async () => renderer.unmount());
+  });
+});

--- a/tests/bonus_ready_panel.test.tsx
+++ b/tests/bonus_ready_panel.test.tsx
@@ -74,7 +74,7 @@ describe('Codex bonusReady reporting', () => {
     await act(async () => renderer.unmount());
   });
 
-  it('does not treat a later leftover reset as a first connected snapshot after fail-soft credits', async () => {
+  it('reports the first connected leftover snapshot after fail-soft credits', async () => {
     const onBonusReadyChange = vi.fn();
     const renderer = await render_panel(disconnectedCredits, onBonusReadyChange);
     expect(onBonusReadyChange).not.toHaveBeenCalled();

--- a/tests/bonus_ready_panel.test.tsx
+++ b/tests/bonus_ready_panel.test.tsx
@@ -3,7 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import CodexPanel from '../src/components/CodexPanel';
 import { backend } from '../src/services/backend';
-import type { CodexResetCredits } from '../src/types/models';
+import type { CodexRateLimits, CodexResetCredits } from '../src/types/models';
 
 const hiddenSections = { timeline: false, cost: false, trend: false, tips: false };
 
@@ -15,6 +15,11 @@ const exhaustedLimits = {
     windowMinutes: 10_080,
     resetsAt: 1_787_961_600,
   },
+};
+
+const emptyLimits: CodexRateLimits = {
+  connected: false,
+  error: 'Network error',
 };
 
 const leftoverCredits: CodexResetCredits = {
@@ -46,9 +51,10 @@ async function render_panel(
   credits: CodexResetCredits,
   onBonusReadyChange: (ready: { exhausted: boolean; availableCount: number }) => void,
   manualRefreshNonce = 0,
+  limits: CodexRateLimits = exhaustedLimits,
 ): Promise<ReactTestRenderer> {
   vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true, planType: 'plus' });
-  vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue(exhaustedLimits);
+  vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue(limits);
   vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue(credits);
   vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
   let renderer!: ReactTestRenderer;
@@ -110,6 +116,61 @@ describe('Codex bonusReady reporting', () => {
     });
 
     vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue(disconnectedCredits);
+    await act(async () => {
+      renderer.update(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+        manualRefreshNonce: 1,
+        onBonusReadyChange,
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onBonusReadyChange).toHaveBeenCalledTimes(1);
+    await act(async () => renderer.unmount());
+  });
+
+  it('does not report while the official weekly window is missing', async () => {
+    const onBonusReadyChange = vi.fn();
+    const renderer = await render_panel(leftoverCredits, onBonusReadyChange, 0, emptyLimits);
+    expect(onBonusReadyChange).not.toHaveBeenCalled();
+    await act(async () => renderer.unmount());
+  });
+
+  it('reports the first leftover snapshot after official weekly usage appears', async () => {
+    const onBonusReadyChange = vi.fn();
+    const renderer = await render_panel(leftoverCredits, onBonusReadyChange, 0, emptyLimits);
+    expect(onBonusReadyChange).not.toHaveBeenCalled();
+
+    vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue(exhaustedLimits);
+    await act(async () => {
+      renderer.update(createElement(CodexPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+        manualRefreshNonce: 1,
+        onBonusReadyChange,
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onBonusReadyChange).toHaveBeenCalledTimes(1);
+    expect(onBonusReadyChange).toHaveBeenCalledWith({
+      exhausted: true,
+      availableCount: 1,
+    });
+    await act(async () => renderer.unmount());
+  });
+
+  it('does not overwrite a leftover snapshot when official weekly usage later disappears', async () => {
+    const onBonusReadyChange = vi.fn();
+    const renderer = await render_panel(leftoverCredits, onBonusReadyChange);
+    expect(onBonusReadyChange).toHaveBeenCalledTimes(1);
+
+    vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue(emptyLimits);
     await act(async () => {
       renderer.update(createElement(CodexPanel, {
         autoRefreshIntervalMs: 0,

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -33,8 +33,36 @@ describe('notification settings', () => {
 
   test('round-trips toggles', () => {
     installMemoryStorage();
-    saveNotificationSettings({ q80: false, q95: true, bonus: false });
-    expect(getSavedNotificationSettings()).toEqual({ q80: false, q95: true, bonus: false });
+    saveNotificationSettings({
+      q80: false,
+      q95: true,
+      q100: false,
+      bonusReady: true,
+      bonus: false,
+    });
+    expect(getSavedNotificationSettings()).toEqual({
+      q80: false,
+      q95: true,
+      q100: false,
+      bonusReady: true,
+      bonus: false,
+    });
+  });
+
+  test('fills new keys from defaults when storage only has the original three', () => {
+    const values = installMemoryStorage();
+    values.set('claude-quota-notifications', JSON.stringify({
+      q80: false,
+      q95: true,
+      bonus: false,
+    }));
+    expect(getSavedNotificationSettings()).toEqual({
+      q80: false,
+      q95: true,
+      q100: true,
+      bonusReady: true,
+      bonus: false,
+    });
   });
 
   test('reads dedupe eligibility without writing storage', () => {

--- a/tests/panel_shell_ui.test.tsx
+++ b/tests/panel_shell_ui.test.tsx
@@ -119,7 +119,7 @@ describe('panel shell UI', () => {
         trayStyle="percent"
         trayCycle={false}
         events={[]}
-        notificationSettings={{ q80: true, q95: true, bonus: false }}
+        notificationSettings={{ q80: true, q95: true, q100: true, bonusReady: true, bonus: false }}
         switcherVisibility={{ claude: true, codex: true, cursor: true, grok: true, antigravity: true }}
         onClose={() => {}}
         onThemeChange={() => {}}
@@ -134,6 +134,8 @@ describe('panel shell UI', () => {
     );
 
     expect((html.match(/class="settings-group"/g) ?? [])).toHaveLength(5);
+    expect(html).toContain('Alert at 100% used');
+    expect(html).toContain('Alert when a bonus reset is unused at 100%');
     expect(html).toContain('>Providers<');
     expect(html).toContain('>Panel<');
     expect(html).toContain('>Menu<');

--- a/tests/service_events.test.tsx
+++ b/tests/service_events.test.tsx
@@ -1,0 +1,115 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useServiceEvents } from '../src/hooks/use_service_events';
+import { defaultServiceMap } from '../src/services/app_state';
+import * as notifications from '../src/services/notifications';
+import type { NotificationSettings } from '../src/services/notifications';
+import type { ServiceMap } from '../src/services/app_state';
+
+vi.mock('../src/services/notifications', async () => {
+  const actual = await vi.importActual<typeof import('../src/services/notifications')>(
+    '../src/services/notifications',
+  );
+  return {
+    ...actual,
+    notify: vi.fn(async () => ({ status: 'sent' as const })),
+  };
+});
+
+const ALL_ON: NotificationSettings = {
+  q80: true,
+  q95: true,
+  q100: true,
+  bonusReady: true,
+  bonus: true,
+};
+
+function Host({
+  used,
+  settings = ALL_ON,
+  logEvent,
+}: {
+  used: ServiceMap<number | null>;
+  settings?: NotificationSettings;
+  logEvent: (level: 'info' | 'warning' | 'critical', text: string) => void;
+}) {
+  useServiceEvents(null, defaultServiceMap(true), used, settings, logEvent);
+  return null;
+}
+
+describe('useServiceEvents 100% crossings', () => {
+  afterEach(() => {
+    vi.mocked(notifications.notify).mockClear();
+  });
+
+  it('logs and notifies when usage reaches 100%, independently of 95%', async () => {
+    const logEvent = vi.fn();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(Host, {
+        used: defaultServiceMap<number | null>(94),
+        logEvent,
+      }));
+    });
+    await act(async () => {
+      renderer.update(createElement(Host, {
+        used: { ...defaultServiceMap<number | null>(94), codex: 100 },
+        logEvent,
+      }));
+    });
+
+    expect(logEvent).toHaveBeenCalledWith('critical', 'Codex usage crossed 95%');
+    expect(logEvent).toHaveBeenCalledWith('critical', 'Codex usage reached 100%');
+    expect(vi.mocked(notifications.notify).mock.calls.map((call) => call[1])).toEqual([
+      'Codex usage crossed 95%',
+      'Codex usage reached 100%',
+    ]);
+    const hundredOptions = vi.mocked(notifications.notify).mock.calls[1]?.[2];
+    expect(typeof hundredOptions?.on_failure).toBe('function');
+    await act(async () => renderer.unmount());
+  });
+
+  it('does not notify 100% when the toggle is off, but still logs', async () => {
+    const logEvent = vi.fn();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(Host, {
+        used: defaultServiceMap<number | null>(99),
+        settings: { ...ALL_ON, q100: false },
+        logEvent,
+      }));
+    });
+    await act(async () => {
+      renderer.update(createElement(Host, {
+        used: { ...defaultServiceMap<number | null>(99), cursor: 100 },
+        settings: { ...ALL_ON, q100: false },
+        logEvent,
+      }));
+    });
+
+    expect(logEvent).toHaveBeenCalledWith('critical', 'Cursor usage reached 100%');
+    expect(vi.mocked(notifications.notify)).not.toHaveBeenCalled();
+    await act(async () => renderer.unmount());
+  });
+
+  it('does not emit bonusReady from the used-percent hook', async () => {
+    const logEvent = vi.fn();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(Host, {
+        used: defaultServiceMap<number | null>(90),
+        logEvent,
+      }));
+    });
+    await act(async () => {
+      renderer.update(createElement(Host, {
+        used: defaultServiceMap<number | null>(100),
+        logEvent,
+      }));
+    });
+
+    expect(logEvent.mock.calls.some((call) => String(call[1]).includes('bonus reset'))).toBe(false);
+    await act(async () => renderer.unmount());
+  });
+});

--- a/tests/storage_write_failures.test.ts
+++ b/tests/storage_write_failures.test.ts
@@ -183,7 +183,13 @@ interface UserSettingCase {
   expectedRead: unknown;
 }
 
-const notificationSettings = { q80: false, q95: true, bonus: false };
+const notificationSettings = {
+  q80: false,
+  q95: true,
+  q100: true,
+  bonusReady: true,
+  bonus: false,
+};
 const panelSections = { timeline: false, cost: true, trend: false, tips: true };
 const switcherVisibility = {
   claude: true,


### PR DESCRIPTION
## Summary
- Add `q100` and `bonusReady` notification keys (defaults on; old 3-key JSON fills the new keys true).
- Fire 100% independently of 95% so the same refresh can emit both.
- Codex `bonusReady` fires only on the edge into exhausted + unused reset(s). Launching already at 100% with a leftover reset does not backfill.

Closes #94

## Test plan
- [ ] Toggle the two new Settings rows; confirm they persist and old saved settings still load.
- [ ] Cross 95% then 100% in one refresh and confirm both events/notifications.
- [ ] Turn off `Alert at 100% used` and confirm the 100% event still logs.
- [ ] Refresh a Codex week already at 100% with unused bonus: no `bonusReady` on first snapshot; crossing into that state later does notify.
- [ ] Bonus expiry reminder body and 12h dedupe stay unchanged.


Made with [Cursor](https://cursor.com)