### PR TITLE
feat(codex): keep last weekly value and raise the exhausted reset path

### DIFF
--- a/docs/product/codex-exhausted-and-settings-analysis.md
+++ b/docs/product/codex-exhausted-and-settings-analysis.md
@@ -1,0 +1,315 @@
+# Codex 打满态、本地估值与设置交互分析
+
+- 状态：已拆成可做 spec，尚未实现
+- 日期：2026-09-03
+- 触发：ChatGPT Plus / Codex Weekly 官方 100%，本机 pace / weekly value 被 freshness 校验隐藏，同时有 1 张 Gifted bonus reset
+- 范围：Codex 面板打满态、本地派生数字策略、popover 交互、Settings 信息架构，以及同类菜单栏配额产品对照
+- 非目标：不在本文改代码；不建议 QuotaBar 内核销 reset credit
+
+## 可做 spec
+
+按独立 PR 拆成三包。分析本文只做背景，实现以各包 product/tech/tasks 为准。
+
+| 优先级 | Issue | Spec | 交付 |
+|---|---|---|---|
+| P0+P1 面板 | [#93](https://github.com/majiayu000/quotabar/issues/93) | `specs/GH93/` | 打满首屏、估值软降级、Bonus 跳转、Tip / last updated |
+| P0 通知 | [#94](https://github.com/majiayu000/quotabar/issues/94) | `specs/GH94/` | 100% 与「打满且有券」通知；可与 #93 平行 |
+| P2 设置 | [#95](https://github.com/majiayu000/quotabar/issues/95) | `specs/GH95/` | 服务预设、Limits/Alerts 拆组、event 导航；叠在 #94 之后 |
+
+Launch at Login、刷新间隔、独立 Settings 窗口不在这三包里。#95 合入后再开 autostart follow-up。
+
+---
+
+## 1. 现场结论（那张截图）
+
+官方链路是活的。顶部 Connected、红条 100%、`Resets in 3d 16h` / `Mon, Sep 7, 10:27 AM`、Bonus `1 available` 都来自 ChatGPT rate-limit / reset-credit API。
+
+两条橙色字不是官方同步失败，是前端把本机派生层丢掉了：
+
+| 文案 | 数据 | 门槛 | 实际含义 |
+|---|---|---|---|
+| Local pace unavailable: snapshot older than 30 minutes | ccstats 读的本机周快照 | `observedAt` > 30 min | CLI 停更后不再画消耗投影 |
+| Weekly value unavailable: stale or invalid observation time | 同一快照估出的 USD / tokens | `observedAt` > 10 min | 估值对象已经返回，渲染时被扔掉 |
+
+额度打满后不再开 Codex CLI，本机 rate-limit 快照冻住；官方仍稳定返回 100%。本地 `usedPct` 和官方差 ≤ 1% 时，后端继续用旧快照做估值，估值继承旧 `observedAt`，前端按 10 分钟门隐藏。这是「有数不画」，不是「无数可画」。
+
+Bonus reset 是 OpenAI 赠送的周窗口重置券。QuotaBar 只读展示，不能核销。要去 ChatGPT / Codex 里用。
+
+---
+
+## 2. 本地数字该不该留下上次结果
+
+### 2.1 用户 job
+
+打满时人要回答的不是「再确认一遍 100%」，而是：
+
+1. 还能不能用 → 官方 100% 已回答
+2. 何时恢复 → 倒计时已回答
+3. 要不要烧掉 Bonus reset
+4. 这一周额度值多少钱
+
+第 3、第 4 个问题在打满那一刻最急，估值卡却被收成英文错误。
+
+### 2.2 当前设计为什么隐藏
+
+0.3.1 / 0.4.0 的原则：本地派生数字宁可空白，也不画出一张会被截图传播的错账。要防的是窗口切周、用量水位漂了、换账号、时钟乱跳。官方额度走「上次 + Stale data」；估值走 fail-closed。Grok 池估值也是同一套 10 分钟门。
+
+这个原则对 **pace（速率）** 是对的，对 **weekly value（水平值）** 用错了对象。10 分钟是实时速率的保质期，不是「已完成周结算金额」的保质期。官方已 100%、窗口还没切时，估值更接近结算，不是预测。
+
+### 2.3 推荐策略：same-window retention，不是缓存永生
+
+硬拒绝（继续隐藏）：无效总额、`usedPct` 对不上、`resetsAt` 对不上、未来时间、解析失败、换账号。
+
+软降级（显示数字 + Last estimate）：其它都过，只是观察时间超过 10 分钟。
+
+不要做：把 10 分钟改成 24 小时继续隐藏；为这次去做磁盘持久化（IPC 已经带回数字）；让 pace 也显示上次耗尽倒计时；在 QuotaBar 里核销 Bonus。
+
+---
+
+## 3. 打满态的交互问题（估值之外）
+
+估值留不留只解决「数在不在」。这张图真正别扭的是：整页还按「正常监控」做交互，人已经进入「额度用完、要做决定」。
+
+### 3.1 信息层级
+
+同一事实说了四遍（托盘 / 顶栏 / 红条 / Tip），唯一出路（1 张 Bonus）压在最下面且不能点。两句橙色技术英文占了 warning 色，看起来像产品坏了。
+
+100% 时应收起诊断、抬高出路：倒计时和 Bonus 成为第一屏。
+
+### 3.2 死胡同
+
+| 控件 | 现在 | 打满时用户预期 |
+|---|---|---|
+| Refresh | 空转 Loading，官方仍 100%，本地仍旧 | 以为能消掉橙色 |
+| Dashboard | 页脚通用「Open dashboard」 | 去用那张 reset |
+| Bonus 卡 | 纯展示 | 主按钮 |
+| Tip | `Codex Weekly is at 100%.` | 「等到周一，或用 1 张券」 |
+
+只读不等于不能有跳转。Bonus 行应打开 Dashboard（最好落到 reset credits）。不要应用内核销。
+
+### 3.3 其它断点
+
+- 两句橙色应合并为一条人话：同一根因是本机快照停更。
+- Connected 绿灯 + `unavailable` 并存，状态点在撒谎。打满时应写 `Weekly exhausted`。
+- 通知有 80% / 95% / Bonus 快过期，没有 100%，也没有「打满且有未用券」。紧急的不是券还剩 29 天，是人已经被挡住。
+- 40% 和 100% 用同一组件顺序。应有 exhausted 专用层级。
+
+### 3.4 打满态建议布局
+
+1. 状态条：Weekly exhausted · resets Mon 10:27
+2. 主行动：1 bonus reset · Open ChatGPT
+3. 结算：Last estimate ≈ $xx
+4. 折叠：pace 警告、复读 Tip
+5. 背景：Timeline / 本地 cost
+
+---
+
+## 4. QuotaBar Settings 现状
+
+设置嵌在同一 popover 里，齿轮切换 `activeView === 'settings'`，并用 `claude-quota-settings-expanded` 记住是否停在设置页。
+
+| 组 | 内容 | 交互 |
+|---|---|---|
+| 01 Appearance | Theme；tray Percent / Ring / Icon only；Cycle one icon | 即时生效 |
+| 02 Providers | 每服务 Panel / Menu 双开关；至少留一个 panel、至少一个 tray | 关光会 toast |
+| 03 Panel content | Timeline / Cost / Trend / Tips 显隐 | 只控制块在不在，不控制块怎么说话 |
+| 04 Limits & alerts | Claude / Codex / Cursor 月预算；通知 80% / 95% / Bonus expiry | 预算只影响 cost 区 |
+| 05 Activity & system | 最近 6 条 event；macOS Hide Dock | event 不可点、不可过滤 |
+
+硬编码、设置里没有的：
+
+- 刷新间隔（官方 60s，429 退到 5min，auth 失败 1h，隐藏窗口 5min）
+- Last updated
+- Launch at Login
+- 100% / exhausted / reset 通知
+- 按 provider、按窗口设阈值
+- 估值过期策略（显示上次 / 隐藏）
+- 语言
+- 引导 / 连接向导
+- 打开某服务的 usage 页
+- 电源 / 电池节省
+
+设置本身的交互问题：
+
+1. **设置在回答「看起来怎样」，不回答「卡住了怎么办」。** 用户从 100% 面板点齿轮，看不到 refresh cadence、看不到 exhausted 告警、也没有「如何用 Bonus」。
+2. **通知模型停在「涨上去」。** 只有 used% 跨越 80/95，以及券快过期。竞品已经覆盖 low / critical / exhausted / reset 全生命周期。
+3. **Panel content 只能关模块，不能改模块在打满时的行为。** 关掉 Tips 只是少一块复读，不会出现决策句。
+4. **Providers 的 Panel vs Menu 对高级用户很好，对第一次进来的人像权限矩阵。** 没有「我只用 Codex」的一键模式。隐藏的 panel 仍后台刷新，hint 写了，但关不掉轮询。
+5. **预算和通知塞在同一组。** 预算是 cost 的输入，通知是配额的输出，job 不同。
+6. **Recent events 放在设置里。** 更像诊断抽屉。打满 / 断线这类 event 不能点回对应面板。
+7. **设置占用整页 popover。** 项目变多之后会变成长表单。竞品把 Providers / General / Usage 拆成独立 Settings 窗口，菜单栏 popover 保持「看数 + 一两个动作」。
+8. **存储 key 仍是 `claude-quota-*`。** 不影响交互，但说明设置是从单服务年代长出来的，没有按「多服务控制面」重新信息架构。
+9. **没有 Launch at Login。** 菜单栏配额工具的默认承诺就是开机在。
+10. **Refresh 不可配置，反馈也不分情境。** 官方已新、只有本地 extras 过期时，Refresh 仍假装能修好。
+
+---
+
+## 5. 同类竞品怎么做
+
+对照的是同一品类：macOS 菜单栏 AI 配额监控。不是系统监视器，也不是 ChatGPT 官网 Usage 页。
+
+### 5.1 CodexBar（steipete / codexbar.app）— 品类标杆
+
+- 独立 Settings 窗口，而不是把表单塞进 popover。
+- **Settings → Providers**：每个服务自己的开关、数据源（OAuth / CLI / cookies）、可选 dashboard extras。
+- **刷新**：Manual / 1m / 2m / 5m / 15m / 30m / Adaptive / Adaptive (agent-aware)。新装默认 Adaptive。菜单里永远有 Refresh now；手动刷新时菜单保持打开。
+- **过期策略**：stale / error **变暗图标，数字留下**，菜单里写状态。营销文案是 `Updated just now`，把新鲜度做成常驻状态，而不是错误条。
+- **通知**：opt-in；按 **剩余百分比** 配阈值，默认 remaining 50% / 20%；session 和 weekly 分开。
+- **Reset credits 是一等公民**：`1 reset available` / `Next expires in 27d`，和 session / weekly 并列，不是底部品类卡。
+- **Usage & Spend** 单独一页，本地 7/30 天成本，不和开关混在一起。
+- 另有 Merge Icons、Overview、WidgetKit、CLI、电池节省、开机后的 provider 探测。
+
+对 QuotaBar 的启示：popover 负责看数和做决定；设置负责源、节奏、阈值。打满时 reset credit 要抬到和红条同一层级。新鲜度用 `Updated 4m ago` 表达，不要用 `unavailable`。
+
+它踩过的坑（不要学错）：为了防「假重置」做过严的 reset-credit 确认，导致官方已经切周、券还在时界面钉死旧百分比。QuotaBar 现在的问题是反的——官方对、本地估值藏过头——但同属「校验比用户还自信」。
+
+### 5.2 AIQuota（aiquota.app）
+
+- 引导式连接，服务可只开一个，空位会收起来。
+- 菜单栏 + popover + **桌面小组件**，三种尺寸。
+- 告警覆盖 **low / critical / exhausted / reset**。打满和恢复都通知，不只是 80/95。
+- 把状态说成 clear / close / capped，而不是校验错误。
+- 匿名统计默认关，设置里一项即可。
+
+对 QuotaBar 的启示：exhausted 和 reset 是告警的两端。设置里的通知如果没有这两档，打满场景等于静音。小组件不是必须，但「适配只开一个服务」值得学。
+
+### 5.3 ClaudeQuota
+
+- 极简：环 + 点击 breakdown，几乎没有设置面。
+- 阈值写在代码常量里（环 75/90，通知 80/95）。
+- **永远有 last updated**。过期是时间戳，不是错误。
+- 刷新 3 分钟；429 退避。
+- Start at Login，无 Dock。
+- 菜单里 Sign in，断线时托盘写 `Sign in`。
+
+对 QuotaBar 的启示：单服务可以几乎无设置。QuotaBar 已经是多服务，不能退回「零设置」，但 last updated 和托盘断线文案是低成本高收益。设置项能不开放就不开放——ClaudeQuota 证明大多数人接受产品默认阈值。
+
+### 5.4 AI Quota Bar（techfanseric）
+
+- Settings 先解决 **连接**（API key / CLI login），再解决显示。
+- Displayed provider：Automatic / 指定服务。Automatic 按谁更紧、消耗是否不可持续来切。
+- Appearance：详细文字 vs 紧凑环；pace 连续百分比 vs 分档。
+- 刷新间隔可调。
+- 网络全挂时：**留下上次的环**，中心改成禁止符。Hover 看出准确数字、pace、重置、连通。
+
+对 QuotaBar 的启示：失败态保留上次图形，用一个符号表达「现在连不上」。这正是 weekly value 该走的路。Cycle tray 已经接近 Automatic，但设置里没有解释「为什么现在显示 Codex」。
+
+### 5.5 官方产品自己的「设置」
+
+ChatGPT / Codex / Claude / Cursor 的 Usage 页才是核销和账单的地方。竞品共识是 **深链过去，不在菜单栏里做写操作**。QuotaBar 的 Dashboard 按钮属于这条共识，只是没有情境文案，也没有从 Bonus 行直接跳。
+
+### 5.6 对照总表
+
+| 能力 | QuotaBar | CodexBar | AIQuota | ClaudeQuota | AI Quota Bar |
+|---|---|---|---|---|---|
+| 设置放哪 | popover 整页 | 独立窗口多 pane | 应用内 + 引导 | 几乎无 | 菜单 Settings |
+| 刷新节奏 | 写死 60s | 可选 + Adaptive | 产品默认 | 3min | 可调 |
+| Last updated | 无 | `Updated just now` | warning states | 常驻一行 | hover |
+| 过期数字 | 官方留、估值藏 | 留 + 图标变暗 | 状态词 | 留 | 留环 + 禁止符 |
+| 通知 | 80 / 95 / bonus 过期 | remaining 50/20，分窗口 | low / critical / exhausted / reset | 80 / 95 | 用尽前警告 |
+| Reset credit | 底部展示，不可点 | 和窗口并列 | 未强调 | 无 | 无 |
+| 打满布局 | 与 40% 相同 | 菜单结构不变，credits 仍在主位 | capped 作为状态 | 环变红 | 环 + 禁止符 |
+| Launch at Login | 无 | 有（品类标配） | 引导后常驻 | 有 | 未强调 |
+| 只用一个服务 | 手动关 Panel/Menu | Providers 开关 | 自动收空位 | 天生单服务 | Automatic / 指定 |
+| 预算 | 有月预算 | Usage & Spend 页 | 无 | 无 | 无 |
+| 主题 / tray 皮肤 | 强 | 中 | 中 | 环颜色 | 文字 / 环 |
+| 小组件 | 无 | 有 | 有 | 无 | 无 |
+
+QuotaBar 现在的差异化在：**多服务总览 + 本地 cost / weekly value + 主题和 tray 皮肤**。短板在：**打满决策路径、新鲜度语言、设置里的节奏与告警生命周期**。不要用「再加 20 个开关」去追 CodexBar 的 provider 广度。
+
+---
+
+## 6. 设置交互该怎么长
+
+原则：popover 里的设置继续保持短；只放改变「看见什么」的开关。改变「何时响 / 多久刷 / 过期怎么办」的，要么给很少的默认、要么以后再拆独立窗口。
+
+### 6.1 现在不必做成开关的
+
+| 主题 | 建议 | 原因 |
+|---|---|---|
+| 估值过期 | 产品默认改为 same-window 留下 | ClaudeQuota 把阈值写死；用户没有在设 10 分钟 |
+| 打满布局 | 产品默认切换层级 | 不需要「exhausted layout」开关 |
+| Tip 文案 | 100% 时自动改成等 / 用券 | 关掉 Tips 不是解决方案 |
+| Bonus 可点 | 默认跳 Dashboard | 只读边界内的跳转 |
+| 两句橙色合并 | 默认合并 | 实现细节不该进设置 |
+
+### 6.2 值得进设置的（按收益）
+
+**P0 — 补通知生命周期，不要先做刷新滑条**
+
+在 Limits & alerts 里把通知改成四档，默认开：
+
+- Approaching（现有 80%）
+- Critical（现有 95%）
+- Exhausted（100% / 窗口打满）
+- Bonus available while exhausted（打满且有未用券）
+- Bonus expiring（现有，保留）
+
+这是 AIQuota 已经验证、CodexBar 用剩余百分比覆盖过的缺口。和截图直接对应：人被挡住、手里有券、系统却不说话。
+
+不要一上来做成「每个 provider、每个窗口、自定义 73%」。CodexBar 那种细阈值是他们用户要的；QuotaBar 的设置已经偏外观。先四档开关，阈值继续产品默认。
+
+**P1 — Last updated 常驻，不是设置项**
+
+面板和托盘 hover 写 `Updated 4m ago`。官方新、本地 extras 旧时写成 `Quota current · local extras 47m ago`。ClaudeQuota / CodexBar 都把这当成状态，不是选项。
+
+**P1 — Refresh 的情境反馈，间隔先不开放**
+
+60s 对菜单栏够用。先改按钮语义：官方已新时不要转圈装忙；本地旧时告诉人「需要一次 Codex CLI 会话」。等真有人要省电 / 要手动，再学 CodexBar 做 Manual / 1m / 5m / Adaptive。
+
+**P2 — Launch at Login**
+
+放进 Activity & system，挨着 Hide Dock。菜单栏工具的默认预期。
+
+**P2 — 「我只用这些服务」的简化**
+
+保留现在的 Panel / Menu 矩阵给高级用户，上面加一行预设：All / Codex only / Claude only。AIQuota 的「只连一个就收空位」比双开关好理解。
+
+**P2 — 设置信息架构微调**
+
+- 04 拆开：Notifications / Budgets，或预算挪到和 cost 更近的地方
+- Recent events 可点回对应 provider
+- 长到超过一屏再考虑独立 Settings 窗口；现在五组还撑得住 popover
+
+### 6.3 明确不要从竞品搬过来的
+
+- 不要独立做成「Source mode / cookies / OAuth picker」大设置。QuotaBar 的信任模型是复用本机已有登录，少一套凭证 UI。
+- 不要 Widget / CLI 来补打满态。那是分发面，不是这条 job。
+- 不要匿名统计开关来充设置丰富度。
+- 不要在设置里暴露 freshness 分钟数。
+- 不要学 CodexBar 用 reset-credit 库存去否决官方新百分比。
+
+---
+
+## 7. 决策与优先级
+
+和截图同一条用户路径上的完整顺序：
+
+| 优先级 | 改动 | 用户立刻感到什么 | 是否进设置 |
+|---|---|---|---|
+| P0 | 打满层级：倒计时 + Bonus 上移，合并橙色 | 首屏能做决定 | 否，默认 |
+| P0 | Bonus 可点跳转；有券时主按钮借义 | 死胡同打开 | 否，默认 |
+| P0 | 通知补 Exhausted + 打满且有券 | 不用自己点开托盘 | 是，默认开 |
+| P1 | 估值 same-window 保留 + Last estimate | 结算还在 | 否，默认 |
+| P1 | Tip 在 100% 改成等 / 用券 | 复读变决策 | 否，默认 |
+| P1 | Last updated + Refresh 情境反馈 | 不再像坏了 | 否，默认 |
+| P2 | Launch at Login；只用某服务预设 | 更像菜单栏工具 | 是 |
+| P2 | 设置分组（通知 / 预算拆开） | 好找 | 是，结构 |
+| 以后 | 刷新节奏、独立 Settings 窗口、细阈值 | 追 CodexBar 的控制欲 | 是 |
+| 不做 | 应用内 reset、估值开关、freshness 滑条 | — | — |
+
+成功标准（回到那张图）：
+
+- 红条 100% 仍在
+- 不再出现 `Weekly value unavailable`
+- 估值卡还在，带 Last estimate
+- Bonus 是可点的主行动
+- Tip 不再复读 100%
+- 若开启通知，打满且有券会响一次
+- 窗口切到下一周后，旧金额必须消失
+
+---
+
+## 8. 记录说明
+
+本文汇总 2026-09-03 对话里的现场诊断、估值策略、打满交互和设置 / 竞品对照。实现以 `specs/GH93`、`specs/GH94`、`specs/GH95` 为准，不要把本文整页当一个 PR。

--- a/specs/GH93/product.md
+++ b/specs/GH93/product.md
@@ -1,0 +1,77 @@
+# GH-93 Product Spec：Codex 打满态首屏与 same-window 估值
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/93
+- `complexity: high`
+- Analysis: `docs/product/codex-exhausted-and-settings-analysis.md`
+- Follow-ups: #94 (lifecycle alerts), #95 (settings control surface)
+
+## Problem
+
+Codex Weekly 官方 100% 时，面板仍按「正常监控」布局说话：
+
+- 本机 weekly value 已算出来，却因 `observedAt` 超过 10 分钟被整卡隐藏。
+- Local pace 与 weekly value 各丢一句英文校验错误，看起来像同步故障。
+- Tip 再复读一遍 100%。
+- 唯一出路（Gifted bonus reset）在底部且不可点。
+- Refresh 与页脚 Dashboard 没有情境。
+
+现场证据：ChatGPT Plus、7-day window 100%、`Resets in 3d 16h`、两条 `unavailable`、Tip `Codex Weekly is at 100%.`、Bonus `1 available`。
+
+## Goals
+
+- 官方周窗口打满时，首屏回答「被挡住 / 还要多久 / 有没有券」，而不是解释校验。
+- 同一官方周窗口、用量仍对齐时，过期估值降级展示，不隐藏。
+- Bonus reset 成为只读跳转的主行动；QuotaBar 不核销。
+- 本地 extras 过期用一句人话 + last updated，不再渲染校验原文。
+- Claude / Cursor / Grok / Antigravity 面板语义不变。
+
+## Non-Goals
+
+- 不内核销 reset credit，不新增写 ChatGPT 的 command。
+- 不改通知生命周期（#94）、设置分组 / Launch at Login / 服务预设（#95）。
+- 不开放 freshness 分钟数、刷新间隔、估值开关。
+- 不改 Grok 池估值的 10 分钟门。
+- 不改后端 weekly 估算公式、官方 used% 计算、tray 百分比语义。
+- 不把 pace 耗尽倒计时也做成 last-known 展示。
+
+## Behavior Invariants
+
+1. `B-001` 官方 weekly used% ≥ 100 且已连接时，header 状态为 `Weekly exhausted`（不是只写 Connected）；倒计时 / 重置时刻仍用官方 `resetsAt`。
+2. `B-002` 打满且存在 `available` bonus credit 时，Bonus 卡上移到 usage 卡之后、估值 / Tip / timeline / cost 之前；卡内主行动打开现有 Codex dashboard（`open_codex_dashboard`），并写明 QuotaBar 不能代为核销。
+3. `B-003` 打满且无 available bonus 时，不画空 Bonus 卡；Tip / 状态条只给等待文案。
+4. `B-004` weekly value 仅因观察时间超过 10 分钟失败，且 `resetsAt`、`usedPct` 仍与官方周窗口对齐时，必须显示数字，并标 `Last estimate` 与观察多久之前；不得出现 `Weekly value unavailable`。
+5. `B-005` 无效总额、用量差 > 5%、重置不对齐、未来 / 无法解析的 `observedAt` 仍整卡隐藏（硬拒绝）。不得把上一周或另一水位的金额留下来。
+6. `B-006` Local pace 在打满后不展示投影；pace / value 若只是本机快照停更，合并为一条次级说明，不渲染 `The local …` 校验原文。
+7. `B-007` 官方 weekly ≥ 100 时，Tip 不得再写 `Codex Weekly is at 100%.`。有券：`Weekly is used up. Wait until {reset}, or use 1 bonus reset.`（count 跟随 available 数）。无券：`Weekly is used up. Resets {reset}.` 未打满时 `getHighUsageTip` 行为不变。
+8. `B-008` 官方 limits 成功后，Codex 面板展示 `Updated …`（just now / Nm ago / …）。仅本地 extras 过期时，Refresh 不得假装能造出 CLI 快照；完成后官方仍新则保持 `Quota current`，extras 继续用 B-006 那条说明。
+9. `B-009` 官方 100% 红条、重置倒计时、Bonus 可用数量、tray `usedPercent` 不被本地 extras 失败改写。页脚 Dashboard 文案保持 `Dashboard`。
+10. `B-010` 窗口切到下一周（官方 `resetsAt` 不再与估值对齐）后，旧估值必须消失。
+
+## Acceptance Criteria
+
+- 复现夹具：官方 weekly 100%、本地 quota `observedAt` 31 分钟前、value estimate 同源时间戳且 used/reset 对齐、1 张 available bonus。结果：红条 100% 仍在；估值卡可见且带 Last estimate；无 `Weekly value unavailable` / `Local pace unavailable` 原文；Bonus 在 Tip 之上且可点；Tip 为决策句；header 为 Weekly exhausted。
+- 估值硬拒绝矩阵保持隐藏：invalid totals、usedPct 漂移、reset 漂移、future/NaN `observedAt`。
+- 未打满、估值新鲜时，现有 API-equivalent week 卡不变。
+- Bonus 主行动调用现有 dashboard opener exactly once；失败走现有 toast，不新增 command。
+- Claude / Cursor / Grok 的 80% Tip 与 Grok 估值隐藏行为有回归断言。
+- 官方周窗口切到新 `resetsAt` 后，旧估值不得出现。
+
+## Boundary Checklist
+
+| 边界 | 结论 |
+| --- | --- |
+| 100% + 同窗口过期估值 + 1 bonus | 显示估值 + Bonus CTA + 决策 Tip |
+| 100% + 无 bonus | 无 Bonus 卡；等待 Tip |
+| 40% + 新鲜估值 | 现有估值卡，无 exhausted 层级 |
+| 40% + 仅过期估值、窗口对齐 | Last estimate，非 unavailable |
+| 估值 reset 对不上 | 隐藏估值 |
+| 打满 + pace 过期 | 不画 pace 投影；一条合并说明 |
+| Refresh 且官方已新 | 不出现假 Loading 失败感；Quota current |
+| 下一周 | 旧 $ 消失 |
+| Dashboard opener 失败 | 现有 toast；面板数字不动 |
+
+## Open Questions
+
+- 无。核销仍在 ChatGPT；dashboard URL 沿用现有 `https://chatgpt.com`，本 issue 不改 opener 目标。

--- a/specs/GH93/tasks.md
+++ b/specs/GH93/tasks.md
@@ -1,0 +1,24 @@
+# GH-93 Tasks：Codex exhausted panel
+
+## Delivery Contract
+
+- Base: then-latest `origin/main`。可与 #94 / #95 平行设计，implementation 不要叠 #94 的通知 key。
+- Commit policy: `per_step`。
+- Scope: Codex 打满层级、估值软降级、Bonus 跳转、Tip / last updated / extras 文案。
+- Compatibility: 官方 limits / reset-credit payload、dashboard URL、其它 provider 面板、通知 schema 不变。
+
+## Implementation Tasks
+
+- [x] `SP93-T1` Owner: impl. Dependencies: this spec. Covers: `B-004`, `B-005`, `B-010`. Done when: weekly value 年龄-only 为 soft Last estimate；hard 失败仍隐藏；reset 漂移后旧值消失。 Verify: `tests/provider_refresh_races.test.tsx` 估值矩阵。
+- [x] `SP93-T2` Owner: impl. Dependencies: T1. Covers: `B-001`~`B-003`, `B-006`, `B-007`. Done when: 打满层级、Bonus CTA、合并 extras 文案、exhausted Tip、header `Weekly exhausted` 全绿；未打满路径视觉顺序不变。 Verify: `tests/codex_exhausted_panel.test.tsx` + `tests/detail_helpers.test.ts`。
+- [x] `SP93-T3` Owner: impl. Dependencies: T2. Covers: `B-008`, `B-009`. Done when: last updated 在官方成功后出现；Refresh 在仅 extras 过期时不写 error banner；footer 仍为 Dashboard；官方 100% 不被 extras 改写。 Verify: exhausted panel + 既有 Codex refresh tests。
+- [x] `SP93-T4` Owner: impl. Dependencies: T1-T3. Covers: `B-001`~`B-010`. Done when: allowlist 外无 diff；`npx tsc --noEmit && npm test && npm run build` 通过。 Verify: tech Test Plan。
+
+## Handoff
+
+- [x] `SP93-T5` Owner: impl. Dependencies: T4. Done when: implementation PR `Closes #93`，正文链到分析文档与本 spec，并写明不核销 reset、不改 opener URL。
+
+## Handoff Notes
+
+- Invariants: `{B-001 … B-010}`。
+- 禁止把校验原文渲染进 JSX、禁止新增核销 API、禁止改 Grok 估值门、禁止改通知 schema。

--- a/specs/GH93/tech.md
+++ b/specs/GH93/tech.md
@@ -1,0 +1,138 @@
+# GH-93 Tech Spec：Codex exhausted layout 与 weekly value 软降级
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/93
+- Product spec: `specs/GH93/product.md`
+
+## Current Mechanism
+
+`CodexPanel` 把官方 limits 与 `get_codex_weekly_quota` 分开拉。官方 100% 照常渲染。本地 `validateWeeklyQuotaWindow` / `validateWeeklyValueEstimate` 把任何失败（含年龄）变成 `displayed* = null` + 校验原文。
+
+年龄门：
+
+- pace：`now - observedAt > 30min`
+- value：`now - observedAt > 10min`，或未来超过 5min，或 NaN
+
+`getHighUsageTip` 只复读最高窗口百分比。Bonus 卡在 Tip 之后，无 click handler。`open_codex_dashboard` 已存在，打开 `https://chatgpt.com`。
+
+## Proposed Design
+
+### 1. 拆硬拒绝 / 软降级
+
+保持两道校验函数，但返回结构化结果，而不是只返回 string：
+
+```ts
+type EstimateCheck =
+  | { ok: true }
+  | { ok: false; kind: 'hard' | 'soft'; message: string };
+```
+
+value **soft** 仅当：totals 合法、`usedPct` 与官方差 ≤ 5%、`resetsAt` 与官方差 ≤ 5min、`observedAt` 可解析且不在未来，只是年龄 > 10min。
+
+其它失败为 **hard**。soft 时 `displayedWeeklyValueEstimate` 仍为 estimate 对象，UI 走 Last estimate；hard 时保持现在的隐藏。
+
+pace：打满（官方 weekly ≥ 100）时不调用 pace 投影、不渲染 `Local pace unavailable: …`。未打满时 pace 硬失败仍可一条合并说明，但不画误导性耗尽倒计时。
+
+### 2. 合并本地 extras 文案
+
+当 pace 或 value 存在 soft/age 失败时，只渲染一行次级 copy，例如：
+
+`Local extras paused · Codex CLI has not refreshed in 47m`
+
+分钟数取更旧的那份 `observedAt`。禁止把 `The local weekly value estimate is stale or has an invalid observation time.` 等函数返回值直接进 JSX。
+
+### 3. Exhausted 层级
+
+当 `selectOfficialWeeklyLimitWindow` 的 `usedPercent >= 100`：
+
+1. Usage 卡（官方红条 + 倒计时）
+2. Bonus 卡（仅 `getAvailableResetCredits` 非空）
+3. Weekly value（soft 或新鲜）
+4. 合并 extras 说明（如有）
+5. Tip（`getExhaustedWeekTip`，不是 `getHighUsageTip`）
+6. Timeline / cost 维持 `sections.*`
+
+header `status`：`Weekly exhausted`；`tone` 用现有 `error` 或 `pending` 中能与 Connected 绿灯区分的值。未打满不走这套顺序。
+
+### 4. Bonus CTA
+
+Bonus 卡（header 或整卡）是 `<button>`，`onClick` 调 `onOpenDashboard`。`App` 把现有 `handleOpenDashboard` 传给 `CodexPanel`。不新增 Tauri command，不改 `link::open_codex_dashboard` URL。
+
+卡上加一句固定说明：`Opens ChatGPT. QuotaBar cannot apply this reset.`
+
+### 5. Tip
+
+在 `detail_helpers.ts` 新增 `getExhaustedWeekTip({ resetLabel, bonusCount })`。`getHighUsageTip` 签名与阈值不变；Codex 打满时不用它。其它 provider 继续只用 `getHighUsageTip`。
+
+`resetLabel` 复用现有 `formatResetAt` / `formatResetTime` 之一，测试锁固定字符串。
+
+### 6. Last updated 与 Refresh 反馈
+
+`CodexPanel` 在官方 `getCodexRateLimits` 成功且无 `limits.error` 时记录 `officialUpdatedAt = Date.now()`。展示 `Updated just now`（< 15s）或 `Updated {n}m ago`。
+
+`loading` 仍由 current generation 控制（GH-52）。若本次成功刷新后官方 weekly 与刷新前相同，且本地 extras 仍 soft-stale，不得另起 error banner。可用一句 `Quota current` 贴在 last updated 旁。
+
+### 7. Tests
+
+扩展 `tests/provider_refresh_races.test.tsx` 的 stale observation 例：从「隐藏 + unavailable 原文」改为「Last estimate + 无 unavailable 原文」。
+
+新增 `tests/codex_exhausted_panel.test.tsx`（或同文件 describe）：
+
+- 100% + stale same-window value + 1 bonus：顺序、CTA、Tip、header
+- 100% + 0 bonus：无 Bonus 卡、等待 Tip
+- hard reject 矩阵
+- 未打满 + 新鲜估值回归
+- reset 漂移后旧估值消失
+- `getHighUsageTip` 在 Claude 80% 仍为旧句
+- dashboard callback 点击一次
+
+## Affected Files / Allowlist
+
+- `src/components/CodexPanel.tsx`
+- `src/services/detail_helpers.ts`
+- `src/App.tsx`（仅传入 `onOpenDashboard`）
+- `src/styles/content.css` 或现行 Codex/bonus 样式所在 stylesheet（只为 CTA / Last estimate 必要 class）
+- `tests/provider_refresh_races.test.tsx`
+- `tests/detail_helpers.test.ts`
+- `tests/codex_exhausted_panel.test.tsx`
+- `specs/GH93/tasks.md`
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| 把上一周 $ 留下 | B-005 / B-010：reset 不对齐必 hard |
+| 点击 Bonus 被当成已核销 | 固定 cannot-apply copy；只调用现有 opener |
+| 改坏其它 provider Tip | Codex 打满走新 helper；旧 helper 回归 |
+| App.tsx 范围膨胀 | 只加一个 optional callback prop |
+| 校验原文又漏进 UI | 测试断言不含 `The local weekly` / `The local pace snapshot` |
+| GH-52 generation 被破坏 | 不改 request coordinator；只在 current success 写 `officialUpdatedAt` |
+
+## Product-to-Test Mapping
+
+| Invariant | Verification |
+| --- | --- |
+| `B-001` | header 文案 + tone |
+| `B-002` `B-003` | Bonus 顺序 / 有无 / click count |
+| `B-004` `B-005` `B-010` | soft vs hard value matrix |
+| `B-006` | 无校验原文；打满无 pace 投影 |
+| `B-007` | exhausted tip + Claude tip 回归 |
+| `B-008` | last updated；refresh 后无 error banner |
+| `B-009` | 官方 100% 与 footer Dashboard 文案不变 |
+
+## Test Plan
+
+```bash
+set -euo pipefail
+npx tsc --noEmit
+npx vitest run tests/provider_refresh_races.test.tsx tests/detail_helpers.test.ts tests/codex_exhausted_panel.test.tsx
+npm test
+npm run build
+```
+
+Rust 不在本 issue 的必跑变更集里。若 `src-tauri` 被误改，PR 必须先撤回再合。
+
+## Rollback Plan
+
+回滚 implementation PR。无 storage schema、无 backend payload、无新 dependency。旧行为恢复为：过期估值隐藏、Bonus 不可点、Tip 复读 100%。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -737,6 +737,7 @@ export default function App() {
                   sections={panelSections}
                   onBonusExpiring={handleBonusExpiring}
                   onBonusReadyChange={handleBonusReadyChange}
+                  onOpenDashboard={handleOpenDashboard}
                 />
               </div>
 

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -14,7 +14,16 @@ import type {
   CodexWeeklyValueEstimate,
 } from '../types/models';
 import { buildCodexQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
-import { getAvailableResetCredits, getHighUsageTip } from '../services/detail_helpers';
+import {
+  checkWeeklyQuotaWindow,
+  checkWeeklyValueEstimate,
+  formatLocalExtrasPaused,
+  formatOfficialUpdatedAt,
+  isHardDisplayCheck,
+  isSoftDisplayCheck,
+  isWeeklyExhausted,
+} from '../services/codex_weekly_display';
+import { getAvailableResetCredits, getExhaustedWeekTip, getHighUsageTip } from '../services/detail_helpers';
 import { clampProgressValue, formatPaceText, formatPlanType, formatResetTime, getProgressStyle } from '../utils/quota_format';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
 import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';
@@ -30,6 +39,7 @@ interface CodexPanelProps {
   sections?: PanelSectionVisibility;
   onBonusExpiring?: (daysLeft: number) => void;
   onBonusReadyChange?: (ready: { exhausted: boolean; availableCount: number }) => void;
+  onOpenDashboard?: () => void;
 }
 
 function formatSubscriptionDate(dateStr?: string): string {
@@ -105,84 +115,6 @@ const COMPACT_TOKEN_FORMAT = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 1,
 });
 
-function validateWeeklyValueEstimate(
-  estimate: CodexWeeklyValueEstimate,
-  official: CodexRateLimitWindow,
-): string | null {
-  if (
-    !Number.isFinite(estimate.observedCostUsd)
-    || estimate.observedCostUsd <= 0
-    || !Number.isFinite(estimate.estimatedWeeklyValueUsd)
-    || estimate.estimatedWeeklyValueUsd <= 0
-    || !Number.isFinite(estimate.observedTokens)
-    || estimate.observedTokens <= 0
-    || !Number.isFinite(estimate.estimatedWeeklyTokens)
-    || estimate.estimatedWeeklyTokens <= 0
-  ) {
-    return 'The local weekly value estimate contains invalid totals.';
-  }
-  if (Math.abs(estimate.usedPct - official.usedPercent) > 5) {
-    return 'The local weekly value estimate does not match the quota usage.';
-  }
-  const estimateObservedAt = Date.parse(estimate.observedAt);
-  const now = Date.now();
-  if (
-    !Number.isFinite(estimateObservedAt)
-    || estimateObservedAt > now + 5 * 60 * 1000
-    || now - estimateObservedAt > 10 * 60 * 1000
-  ) {
-    return 'The local weekly value estimate is stale or has an invalid observation time.';
-  }
-  const estimateReset = Date.parse(estimate.resetsAt);
-  const officialReset = (official.resetsAt ?? 0) * 1000;
-  if (
-    !Number.isFinite(estimateReset)
-    || officialReset <= 0
-    || Math.abs(estimateReset - officialReset) > 5 * 60 * 1000
-  ) {
-    return 'The local weekly value estimate does not match the quota reset.';
-  }
-  return null;
-}
-
-function validateWeeklyQuotaWindow(
-  quota: CodexWeeklyQuota,
-  official?: CodexRateLimits['secondary'],
-): string | null {
-  if (!official) return 'The official weekly quota window is unavailable.';
-  if (!Number.isFinite(official.windowMinutes) || (official.windowMinutes ?? 0) <= 0) {
-    return 'The official weekly window length is unavailable.';
-  }
-  if (official.windowMinutes !== quota.windowMinutes) {
-    return 'The local pace snapshot does not match the official weekly window.';
-  }
-  const officialReset = official.resetsAt;
-  if (!Number.isFinite(officialReset) || (officialReset ?? 0) <= 0) {
-    return 'The official weekly reset time is unavailable.';
-  }
-  const localReset = Date.parse(quota.resetsAt) / 1000;
-  if (!Number.isFinite(localReset) || localReset <= 0) {
-    return 'The local pace snapshot has an invalid reset time.';
-  }
-  if (Math.abs(localReset - (officialReset ?? 0)) > 5 * 60) {
-    return 'The local pace snapshot does not match the current official reset.';
-  }
-  const observedAt = Date.parse(quota.observedAt);
-  const now = Date.now();
-  if (!Number.isFinite(observedAt)) {
-    return 'The local pace snapshot has an invalid observation time.';
-  }
-  if (observedAt > now + 5 * 60 * 1000) {
-    return 'The local pace snapshot is dated in the future.';
-  }
-  if (now - observedAt > 30 * 60 * 1000) {
-    return 'The local pace snapshot is older than 30 minutes.';
-  }
-  if (Math.abs(quota.usedPct - official.usedPercent) > 1) {
-    return 'The local pace usage does not match the current official usage.';
-  }
-  return null;
-}
 
 function selectOfficialWeeklyWindow(
   limits: CodexRateLimits | null,
@@ -264,6 +196,7 @@ export default function CodexPanel({
   sections = defaultPanelSections(),
   onBonusExpiring,
   onBonusReadyChange,
+  onOpenDashboard,
 }: CodexPanelProps) {
   const [codexData, setCodexData] = useState<CodexData | null>(null);
   const [rateLimits, setRateLimits] = useState<CodexRateLimits | null>(null);
@@ -272,6 +205,7 @@ export default function CodexPanel({
   const [weeklyQuotaError, setWeeklyQuotaError] = useState<string | null>(null);
   const [weeklyValueEstimate, setWeeklyValueEstimate] = useState<CodexWeeklyValueEstimate | null>(null);
   const [weeklyValueEstimateError, setWeeklyValueEstimateError] = useState<string | null>(null);
+  const [officialUpdatedAt, setOfficialUpdatedAt] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [rateLimitsError, setRateLimitsError] = useState<string | null>(null);
@@ -323,8 +257,11 @@ export default function CodexPanel({
       if (limits.error) {
         setError(limits.error);
         setRateLimitsError(limits.error);
-      } else if (info.error) {
-        setError(info.error);
+      } else {
+        setOfficialUpdatedAt(Date.now());
+        if (info.error) {
+          setError(info.error);
+        }
       }
 
       // Notify parent about connection status change
@@ -378,18 +315,17 @@ export default function CodexPanel({
     }
   }, [resetCredits, onBonusExpiring]);
 
-  const officialWeeklyLimitForReady = selectOfficialWeeklyLimitWindow(rateLimits);
-  const weeklyExhaustedForReady = typeof officialWeeklyLimitForReady?.usedPercent === 'number'
-    && officialWeeklyLimitForReady.usedPercent >= 100;
-  const availableResetCreditsForReady = getAvailableResetCredits(resetCredits);
+  const officialWeeklyLimit = selectOfficialWeeklyLimitWindow(rateLimits);
+  const weeklyExhausted = isWeeklyExhausted(officialWeeklyLimit?.usedPercent);
+  const availableResetCredits = getAvailableResetCredits(resetCredits);
 
   useEffect(() => {
     if (!onBonusReadyChange || !rateLimits) return;
     onBonusReadyChange({
-      exhausted: weeklyExhaustedForReady,
-      availableCount: availableResetCreditsForReady.length,
+      exhausted: weeklyExhausted,
+      availableCount: availableResetCredits.length,
     });
-  }, [availableResetCreditsForReady.length, onBonusReadyChange, rateLimits, weeklyExhaustedForReady]);
+  }, [availableResetCredits.length, onBonusReadyChange, rateLimits, weeklyExhausted]);
 
   if (loading && !codexData && !rateLimits) {
     return (
@@ -406,26 +342,44 @@ export default function CodexPanel({
   const topWindow = sortMostConstrained(windows)[0];
   const showingStaleLimits = Boolean(rateLimitsError && hasRateLimits);
   const quotaUnavailable = Boolean(rateLimitsError && !hasRateLimits);
-  const availableResetCredits = getAvailableResetCredits(resetCredits);
   const bonusGrantGroups = buildBonusGrantGroups(availableResetCredits);
   const officialWeeklyWindow = selectOfficialWeeklyWindow(rateLimits, weeklyQuota);
-  const officialWeeklyLimit = selectOfficialWeeklyLimitWindow(rateLimits);
-  const weeklyQuotaValidationError = weeklyQuota
-    ? validateWeeklyQuotaWindow(weeklyQuota, officialWeeklyWindow)
+  const weeklyQuotaCheck = weeklyQuota
+    ? checkWeeklyQuotaWindow(weeklyQuota, officialWeeklyWindow)
     : null;
-  const displayedWeeklyQuota = weeklyQuotaValidationError ? null : weeklyQuota;
-  const displayedWeeklyQuotaError = weeklyQuotaValidationError ?? weeklyQuotaError;
-  const weeklyValueValidationError = officialWeeklyLimit && weeklyValueEstimate
-    ? validateWeeklyValueEstimate(weeklyValueEstimate, officialWeeklyLimit)
+  const displayedWeeklyQuota = weeklyQuotaCheck?.ok ? weeklyQuota : null;
+  const displayedWeeklyQuotaError = isHardDisplayCheck(weeklyQuotaCheck)
+    ? weeklyQuotaCheck.message
+    : weeklyQuotaCheck?.ok
+      ? null
+      : weeklyQuotaError;
+  const weeklyValueCheck = officialWeeklyLimit && weeklyValueEstimate
+    ? checkWeeklyValueEstimate(weeklyValueEstimate, officialWeeklyLimit)
     : null;
-  const displayedWeeklyValueEstimate = weeklyValueValidationError || !officialWeeklyLimit
-    ? null
-    : weeklyValueEstimate;
-  const displayedWeeklyValueEstimateError = officialWeeklyLimit
-    ? (weeklyValueValidationError ?? weeklyValueEstimateError)
+  const displayedWeeklyValueEstimate = officialWeeklyLimit && weeklyValueEstimate && (
+    weeklyValueCheck?.ok || isSoftDisplayCheck(weeklyValueCheck)
+  )
+    ? weeklyValueEstimate
+    : null;
+  const valueIsLastEstimate = isSoftDisplayCheck(weeklyValueCheck);
+  const displayedWeeklyValueEstimateError = officialWeeklyLimit && !displayedWeeklyValueEstimate
+    ? (isHardDisplayCheck(weeklyValueCheck) ? null : weeklyValueEstimateError)
+    : null;
+  const extrasObservedAt = [
+    isSoftDisplayCheck(weeklyValueCheck) && weeklyValueEstimate
+      ? Date.parse(weeklyValueEstimate.observedAt)
+      : Number.NaN,
+    isSoftDisplayCheck(weeklyQuotaCheck) && weeklyQuota
+      ? Date.parse(weeklyQuota.observedAt)
+      : Number.NaN,
+  ].filter((value) => Number.isFinite(value));
+  const extrasPausedCopy = extrasObservedAt.length > 0
+    ? formatLocalExtrasPaused(Math.min(...extrasObservedAt))
     : null;
   const renderWeeklyPace = (window: CodexRateLimitWindow) => {
+    if (weeklyExhausted) return null;
     if (window !== officialWeeklyWindow) return null;
+    if (isSoftDisplayCheck(weeklyQuotaCheck)) return null;
     if (!displayedWeeklyQuota && displayedWeeklyQuotaError) {
       return (
         <span className="quota-pace warning">
@@ -434,6 +388,73 @@ export default function CodexPanel({
       );
     }
     return null;
+  };
+  const headerStatus = showingStaleLimits
+    ? 'Stale data'
+    : quotaUnavailable
+      ? 'Quota unavailable'
+      : weeklyExhausted
+        ? 'Weekly exhausted'
+        : connected
+          ? 'Connected'
+          : 'Offline';
+  const headerTone = showingStaleLimits
+    ? 'pending'
+    : quotaUnavailable || weeklyExhausted
+      ? 'error'
+      : connected
+        ? 'online'
+        : 'offline';
+  const exhaustedTip = weeklyExhausted
+    ? getExhaustedWeekTip(formatResetAt(officialWeeklyLimit?.resetsAt), availableResetCredits.length)
+    : null;
+  const renderBonusPanel = () => {
+    if (availableResetCredits.length === 0) return null;
+    const body = (
+      <>
+        <div className="bonus-header">
+          <div className="bonus-title-row">
+            <span className="bonus-title">Bonus resets</span>
+            <span className="bonus-badge">Gifted</span>
+          </div>
+          <span className="bonus-count">{availableResetCredits.length} available</span>
+        </div>
+        <div className="bonus-grants">
+          {bonusGrantGroups.map((group) => {
+            const daysLeft = getDaysLeft(group.expiresAt);
+            return (
+              <div className="bonus-grant-row" key={group.key}>
+                <span className="bonus-grant-left">
+                  <span className="bonus-dot" />
+                  <span className="bonus-grant-label">
+                    +{group.count} · granted {formatGrantDate(group.grantedAt)}
+                  </span>
+                </span>
+                <span className={`bonus-grant-right ${daysLeft != null && daysLeft <= 10 ? 'warning' : ''}`}>
+                  {daysLeft == null ? 'Expires unknown' : `${daysLeft}d left · ${formatGrantDate(group.expiresAt)}`}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        <div className="bonus-note">Gifted occasionally · no cap · each grant valid 30 days</div>
+        {onOpenDashboard && (
+          <div className="bonus-note">Opens ChatGPT. QuotaBar cannot apply this reset.</div>
+        )}
+      </>
+    );
+    if (!onOpenDashboard) {
+      return <div className="bonus-panel">{body}</div>;
+    }
+    return (
+      <button
+        type="button"
+        className="bonus-panel bonus-panel-action"
+        onClick={onOpenDashboard}
+      >
+        {body}
+      </button>
+    );
   };
 
   return (
@@ -452,12 +473,18 @@ export default function CodexPanel({
         <div className="codex-content">
           <ProviderDetailHeader
             service="codex"
-            status={showingStaleLimits ? 'Stale data' : quotaUnavailable ? 'Quota unavailable' : connected ? 'Connected' : 'Offline'}
+            status={headerStatus}
             plan={formatCodexPlan(planType)}
             usedPercent={topWindow?.usedPercent ?? null}
             usageLabel={topWindow?.label}
-            tone={showingStaleLimits ? 'pending' : quotaUnavailable ? 'error' : connected ? 'online' : 'offline'}
+            tone={headerTone}
           />
+          {officialUpdatedAt != null && (
+            <div className="codex-updated">
+              <span>{formatOfficialUpdatedAt(officialUpdatedAt)}</span>
+              {extrasPausedCopy && <span>Quota current</span>}
+            </div>
+          )}
 
           {/* Rate Limits Section */}
           {hasRateLimits && (
@@ -495,7 +522,7 @@ export default function CodexPanel({
                         <span>{formatResetAt(rateLimits.primary.resetsAt)}</span>
                       </div>
                     )}
-                    {(() => {
+                    {!weeklyExhausted && (() => {
                       const pace = formatPaceText(
                         rateLimits.primary.usedPercent,
                         rateLimits.primary.resetsAt,
@@ -561,6 +588,8 @@ export default function CodexPanel({
             </div>
           )}
 
+          {weeklyExhausted && renderBonusPanel()}
+
           {officialWeeklyLimit
             && (displayedWeeklyValueEstimate || displayedWeeklyValueEstimateError) && (
             <div className="section weekly-value-section">
@@ -573,7 +602,9 @@ export default function CodexPanel({
                           <span className="weekly-value-dot" />
                           API-equivalent week
                         </span>
-                        <span className="weekly-value-badge">Local estimate</span>
+                        <span className="weekly-value-badge">
+                          {valueIsLastEstimate ? 'Last estimate' : 'Local estimate'}
+                        </span>
                       </div>
                       <div className="weekly-value-body">
                         <div className="weekly-value-metrics">
@@ -606,7 +637,9 @@ export default function CodexPanel({
                           {`Based on ${Math.round(displayedWeeklyValueEstimate.usedPct)}% used · ${USD_FORMAT.format(displayedWeeklyValueEstimate.observedCostUsd)} local`}
                         </span>
                         <span>
-                          {`${COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.observedTokens)} observed tokens · Not an official allowance`}
+                          {valueIsLastEstimate
+                            ? `${COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.observedTokens)} observed tokens · Not an official allowance · snapshot not refreshed`
+                            : `${COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.observedTokens)} observed tokens · Not an official allowance`}
                         </span>
                       </div>
                     </>
@@ -620,39 +653,15 @@ export default function CodexPanel({
             </div>
           )}
 
-          {sections.tips && <SmartTip message={getHighUsageTip(windows)} />}
-
-          {/* Bonus Reset Credits Section */}
-          {availableResetCredits.length > 0 && (
-            <div className="bonus-panel">
-              <div className="bonus-header">
-                <div className="bonus-title-row">
-                  <span className="bonus-title">Bonus resets</span>
-                  <span className="bonus-badge">Gifted</span>
-                </div>
-                <span className="bonus-count">{availableResetCredits.length} available</span>
-              </div>
-              <div className="bonus-grants">
-                {bonusGrantGroups.map((group) => {
-                  const daysLeft = getDaysLeft(group.expiresAt);
-                  return (
-                  <div className="bonus-grant-row" key={group.key}>
-                    <span className="bonus-grant-left">
-                      <span className="bonus-dot" />
-                      <span className="bonus-grant-label">
-                        +{group.count} · granted {formatGrantDate(group.grantedAt)}
-                      </span>
-                    </span>
-                    <span className={`bonus-grant-right ${daysLeft != null && daysLeft <= 10 ? 'warning' : ''}`}>
-                      {daysLeft == null ? 'Expires unknown' : `${daysLeft}d left · ${formatGrantDate(group.expiresAt)}`}
-                    </span>
-                  </div>
-                  );
-                })}
-              </div>
-              <div className="bonus-note">Gifted occasionally · no cap · each grant valid 30 days</div>
-            </div>
+          {extrasPausedCopy && (
+            <p className="codex-local-extras">{extrasPausedCopy}</p>
           )}
+
+          {sections.tips && (
+            <SmartTip message={weeklyExhausted ? exhaustedTip : getHighUsageTip(windows)} />
+          )}
+
+          {!weeklyExhausted && renderBonusPanel()}
 
           {sections.timeline && <ResetTimeline windows={windows} />}
 

--- a/src/redesign/panels.css
+++ b/src/redesign/panels.css
@@ -538,6 +538,31 @@
   -webkit-backdrop-filter: blur(16px) saturate(1.5);
 }
 
+.bonus-panel-action {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: inherit;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.codex-updated,
+.codex-local-extras {
+  margin: 4px 2px 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.codex-updated {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .bonus-header,
 .bonus-title-row,
 .bonus-grant-row {

--- a/src/services/codex_weekly_display.ts
+++ b/src/services/codex_weekly_display.ts
@@ -1,0 +1,128 @@
+import type { CodexRateLimitWindow, CodexWeeklyQuota, CodexWeeklyValueEstimate } from '../types/models';
+
+export type DisplayCheck =
+  | { ok: true }
+  | { ok: false; kind: 'hard' | 'soft'; message: string };
+
+export function isSoftDisplayCheck(
+  check: DisplayCheck | null,
+): check is { ok: false; kind: 'soft'; message: string } {
+  return check != null && !check.ok && check.kind === 'soft';
+}
+
+export function isHardDisplayCheck(
+  check: DisplayCheck | null,
+): check is { ok: false; kind: 'hard'; message: string } {
+  return check != null && !check.ok && check.kind === 'hard';
+}
+
+export function checkWeeklyValueEstimate(
+  estimate: CodexWeeklyValueEstimate,
+  official: CodexRateLimitWindow,
+): DisplayCheck {
+  if (
+    !Number.isFinite(estimate.observedCostUsd)
+    || estimate.observedCostUsd <= 0
+    || !Number.isFinite(estimate.estimatedWeeklyValueUsd)
+    || estimate.estimatedWeeklyValueUsd <= 0
+    || !Number.isFinite(estimate.observedTokens)
+    || estimate.observedTokens <= 0
+    || !Number.isFinite(estimate.estimatedWeeklyTokens)
+    || estimate.estimatedWeeklyTokens <= 0
+  ) {
+    return { ok: false, kind: 'hard', message: 'The local weekly value estimate contains invalid totals.' };
+  }
+  if (Math.abs(estimate.usedPct - official.usedPercent) > 5) {
+    return { ok: false, kind: 'hard', message: 'The local weekly value estimate does not match the quota usage.' };
+  }
+  const estimateObservedAt = Date.parse(estimate.observedAt);
+  const now = Date.now();
+  if (!Number.isFinite(estimateObservedAt)) {
+    return {
+      ok: false,
+      kind: 'hard',
+      message: 'The local weekly value estimate is stale or has an invalid observation time.',
+    };
+  }
+  if (estimateObservedAt > now + 5 * 60 * 1000) {
+    return {
+      ok: false,
+      kind: 'hard',
+      message: 'The local weekly value estimate is stale or has an invalid observation time.',
+    };
+  }
+  const estimateReset = Date.parse(estimate.resetsAt);
+  const officialReset = (official.resetsAt ?? 0) * 1000;
+  if (
+    !Number.isFinite(estimateReset)
+    || officialReset <= 0
+    || Math.abs(estimateReset - officialReset) > 5 * 60 * 1000
+  ) {
+    return { ok: false, kind: 'hard', message: 'The local weekly value estimate does not match the quota reset.' };
+  }
+  if (now - estimateObservedAt > 10 * 60 * 1000) {
+    return {
+      ok: false,
+      kind: 'soft',
+      message: 'The local weekly value estimate is stale or has an invalid observation time.',
+    };
+  }
+  return { ok: true };
+}
+
+export function checkWeeklyQuotaWindow(
+  quota: CodexWeeklyQuota,
+  official?: CodexRateLimitWindow,
+): DisplayCheck {
+  if (!official) {
+    return { ok: false, kind: 'hard', message: 'The official weekly quota window is unavailable.' };
+  }
+  if (!Number.isFinite(official.windowMinutes) || (official.windowMinutes ?? 0) <= 0) {
+    return { ok: false, kind: 'hard', message: 'The official weekly window length is unavailable.' };
+  }
+  if (official.windowMinutes !== quota.windowMinutes) {
+    return { ok: false, kind: 'hard', message: 'The local pace snapshot does not match the official weekly window.' };
+  }
+  const officialReset = official.resetsAt;
+  if (!Number.isFinite(officialReset) || (officialReset ?? 0) <= 0) {
+    return { ok: false, kind: 'hard', message: 'The official weekly reset time is unavailable.' };
+  }
+  const localReset = Date.parse(quota.resetsAt) / 1000;
+  if (!Number.isFinite(localReset) || localReset <= 0) {
+    return { ok: false, kind: 'hard', message: 'The local pace snapshot has an invalid reset time.' };
+  }
+  if (Math.abs(localReset - (officialReset ?? 0)) > 5 * 60) {
+    return { ok: false, kind: 'hard', message: 'The local pace snapshot does not match the current official reset.' };
+  }
+  const observedAt = Date.parse(quota.observedAt);
+  const now = Date.now();
+  if (!Number.isFinite(observedAt)) {
+    return { ok: false, kind: 'hard', message: 'The local pace snapshot has an invalid observation time.' };
+  }
+  if (observedAt > now + 5 * 60 * 1000) {
+    return { ok: false, kind: 'hard', message: 'The local pace snapshot is dated in the future.' };
+  }
+  if (now - observedAt > 30 * 60 * 1000) {
+    return { ok: false, kind: 'soft', message: 'The local pace snapshot is older than 30 minutes.' };
+  }
+  if (Math.abs(quota.usedPct - official.usedPercent) > 1) {
+    return { ok: false, kind: 'hard', message: 'The local pace usage does not match the current official usage.' };
+  }
+  return { ok: true };
+}
+
+export function formatLocalExtrasPaused(observedAtMs: number, now = Date.now()): string {
+  const minutes = Math.max(1, Math.round((now - observedAtMs) / 60_000));
+  return `Local extras paused · Codex CLI has not refreshed in ${minutes}m`;
+}
+
+export function formatOfficialUpdatedAt(updatedAtMs: number, now = Date.now()): string {
+  const elapsed = now - updatedAtMs;
+  if (elapsed < 15_000) return 'Updated just now';
+  const minutes = Math.max(1, Math.round(elapsed / 60_000));
+  return `Updated ${minutes}m ago`;
+}
+
+export function isWeeklyExhausted(usedPercent?: number): boolean {
+  return typeof usedPercent === 'number' && Number.isFinite(usedPercent) && usedPercent >= 100;
+}

--- a/src/services/detail_helpers.ts
+++ b/src/services/detail_helpers.ts
@@ -1,6 +1,17 @@
 import type { CodexResetCredit, CodexResetCredits } from '../types/models';
 import type { QuotaWindowSummary } from './provider_summary';
 
+export function getExhaustedWeekTip(
+  resetLabel: string,
+  bonusCount: number,
+): string {
+  if (bonusCount > 0) {
+    const noun = bonusCount === 1 ? 'bonus reset' : 'bonus resets';
+    return `Weekly is used up. Wait until ${resetLabel}, or use ${bonusCount} ${noun}.`;
+  }
+  return `Weekly is used up. Resets ${resetLabel}.`;
+}
+
 export function getHighUsageTip(
   windows: QuotaWindowSummary[],
   threshold = 80,

--- a/tests/codex_exhausted_panel.test.tsx
+++ b/tests/codex_exhausted_panel.test.tsx
@@ -1,0 +1,152 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import CodexPanel from '../src/components/CodexPanel';
+import { backend } from '../src/services/backend';
+
+function rendered_text(renderer: ReactTestRenderer): string {
+  return JSON.stringify(renderer.toJSON());
+}
+
+async function unmount(renderer: ReactTestRenderer): Promise<void> {
+  await act(async () => renderer.unmount());
+}
+
+const WEEKLY_RESET = 1_787_961_600;
+
+async function render_exhausted(options?: {
+  usedPercent?: number;
+  bonusCount?: number;
+  valueObservedAt?: string;
+  valueResetsAt?: string;
+  onOpenDashboard?: () => void;
+}): Promise<ReactTestRenderer> {
+  const usedPercent = options?.usedPercent ?? 100;
+  const bonusCount = options?.bonusCount ?? 1;
+  const observedAt = options?.valueObservedAt ?? new Date(Date.now() - 31 * 60 * 1000).toISOString();
+  vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true, planType: 'plus' });
+  vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({
+    connected: true,
+    planType: 'plus',
+    primary: {
+      usedPercent,
+      windowMinutes: 10_080,
+      resetsAt: WEEKLY_RESET,
+    },
+  });
+  vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({
+    connected: true,
+    availableCount: bonusCount,
+    credits: Array.from({ length: bonusCount }, () => ({
+      status: 'available',
+      title: 'Gifted',
+      grantedAt: '2026-09-06T00:00:00Z',
+      expiresAt: '2026-10-06T00:00:00Z',
+    })),
+  });
+  vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({
+    quota: {
+      observedAt,
+      resetsAt: '2026-08-29T00:00:00Z',
+      windowMinutes: 10_080,
+      usedPct: usedPercent,
+      remainingPct: Math.max(0, 100 - usedPercent),
+      projectedPctAtReset: usedPercent,
+      status: usedPercent >= 100 ? 'exhausted' : 'on_track',
+    },
+    valueEstimate: {
+      observedAt,
+      windowStartedAt: '2026-08-22T00:00:00Z',
+      resetsAt: options?.valueResetsAt ?? '2026-08-29T00:00:00Z',
+      usedPct: usedPercent,
+      observedCostUsd: 186,
+      estimatedWeeklyValueUsd: 186,
+      observedTokens: 4_200_000,
+      estimatedWeeklyTokens: 4_200_000,
+    },
+  });
+
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(createElement(CodexPanel, {
+      autoRefreshIntervalMs: 0,
+      showCostSummary: false,
+      onOpenDashboard: options?.onOpenDashboard,
+    }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return renderer;
+}
+
+describe('Codex exhausted panel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps official 100%, last estimate, and a clickable bonus card', async () => {
+    const onOpenDashboard = vi.fn();
+    const renderer = await render_exhausted({ onOpenDashboard });
+    const text = rendered_text(renderer);
+
+    expect(text).toContain('100%');
+    expect(text).toContain('Weekly exhausted');
+    expect(text).toContain('API-equivalent week');
+    expect(text).toContain('Last estimate');
+    expect(text).toContain('$186.00');
+    expect(text).not.toContain('Weekly value unavailable');
+    expect(text).not.toContain('Local pace unavailable');
+    expect(text).toContain('Local extras paused');
+    expect(text).toContain('Weekly is used up.');
+    expect(text).toContain('or use 1 bonus reset');
+    expect(text).not.toContain('Codex Weekly is at 100%.');
+    expect(text).toContain('Opens ChatGPT. QuotaBar cannot apply this reset.');
+    expect(text).toContain('Updated just now');
+    expect(text).toContain('Quota current');
+
+    const button = renderer.root.findByProps({ className: 'bonus-panel bonus-panel-action' });
+    await act(async () => {
+      button.props.onClick();
+    });
+    expect(onOpenDashboard).toHaveBeenCalledTimes(1);
+    await unmount(renderer);
+  });
+
+  it('hides the bonus card and uses the wait tip when no credit is available', async () => {
+    const renderer = await render_exhausted({ bonusCount: 0 });
+    const text = rendered_text(renderer);
+
+    expect(text).toContain('Weekly is used up. Resets');
+    expect(text).not.toContain('bonus reset');
+    expect(text).not.toContain('Bonus resets');
+    await unmount(renderer);
+  });
+
+  it('hides a prior-week estimate when the official reset no longer matches', async () => {
+    const renderer = await render_exhausted({
+      valueResetsAt: '2026-09-05T00:00:00Z',
+    });
+    const text = rendered_text(renderer);
+
+    expect(text).toContain('100%');
+    expect(text).not.toContain('API-equivalent week');
+    expect(text).not.toContain('$186.00');
+    await unmount(renderer);
+  });
+
+  it('keeps the fresh estimate card when the week is not exhausted', async () => {
+    const renderer = await render_exhausted({
+      usedPercent: 40,
+      bonusCount: 0,
+      valueObservedAt: new Date().toISOString(),
+    });
+    const text = rendered_text(renderer);
+
+    expect(text).toContain('Connected');
+    expect(text).not.toContain('Weekly exhausted');
+    expect(text).toContain('Local estimate');
+    expect(text).not.toContain('Last estimate');
+    expect(text).not.toContain('Weekly is used up.');
+    await unmount(renderer);
+  });
+});

--- a/tests/detail_helpers.test.ts
+++ b/tests/detail_helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { getAvailableResetCredits, getHighUsageTip } from '../src/services/detail_helpers';
+import { getAvailableResetCredits, getExhaustedWeekTip, getHighUsageTip } from '../src/services/detail_helpers';
 
 describe('detail helpers', () => {
   test('hides smart tips when usage is missing or below threshold', () => {
@@ -10,6 +10,24 @@ describe('detail helpers', () => {
       label: 'Weekly limit',
       usedPercent: 79,
     }])).toBeNull();
+  });
+
+  test('uses Claude 80% copy when it is the only high window', () => {
+    expect(getHighUsageTip([{
+      provider: 'claude',
+      providerLabel: 'Claude',
+      label: 'Session',
+      usedPercent: 80,
+    }])).toBe('Claude Session is at 80%.');
+  });
+
+  test('builds exhausted-week decision copy', () => {
+    expect(getExhaustedWeekTip('Mon, Sep 7, 10:27 AM', 1)).toBe(
+      'Weekly is used up. Wait until Mon, Sep 7, 10:27 AM, or use 1 bonus reset.',
+    );
+    expect(getExhaustedWeekTip('Mon, Sep 7, 10:27 AM', 0)).toBe(
+      'Weekly is used up. Resets Mon, Sep 7, 10:27 AM.',
+    );
   });
 
   test('uses the highest real usage window for smart tips', () => {

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -436,15 +436,11 @@ describe('Codex weekly pace', () => {
   });
 
   it.each([
-    ['invalid totals', { estimatedWeeklyValueUsd: 0 }, 'contains invalid totals'],
-    ['usage mismatch', { usedPct: 55 }, 'does not match the quota usage'],
-    ['reset mismatch', { resetsAt: '2026-09-05T00:00:00Z' }, 'does not match the quota reset'],
-    [
-      'stale observation',
-      { observedAt: new Date(Date.now() - 11 * 60 * 1000).toISOString() },
-      'is stale or has an invalid observation time',
-    ],
-  ])('rejects a weekly value estimate with %s', async (_case, override, expected_error) => {
+    ['invalid totals', { estimatedWeeklyValueUsd: 0 }],
+    ['usage mismatch', { usedPct: 55 }],
+    ['reset mismatch', { resetsAt: '2026-09-05T00:00:00Z' }],
+    ['future observation', { observedAt: new Date(Date.now() + 11 * 60 * 1000).toISOString() }],
+  ])('hides a weekly value estimate with %s', async (_case, override) => {
     const renderer = await render_codex({
       quota: {
         observedAt: new Date().toISOString(),
@@ -468,8 +464,40 @@ describe('Codex weekly pace', () => {
       },
     });
 
-    expect(rendered_text(renderer)).toContain(expected_error);
     expect(rendered_text(renderer)).not.toContain('API-equivalent week');
+    expect(rendered_text(renderer)).not.toContain('Last estimate');
+    expect(rendered_text(renderer)).not.toContain('Weekly value unavailable');
+    await unmount(renderer);
+  });
+
+  it('keeps a same-window weekly value estimate when only the observation is stale', async () => {
+    const renderer = await render_codex({
+      quota: {
+        observedAt: new Date().toISOString(),
+        resetsAt: '2026-08-29T00:00:00Z',
+        windowMinutes: 10_080,
+        usedPct: 40,
+        remainingPct: 60,
+        projectedPctAtReset: 90,
+        status: 'on_track',
+      },
+      valueEstimate: {
+        observedAt: new Date(Date.now() - 11 * 60 * 1000).toISOString(),
+        windowStartedAt: '2026-08-22T00:00:00Z',
+        resetsAt: '2026-08-29T00:00:00Z',
+        usedPct: 40,
+        observedCostUsd: 80,
+        estimatedWeeklyValueUsd: 200,
+        observedTokens: 1_600_000,
+        estimatedWeeklyTokens: 4_000_000,
+      },
+    });
+
+    expect(rendered_text(renderer)).toContain('API-equivalent week');
+    expect(rendered_text(renderer)).toContain('Last estimate');
+    expect(rendered_text(renderer)).toContain('$200.00');
+    expect(rendered_text(renderer)).not.toContain('Weekly value unavailable');
+    expect(rendered_text(renderer)).toContain('Local extras paused');
     await unmount(renderer);
   });
 
@@ -604,7 +632,8 @@ describe('Codex weekly pace', () => {
       },
     });
 
-    expect(rendered_text(renderer)).toContain('older than 30 minutes');
+    expect(rendered_text(renderer)).toContain('Local extras paused');
+    expect(rendered_text(renderer)).not.toContain('older than 30 minutes');
     expect(rendered_text(renderer)).not.toContain('projected');
     await unmount(renderer);
   });


### PR DESCRIPTION
## Summary
- When official weekly used% is 100, switch Codex to an exhausted layout: header `Weekly exhausted`, bonus CTA above the value card, and a tip that points at reset time or leftover bonus resets.
- Same-window weekly value stays visible as `Last estimate` if only `observedAt` is stale. Hard mismatches still hide the card; validation strings are not rendered as orange errors.
- Stale local extras collapse to `Local extras paused · Codex CLI has not refreshed in {n}m`. Official last-updated stays on the value card. Dashboard still opens `https://chatgpt.com`; QuotaBar does not redeem resets.

Stacked on #97. Closes #93

Analysis: `docs/product/codex-exhausted-and-settings-analysis.md`

## Test plan
- [ ] Official week at 100% with a leftover bonus: header, bonus button above the value card, exhausted tip, no `Weekly value unavailable`.
- [ ] Click bonus CTA: ChatGPT opens; copy says QuotaBar cannot apply the reset.
- [ ] Same-window value older than 10 minutes still shows numbers + `Last estimate`.
- [ ] Hard fail (used% drift, reset mismatch, future/NaN): value card hidden, no validation sentence.
- [ ] Pace projection stays hidden when exhausted.
- [ ] After a successful official limits fetch: `Updated just now` / `Updated {n}m ago`; extras-paused also shows `Quota current`.
- [ ] Confirm `open_codex_dashboard` URL is unchanged.


Made with [Cursor](https://cursor.com)