### PR TITLE
feat(settings): add provider presets and split alert groups

### DIFF
--- a/specs/GH95/product.md
+++ b/specs/GH95/product.md
@@ -1,0 +1,62 @@
+# GH-95 Product Spec：设置控制面（预设与分组）
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/95
+- `complexity: medium`
+- Analysis: `docs/product/codex-exhausted-and-settings-analysis.md`
+- Depends: #94 合入后再改 Notifications 分组，以免和五行 key 冲突。不依赖 #93 的面板层级。
+
+## Problem
+
+设置回答「看起来怎样」，不回答「我只用 Codex」。Panel / Menu 矩阵正确但难懂。预算和通知挤在一组。Recent events 不能点回对应 provider。Launch at Login 缺失，但本仓库还没有 autostart 插件。
+
+## Goals
+
+- 在现有矩阵之上提供一键预设：All / 单个已支持服务。
+- 把 Budgets 与 Notifications 分成两个 settings group。
+- Recent events 可点回匹配的 provider 面板。
+- 保持「至少一 panel、至少一 tray」的既有 guard（GH-61）。
+
+## Non-Goals
+
+- 不做独立 Settings 窗口。
+- 不开放刷新间隔 / Adaptive / freshness 滑条。
+- 不做 provider source-mode、cookies、OAuth picker。
+- **本 issue 不做 Launch at Login。** 需要 `tauri-plugin-autostart` 与开机权限，另开 follow-up，避免本 PR 引入新 native dependency。
+- 不改通知 key 语义（那是 #94）。
+- 不改 tray guard 文案或 switcher guard 文案。
+
+## Behavior Invariants
+
+1. `B-001` Providers 组顶部增加预设：`All`，以及 `Claude` / `Codex` / `Cursor` / `Grok` / `Antigravity` 各一。点 `All`：五个 Panel 全开；tray 保持用户当前 tray 开关（不强制全开）。点单一服务：该服务 Panel 开、其它 Panel 关；该服务 Menu/tray 开；其它 tray 保持不变，除非会违反「至少一个 tray」——不得把最后一个 tray 关掉。
+2. `B-002` 预设走与手动开关同一套 persistence / guard。关到只剩一个 panel 时，矩阵里最后一个 panel 开关仍 disabled（现有 `panelLocked`）。预设不会产生非法「零 panel」状态。
+3. `B-003` Settings 出现两个 group：`Limits`（月预算，现有输入）与 `Alerts`（`NOTIFICATION_ROWS`，含 #94 的行）。编号顺延，不删 Appearance / Providers / Panel content / Activity。
+4. `B-004` Recent events 里文本能解析出 provider label（`Claude` / `Codex` / `Cursor` / `Grok` / `Antigravity`）的行是按钮；点击关闭 Settings 并切到该 provider tab。解析不到的行保持只读。
+5. `B-005` Hide Dock、theme、tray style、cycle、panel sections 行为不变。
+6. `B-006` 不新增 Tauri plugin、不改 storage key 名字（仍可用 `claude-quota-*`）。预设不单独持久化；只是写现有 switcher / tray bits。
+
+## Acceptance Criteria
+
+- 点 Codex only：switcher 仅 Codex true；Codex tray true；其它 panel false；其它 tray 若原先是唯一开启的非 Codex tray，不得被关到零 tray（保留至少一个 tray，优先保留 Codex）。
+- 点 All：五 panel true；tray 集合与点击前相比，Codex-only 用户再点 All 只恢复 panel，不擅自打开用户关过的 tray。
+- StrictMode 下预设 persistence 次数与 GH-61 一样：每次 accepted 预设各相关 save exactly once per store，不在 updater 里 save。
+- Budgets 与 Notifications 不在同一个 `settings-group` DOM 里。
+- `Codex usage crossed 95%` 事件可点，回到 Codex 面板且 Settings 关闭。
+- `Failed to persist local setting.` 这类无 provider 的事件不可点。
+
+## Boundary Checklist
+
+| 边界 | 结论 |
+| --- | --- |
+| Codex only | 一 panel；Codex tray on；零 panel 不可能 |
+| All | 五 panel；不强制打开已关 tray |
+| 只剩一个 tray 且不是目标服务 | 不得关到零 tray；目标 tray 打开 |
+| GH-61 only-visible panel disable | 仍 blocked + toast |
+| event 带 Codex | 切 Codex，关 Settings |
+| event 无 label | 只读 |
+| Launch at Login | 本 issue 不出现该行 |
+
+## Open Questions
+
+- Launch at Login 的 follow-up issue 在本 PR 合入后另开，不阻塞 #95。

--- a/specs/GH95/tasks.md
+++ b/specs/GH95/tasks.md
@@ -1,0 +1,24 @@
+# GH-95 Tasks：settings control surface
+
+## Delivery Contract
+
+- Base: 已含 #94 的 `main`（或 stacked on #94）。不要叠 #93 的 Codex 布局 diff。
+- Commit policy: `per_step`。
+- Scope: 预设、Limits/Alerts 拆组、event 导航。
+- Compatibility: GH-61 guard、通知 key、无新 native plugin。
+
+## Implementation Tasks
+
+- [x] `SP95-T1` Owner: impl. Dependencies: this spec + #94 merged. Covers: `B-001`, `B-002`, `B-006`. Done when: preset 纯函数 + App handler 一次 persist；零 panel / 零 tray 不可能。 Verify: `tests/provider_presets.test.ts`。
+- [x] `SP95-T2` Owner: impl. Dependencies: T1. Covers: `B-003`, `B-005`. Done when: Limits 与 Alerts 分 group；其它组行为不变。 Verify: settings render test。
+- [x] `SP95-T3` Owner: impl. Dependencies: T1. Covers: `B-004`. Done when: 带 provider label 的 event 回到对应 tab 并关闭 Settings；无 label 只读。 Verify: settings events navigation test。
+- [x] `SP95-T4` Owner: impl. Dependencies: T1-T3. Covers: `B-001`~`B-006`. Done when: 无 `src-tauri` diff；GH-61 测试仍绿；`npx tsc --noEmit && npm test && npm run build`。 Verify: tech Test Plan。
+
+## Handoff
+
+- [x] `SP95-T5` Owner: impl. Dependencies: T4. Done when: implementation PR `Closes #95`。Launch at Login follow-up 已开：https://github.com/majiayu000/quotabar/issues/96。
+
+## Handoff Notes
+
+- Invariants: `{B-001 … B-006}`。
+- 禁止 autostart 插件、禁止刷新滑条、禁止改通知语义。

--- a/specs/GH95/tech.md
+++ b/specs/GH95/tech.md
@@ -1,0 +1,89 @@
+# GH-95 Tech Spec：presets 与 settings 分组
+
+## Linked Issue
+
+- Issue: https://github.com/majiayu000/quotabar/issues/95
+- Product spec: `specs/GH95/product.md`
+
+## Current Mechanism
+
+`SettingsView` 五组。Providers 是 Panel/Menu 矩阵，`handleSwitcherToggle` / `handleTrayToggle` 已按 GH-61 用 render snapshot 决策，禁止在 functional updater 里 persist。
+
+Notifications 与 budgets 同在 group 04。Events 是只读 6 行。无 autostart 依赖。
+
+## Proposed Design
+
+### 1. Presets
+
+在 `App` 增加 `applyProviderPreset(preset: 'all' | TrayServiceName)`：
+
+- `all`：`nextSwitcher =` 所有 service true；`saveSwitcherVisibility` once；不改 tray map。
+- service：`nextSwitcher` 仅该 service true；若该服务 tray 未开则打开并 `saveTrayEnabled`；其它 tray 不关，除非当前 enabled tray 集合在「不打开目标」时为空——此时必须打开目标 tray，其它可保持。
+
+决策与 persist 放在 handler 里，不放进 `setState(updater)`。测试用真实 Settings 回调或抽纯函数 `planProviderPreset(currentSwitcher, currentTrays, preset)`，**推荐抽纯函数** 以便单测非法态，但仍由 App handler 调 save，避免复制 GH-61 的 side-effect 错误。
+
+Settings UI：矩阵上方一排 `settings-seg` 按钮，label `All` / 各 `SERVICE_META.shortLabel`。
+
+### 2. Group split
+
+`SettingsView` 把 group 04 拆成：
+
+- Limits：月预算 + 现有 hint
+- Alerts：`NOTIFICATION_ROWS`
+
+Activity 仍是 events + Dock。组标题 index 重排为 01–06。
+
+### 3. Clickable events
+
+`event.text` 用 `SERVICE_META[service].label` 做 prefix / includes 匹配，先匹配最长 label，避免将来短名冲突。命中则渲染 button，`onSelectProvider(service)`：`saveSettingsExpanded(false)` + `setAndPersistTab(service)`。
+
+### 4. Tests
+
+- `planProviderPreset` 或 real-App：All、Codex only、只剩 Cursor tray 时点 Codex only（Cursor tray 可留、Codex tray 开，零 tray 不可能）。
+- Settings DOM：两个 group heading `Limits` / `Alerts`。
+- event 行：Codex 文案可点；无 label 不可点。
+- GH-61 既有 switcher 测试继续绿。
+
+## Affected Files / Allowlist
+
+- `src/App.tsx`
+- `src/components/SettingsView.tsx`
+- `src/services/switcher_providers.ts` 或新建 `src/services/provider_presets.ts`（纯函数）
+- `src/redesign-settings.css` 仅当预设行需要既有 seg 样式的最小补充
+- `tests/provider_presets.test.ts`
+- `tests/settings_events_navigation.test.tsx` 或扩展现有 settings / switcher tests
+- `specs/GH95/tasks.md`
+
+禁止：`src-tauri/**`、新 Cargo 依赖、通知 key 改名、CodexPanel 布局。
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| 预设关光 tray | 纯函数断言 enabled tray ≥ 1 |
+| updater 里 save | 与 GH-61 相同：handler 内 snapshot + exact once |
+| 与 #94 五行冲突 | 本 PR 基于已含 #94 的 main，只搬 DOM 分组 |
+| All 打开用户关过的 tray | B-001：All 不改 tray |
+
+## Product-to-Test Mapping
+
+| Invariant | Verification |
+| --- | --- |
+| `B-001` `B-002` | preset matrix + tray cardinality |
+| `B-003` | two groups |
+| `B-004` | event click / non-click |
+| `B-005` `B-006` | 无新 key / 无 plugin |
+
+## Test Plan
+
+```bash
+set -euo pipefail
+npx tsc --noEmit
+npx vitest run tests/provider_presets.test.ts tests/switcher_visibility_transactions.test.tsx
+npm test
+npm run build
+```
+
+## Rollback Plan
+
+回滚 implementation PR。switcher / tray storage 格式不变。无 migration。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ import {
   subscribeStorageWriteFailures,
 } from './services/storage';
 import { bonusReadyEntered, formatBonusReadyMessage } from './services/bonus_ready';
+import { planProviderPreset, type ProviderPreset } from './services/provider_presets';
 import { useServiceEvents } from './hooks/use_service_events';
 import { usePopoverWindow } from './hooks/use_popover_window';
 import { useLatestRequestGeneration } from './hooks/use_latest_request_generation';
@@ -439,6 +440,24 @@ export default function App() {
     }
   }, [logEvent, notifSettings.bonusReady]);
 
+  const applyProviderPreset = useCallback((preset: ProviderPreset) => {
+    const plan = planProviderPreset(switcherVisibility, trayEnabled, preset);
+    setSwitcherVisibility(plan.switcher);
+    saveSwitcherVisibility(plan.switcher);
+    const trayChanged = SERVICES.some((service) => plan.trays[service] !== trayEnabled[service]);
+    if (!trayChanged) return;
+    setTrayEnabled(plan.trays);
+    for (const service of SERVICES) {
+      if (plan.trays[service] !== trayEnabled[service]) {
+        saveTrayEnabled(service, plan.trays[service]);
+      }
+    }
+  }, [switcherVisibility, trayEnabled]);
+
+  const handleSelectEventProvider = useCallback((service: TrayServiceName) => {
+    setAndPersistTab(service);
+  }, [setAndPersistTab]);
+
   const handleTrayStyleChange = useCallback((style: TrayStyle) => {
     saveTrayStyle(style);
     setTrayStyle(style);
@@ -700,6 +719,8 @@ export default function App() {
               onTrayCycleToggle={handleTrayCycleToggle}
               onNotificationToggle={handleNotificationToggle}
               onSwitcherToggle={handleSwitcherToggle}
+              onApplyPreset={applyProviderPreset}
+              onSelectEventProvider={handleSelectEventProvider}
             />
           </div>
         ) : (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,7 @@ import {
   subscribeStorageWriteFailures,
 } from './services/storage';
 import { bonusReadyEntered, formatBonusReadyMessage } from './services/bonus_ready';
-import { planProviderPreset, type ProviderPreset } from './services/provider_presets';
+import { planProviderPreset, planRevealProviderPanel, type ProviderPreset } from './services/provider_presets';
 import { useServiceEvents } from './hooks/use_service_events';
 import { usePopoverWindow } from './hooks/use_popover_window';
 import { useLatestRequestGeneration } from './hooks/use_latest_request_generation';
@@ -455,8 +455,13 @@ export default function App() {
   }, [switcherVisibility, trayEnabled]);
 
   const handleSelectEventProvider = useCallback((service: TrayServiceName) => {
+    const next = planRevealProviderPanel(switcherVisibility, service);
+    if (next !== switcherVisibility) {
+      setSwitcherVisibility(next);
+      saveSwitcherVisibility(next);
+    }
     setAndPersistTab(service);
-  }, [setAndPersistTab]);
+  }, [setAndPersistTab, switcherVisibility]);
 
   const handleTrayStyleChange = useCallback((style: TrayStyle) => {
     saveTrayStyle(style);

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -9,6 +9,7 @@ import {
   saveMonthlyBudgets,
   type MonthlyBudgets,
 } from '../services/budget';
+import { matchProviderInEventText, type ProviderPreset } from '../services/provider_presets';
 import { SERVICE_META, SERVICES } from '../services/service_meta';
 import type { SwitcherVisibility } from '../services/switcher_providers';
 import { TRAY_STYLE_OPTIONS, type TrayStyle } from '../services/tray_style';
@@ -46,6 +47,8 @@ interface SettingsViewProps {
   onTrayCycleToggle: () => void;
   onNotificationToggle: (key: NotificationKey) => void;
   onSwitcherToggle: (service: TrayServiceName) => void;
+  onApplyPreset: (preset: ProviderPreset) => void;
+  onSelectEventProvider: (service: TrayServiceName) => void;
 }
 
 export default function SettingsView({
@@ -68,6 +71,8 @@ export default function SettingsView({
   onTrayCycleToggle,
   onNotificationToggle,
   onSwitcherToggle,
+  onApplyPreset,
+  onSelectEventProvider,
 }: SettingsViewProps) {
   const [budgets, setBudgets] = useState<MonthlyBudgets>(getSavedMonthlyBudgets);
   const enabledSwitcherCount = SERVICES.filter((service) => switcherVisibility[service]).length;
@@ -149,6 +154,26 @@ export default function SettingsView({
             <h2 id="settings-providers-title">Providers</h2>
             <p>Choose where each service appears</p>
           </div>
+        </div>
+        <div className="settings-subsection-title">Presets</div>
+        <div className="settings-seg">
+          <button
+            type="button"
+            className="settings-seg-btn"
+            onClick={() => onApplyPreset('all')}
+          >
+            All
+          </button>
+          {SERVICES.map((service) => (
+            <button
+              key={service}
+              type="button"
+              className="settings-seg-btn"
+              onClick={() => onApplyPreset(service)}
+            >
+              {SERVICE_META[service].shortLabel}
+            </button>
+          ))}
         </div>
         <div className="provider-visibility-grid">
           <div className="provider-visibility-head" aria-hidden="true">
@@ -234,15 +259,14 @@ export default function SettingsView({
         ))}
       </section>
 
-      <section className="settings-group" aria-labelledby="settings-alerts-title">
+      <section className="settings-group" aria-labelledby="settings-limits-title">
         <div className="settings-group-header">
           <span className="settings-group-index">04</span>
           <div>
-            <h2 id="settings-alerts-title">Limits & alerts</h2>
-            <p>Budgets and usage notifications</p>
+            <h2 id="settings-limits-title">Limits</h2>
+            <p>Monthly API-equivalent budgets</p>
           </div>
         </div>
-        <div className="settings-subsection-title">Monthly budgets</div>
         {BUDGET_SOURCES.map((source) => (
           <label className="settings-line" key={source}>
             <span>{SERVICE_META[source].label}</span>
@@ -262,7 +286,16 @@ export default function SettingsView({
           </label>
         ))}
         <div className="settings-hint">Shown in the API-equivalent usage section.</div>
-        <div className="settings-subsection-title settings-subsection-divider">Notifications</div>
+      </section>
+
+      <section className="settings-group" aria-labelledby="settings-alerts-title">
+        <div className="settings-group-header">
+          <span className="settings-group-index">05</span>
+          <div>
+            <h2 id="settings-alerts-title">Alerts</h2>
+            <p>Usage and bonus notifications</p>
+          </div>
+        </div>
         {NOTIFICATION_ROWS.map(({ key, label }) => (
           <div className="settings-line" key={key}>
             <span>{label}</span>
@@ -282,7 +315,7 @@ export default function SettingsView({
 
       <section className="settings-group" aria-labelledby="settings-system-title">
         <div className="settings-group-header">
-          <span className="settings-group-index">05</span>
+          <span className="settings-group-index">06</span>
           <div>
             <h2 id="settings-system-title">Activity & system</h2>
             <p>Recent status changes and app behavior</p>
@@ -291,13 +324,26 @@ export default function SettingsView({
         <div className="settings-subsection-title">Recent events</div>
         {events.length > 0 ? (
           <div className="event-list">
-            {events.slice(0, 6).map((event) => (
+            {events.slice(0, 6).map((event) => {
+              const provider = matchProviderInEventText(event.text);
+              return (
               <div className="event-row" key={event.id}>
                 <span className={`event-dot ${event.level}`} />
-                <span className="event-text">{event.text}</span>
+                {provider ? (
+                  <button
+                    type="button"
+                    className="event-text event-text-link"
+                    onClick={() => onSelectEventProvider(provider)}
+                  >
+                    {event.text}
+                  </button>
+                ) : (
+                  <span className="event-text">{event.text}</span>
+                )}
                 <span className="event-time">{formatEventTime(event.time)}</span>
               </div>
-            ))}
+              );
+            })}
           </div>
         ) : (
           <div className="settings-hint">No events yet.</div>

--- a/src/redesign-settings.css
+++ b/src/redesign-settings.css
@@ -539,6 +539,16 @@
   background: #ff3b30;
 }
 
+.settings-group .event-text-link {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
 .settings-group .event-text {
   flex: 1;
   min-width: 0;

--- a/src/services/provider_presets.ts
+++ b/src/services/provider_presets.ts
@@ -27,12 +27,15 @@ export function planProviderPreset(
     return acc;
   }, {} as SwitcherVisibility);
 
-  const trays = { ...currentTrays, [preset]: true };
-  if (!SERVICES.some((service) => trays[service])) {
-    trays[preset] = true;
-  }
+  return { switcher, trays: { ...currentTrays, [preset]: true } };
+}
 
-  return { switcher, trays };
+export function planRevealProviderPanel(
+  current: SwitcherVisibility,
+  service: TrayServiceName,
+): SwitcherVisibility {
+  if (current[service]) return current;
+  return { ...current, [service]: true };
 }
 
 export function matchProviderInEventText(text: string): TrayServiceName | null {

--- a/src/services/provider_presets.ts
+++ b/src/services/provider_presets.ts
@@ -1,0 +1,49 @@
+import { SERVICE_META, SERVICES } from './service_meta';
+import type { SwitcherVisibility } from './switcher_providers';
+import type { TrayServiceName } from './tray_visibility';
+
+export type ProviderPreset = 'all' | TrayServiceName;
+
+export interface ProviderPresetPlan {
+  switcher: SwitcherVisibility;
+  trays: Record<TrayServiceName, boolean>;
+}
+
+export function planProviderPreset(
+  _currentSwitcher: SwitcherVisibility,
+  currentTrays: Record<TrayServiceName, boolean>,
+  preset: ProviderPreset,
+): ProviderPresetPlan {
+  if (preset === 'all') {
+    const switcher = SERVICES.reduce((acc, service) => {
+      acc[service] = true;
+      return acc;
+    }, {} as SwitcherVisibility);
+    return { switcher, trays: { ...currentTrays } };
+  }
+
+  const switcher = SERVICES.reduce((acc, service) => {
+    acc[service] = service === preset;
+    return acc;
+  }, {} as SwitcherVisibility);
+
+  const trays = { ...currentTrays, [preset]: true };
+  if (!SERVICES.some((service) => trays[service])) {
+    trays[preset] = true;
+  }
+
+  return { switcher, trays };
+}
+
+export function matchProviderInEventText(text: string): TrayServiceName | null {
+  let found: TrayServiceName | null = null;
+  let bestLength = 0;
+  for (const service of SERVICES) {
+    const label = SERVICE_META[service].label;
+    if (text.includes(label) && label.length > bestLength) {
+      found = service;
+      bestLength = label.length;
+    }
+  }
+  return found;
+}

--- a/tests/panel_shell_ui.test.tsx
+++ b/tests/panel_shell_ui.test.tsx
@@ -119,7 +119,13 @@ describe('panel shell UI', () => {
         trayStyle="percent"
         trayCycle={false}
         events={[]}
-        notificationSettings={{ q80: true, q95: true, q100: true, bonusReady: true, bonus: false }}
+        notificationSettings={{
+          q80: true,
+          q95: true,
+          q100: true,
+          bonusReady: true,
+          bonus: false,
+        }}
         switcherVisibility={{ claude: true, codex: true, cursor: true, grok: true, antigravity: true }}
         onClose={() => {}}
         onThemeChange={() => {}}
@@ -130,10 +136,14 @@ describe('panel shell UI', () => {
         onTrayCycleToggle={() => {}}
         onNotificationToggle={() => {}}
         onSwitcherToggle={() => {}}
+        onApplyPreset={() => {}}
+        onSelectEventProvider={() => {}}
       />,
     );
 
-    expect((html.match(/class="settings-group"/g) ?? [])).toHaveLength(5);
+    expect((html.match(/class="settings-group"/g) ?? [])).toHaveLength(6);
+    expect(html).toContain('>Limits<');
+    expect(html).toContain('>Alerts<');
     expect(html).toContain('Alert at 100% used');
     expect(html).toContain('Alert when a bonus reset is unused at 100%');
     expect(html).toContain('>Providers<');

--- a/tests/provider_presets.test.ts
+++ b/tests/provider_presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { matchProviderInEventText, planProviderPreset } from '../src/services/provider_presets';
+import { matchProviderInEventText, planProviderPreset, planRevealProviderPanel } from '../src/services/provider_presets';
 import { defaultSwitcherVisibility } from '../src/services/switcher_providers';
 import type { TrayServiceName } from '../src/services/tray_visibility';
 
@@ -46,9 +46,13 @@ describe('planProviderPreset', () => {
       grok: false,
       antigravity: false,
     });
-    expect(plan.trays.codex).toBe(true);
-    expect(plan.trays.claude).toBe(true);
-    expect(Object.values(plan.trays).some(Boolean)).toBe(true);
+    expect(plan.trays).toEqual({
+      claude: true,
+      codex: true,
+      cursor: true,
+      grok: true,
+      antigravity: false,
+    });
   });
 
   test('never produces zero trays when only another tray was enabled', () => {
@@ -63,6 +67,26 @@ describe('planProviderPreset', () => {
     expect(plan.trays.codex).toBe(true);
     expect(plan.trays.cursor).toBe(true);
     expect(Object.values(plan.trays).filter(Boolean).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('planRevealProviderPanel', () => {
+  test('turns a hidden panel on without hiding the others', () => {
+    const isolated = planProviderPreset(defaultSwitcherVisibility(), allTrays, 'codex').switcher;
+    const revealed = planRevealProviderPanel(isolated, 'claude');
+
+    expect(revealed).toEqual({
+      claude: true,
+      codex: true,
+      cursor: false,
+      grok: false,
+      antigravity: false,
+    });
+  });
+
+  test('returns the same map when the panel is already visible', () => {
+    const current = defaultSwitcherVisibility();
+    expect(planRevealProviderPanel(current, 'codex')).toBe(current);
   });
 });
 

--- a/tests/provider_presets.test.ts
+++ b/tests/provider_presets.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest';
+import { matchProviderInEventText, planProviderPreset } from '../src/services/provider_presets';
+import { defaultSwitcherVisibility } from '../src/services/switcher_providers';
+import type { TrayServiceName } from '../src/services/tray_visibility';
+
+const allTrays: Record<TrayServiceName, boolean> = {
+  claude: true,
+  codex: true,
+  cursor: true,
+  grok: true,
+  antigravity: false,
+};
+
+describe('planProviderPreset', () => {
+  test('All opens every panel and leaves trays unchanged', () => {
+    const currentSwitcher = {
+      ...defaultSwitcherVisibility(),
+      claude: false,
+      cursor: false,
+      grok: false,
+      antigravity: false,
+    };
+    const currentTrays = { ...allTrays, claude: false, cursor: false, grok: false };
+    const plan = planProviderPreset(currentSwitcher, currentTrays, 'all');
+
+    expect(plan.switcher).toEqual({
+      claude: true,
+      codex: true,
+      cursor: true,
+      grok: true,
+      antigravity: true,
+    });
+    expect(plan.trays).toEqual(currentTrays);
+  });
+
+  test('Codex only isolates the panel and turns the Codex tray on', () => {
+    const plan = planProviderPreset(defaultSwitcherVisibility(), {
+      ...allTrays,
+      codex: false,
+    }, 'codex');
+
+    expect(plan.switcher).toEqual({
+      claude: false,
+      codex: true,
+      cursor: false,
+      grok: false,
+      antigravity: false,
+    });
+    expect(plan.trays.codex).toBe(true);
+    expect(plan.trays.claude).toBe(true);
+    expect(Object.values(plan.trays).some(Boolean)).toBe(true);
+  });
+
+  test('never produces zero trays when only another tray was enabled', () => {
+    const plan = planProviderPreset(defaultSwitcherVisibility(), {
+      claude: false,
+      codex: false,
+      cursor: true,
+      grok: false,
+      antigravity: false,
+    }, 'codex');
+
+    expect(plan.trays.codex).toBe(true);
+    expect(plan.trays.cursor).toBe(true);
+    expect(Object.values(plan.trays).filter(Boolean).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('matchProviderInEventText', () => {
+  test('matches the provider label', () => {
+    expect(matchProviderInEventText('Codex usage crossed 95%')).toBe('codex');
+    expect(matchProviderInEventText('Claude connected')).toBe('claude');
+  });
+
+  test('leaves unlabeled events unmatched', () => {
+    expect(matchProviderInEventText('Failed to persist local setting.')).toBeNull();
+  });
+});

--- a/tests/settings_events_navigation.test.tsx
+++ b/tests/settings_events_navigation.test.tsx
@@ -1,0 +1,69 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import SettingsView from '../src/components/SettingsView';
+import type { TrayToggleEntry } from '../src/components/TrayToggles';
+
+const trayEntries: TrayToggleEntry[] = [
+  { service: 'claude', label: 'Claude Tray', enabled: true, canDisable: true, connected: true },
+  { service: 'codex', label: 'Codex Tray', enabled: true, canDisable: true, connected: true },
+  { service: 'cursor', label: 'Cursor Tray', enabled: true, canDisable: true, connected: false },
+  { service: 'grok', label: 'Grok Tray', enabled: true, canDisable: true, connected: false },
+  { service: 'antigravity', label: 'Antigravity Tray', enabled: false, canDisable: true, connected: false },
+];
+
+function settingsProps() {
+  return {
+    isMacOS: true,
+    theme: 'light' as const,
+    dockHidden: true,
+    trayEntries,
+    panelSections: { timeline: true, cost: true, trend: true, tips: true },
+    trayStyle: 'percent' as const,
+    trayCycle: false,
+    events: [
+      { id: '1', time: '2026-09-03T10:00:00Z', level: 'critical' as const, text: 'Codex usage crossed 95%' },
+      { id: '2', time: '2026-09-03T10:00:00Z', level: 'critical' as const, text: 'Failed to persist local setting.' },
+    ],
+    notificationSettings: {
+      q80: true,
+      q95: true,
+      q100: true,
+      bonusReady: true,
+      bonus: true,
+    },
+    switcherVisibility: {
+      claude: true,
+      codex: true,
+      cursor: true,
+      grok: true,
+      antigravity: true,
+    },
+    onClose: () => {},
+    onThemeChange: () => {},
+    onDockToggle: () => {},
+    onTrayToggle: () => {},
+    onPanelSectionToggle: () => {},
+    onTrayStyleChange: () => {},
+    onTrayCycleToggle: () => {},
+    onNotificationToggle: () => {},
+    onSwitcherToggle: () => {},
+    onApplyPreset: vi.fn(),
+    onSelectEventProvider: vi.fn(),
+  };
+}
+
+describe('settings event navigation', () => {
+  it('makes labeled events clickable and leaves unlabeled events read-only', () => {
+    const html = renderToStaticMarkup(createElement(SettingsView, settingsProps()));
+
+    expect(html).toContain('event-text event-text-link');
+    expect(html).toContain('Codex usage crossed 95%');
+    expect(html).toContain('Failed to persist local setting.');
+    expect((html.match(/event-text-link/g) ?? [])).toHaveLength(1);
+    expect(html).toContain('>Limits<');
+    expect(html).toContain('>Alerts<');
+    expect(html).toContain('>All<');
+    expect(html).toContain('>Codex<');
+  });
+});


### PR DESCRIPTION
## Summary
- Add All / per-service presets: All turns every panel on and leaves trays alone; a single service shows only that panel and turns that tray on without turning other trays off.
- Split Settings into Limits vs Alerts so the five lifecycle keys from #97 sit in their own group.
- Events that mention a provider label become buttons back to that tab.

Stacked on #97. Closes #95

Launch at Login stays deferred: #96

## Test plan
- [ ] All preset: every panel on; menu trays unchanged.
- [ ] Single-service preset: only that panel; that tray on; other trays untouched.
- [ ] Confirm a user cannot reach zero panels or zero trays.
- [ ] Settings shows Limits and Alerts as separate groups; five alert rows still match #97.
- [ ] Click an event that names Codex/Claude/etc.: Settings closes and that tab opens.
- [ ] Events without a provider label stay read-only.


Made with [Cursor](https://cursor.com)