### PR TITLE
fix(cursor): retain last-good usage on 5xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Keep last-good Cursor usage across 5xx and 429 responses instead of flashing disconnected.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/src-tauri/src/services/cursor.rs
+++ b/src-tauri/src/services/cursor.rs
@@ -230,6 +230,10 @@ fn is_transient_cursor_error(message: &str) -> bool {
         || lowercase.contains("database table is locked")
 }
 
+fn is_transient_cursor_status(status: reqwest::StatusCode) -> bool {
+    status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+}
+
 fn fallback_or_disconnected(error: impl Into<String>) -> CursorData {
     let error = error.into();
     if is_transient_cursor_error(&error) {
@@ -283,7 +287,11 @@ pub async fn fetch_cursor_info() -> CursorData {
         return CursorData::disconnected("Cursor session expired. Re-open Cursor and sign in.");
     }
     if !status.is_success() {
-        return CursorData::disconnected(format!("Cursor API error: {status}"));
+        let error = format!("Cursor API error: {status}");
+        if is_transient_cursor_status(status) {
+            return fallback_or_disconnected(error);
+        }
+        return CursorData::disconnected(error);
     }
 
     let data = match response.json::<serde_json::Value>().await {
@@ -657,6 +665,12 @@ mod tests {
             "Failed to read state.vscdb: database table is locked"
         ));
         assert!(!is_transient_cursor_error("Cursor session not found"));
+        assert!(is_transient_cursor_status(reqwest::StatusCode::BAD_GATEWAY));
+        assert!(is_transient_cursor_status(
+            reqwest::StatusCode::TOO_MANY_REQUESTS
+        ));
+        assert!(!is_transient_cursor_status(reqwest::StatusCode::FORBIDDEN));
+        assert!(!is_transient_cursor_status(reqwest::StatusCode::NOT_FOUND));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Treat Cursor 5xx and 429 as transient so the last good usage stays on screen. 401/403 still disconnect.

Fixes #102

## Verification

- [x] `cargo test sqlite_lock_errors`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)