### PR TITLE
fix(cursor): do not cache disconnected payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Stop caching disconnected Cursor payloads so a transient empty body cannot pin "not connected" for 120s.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/src-tauri/src/services/cursor.rs
+++ b/src-tauri/src/services/cursor.rs
@@ -240,7 +240,14 @@ fn fallback_or_disconnected(error: impl Into<String>) -> CursorData {
     CursorData::disconnected(error)
 }
 
+fn should_persist_cursor_cache(data: &CursorData) -> bool {
+    data.connected
+}
+
 fn save_cursor_cache(data: &CursorData) {
+    if !should_persist_cursor_cache(data) {
+        return;
+    }
     if let Ok(mut guard) = cursor_cache().lock() {
         *guard = Some(CachedCursor {
             data: data.clone(),
@@ -642,6 +649,22 @@ mod tests {
                 Some("Cursor API returned no usage fields.")
             );
         }
+    }
+
+    #[test]
+    fn disconnected_payloads_are_not_persisted() {
+        let empty = parse_cursor_payload(&serde_json::json!({}));
+        assert!(!empty.connected);
+        assert!(!should_persist_cursor_cache(&empty));
+
+        let connected = parse_cursor_payload(&serde_json::json!({
+            "membershipType": "pro",
+            "individualUsage": {
+                "plan": { "totalPercentUsed": 12.0 }
+            }
+        }));
+        assert!(connected.connected);
+        assert!(should_persist_cursor_cache(&connected));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Only persist Cursor quota cache when the payload is connected, so an empty or disconnected response cannot occupy the 120s cache.

Fixes #103

## Verification

- [x] `cargo test disconnected_payloads`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)