### PR TITLE
fix(tray): keep NSStatusItem alive while cycling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Collapse cycling macOS tray icons by status-item length instead of removing and recreating NSStatusItems.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,5 +38,5 @@ tauri-plugin-notification = "2.3.3"
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSStatusItem"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSStatusItem", "objc2-core-foundation"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString", "NSUserDefaults"] }

--- a/src-tauri/src/services/tray.rs
+++ b/src-tauri/src/services/tray.rs
@@ -306,6 +306,24 @@ fn apply_status_item_autosave(app: AppHandle, tray_id: &'static str) {
     });
 }
 
+fn destroy_hidden_tray() -> bool {
+    !cfg!(target_os = "macos")
+}
+
+#[cfg(target_os = "macos")]
+fn set_status_item_collapsed(app: &AppHandle, tray_id: &str, collapsed: bool) {
+    let Some(tray) = app.tray_by_id(tray_id) else {
+        return;
+    };
+    let _ = tray.with_inner_tray_icon(move |inner| {
+        if let Some(item) = inner.ns_status_item() {
+            // NSVariableStatusItemLength == -1. Length 0 hides without destroying
+            // the extras-region item (set_visible(false) removes it on macOS 26).
+            item.setLength(if collapsed { 0.0 } else { -1.0 });
+        }
+    });
+}
+
 fn format_tooltip(service: TrayService, percentage: Option<u8>) -> String {
     match percentage {
         Some(value) => format!("{}: {}% used", service.label(), value),
@@ -447,7 +465,12 @@ pub async fn update_tray_icon(
             }
 
             if !visible {
-                let _ = app_handle.remove_tray_by_id(service.tray_id());
+                if destroy_hidden_tray() {
+                    let _ = app_handle.remove_tray_by_id(service.tray_id());
+                } else {
+                    #[cfg(target_os = "macos")]
+                    set_status_item_collapsed(&app_handle, service.tray_id(), true);
+                }
                 {
                     let mut state = runtime
                         .lock()
@@ -462,6 +485,8 @@ pub async fn update_tray_icon(
             if app_handle.tray_by_id(service.tray_id()).is_none() {
                 build_service_tray(&app_handle, service).map_err(|e| e.to_string())?;
             }
+            #[cfg(target_os = "macos")]
+            set_status_item_collapsed(&app_handle, service.tray_id(), false);
 
             let Some(tray) = app_handle.tray_by_id(service.tray_id()) else {
                 return Err(format!("missing tray icon for {}", service.label()));
@@ -510,7 +535,7 @@ pub async fn update_tray_icon(
 
 #[cfg(test)]
 mod tests {
-    use super::{format_tooltip, TrayRuntimeState, TrayService, TraySnapshot};
+    use super::{destroy_hidden_tray, format_tooltip, TrayRuntimeState, TrayService, TraySnapshot};
     use crate::services::tray_icon::TrayIconStyle;
 
     #[test]
@@ -560,6 +585,11 @@ mod tests {
 
         assert!(state.should_skip_update(TrayService::Claude, snapshot, false));
         assert!(!state.should_skip_update(TrayService::Claude, snapshot, true));
+    }
+
+    #[test]
+    fn macos_keeps_hidden_status_items_alive() {
+        assert_eq!(destroy_hidden_tray(), !cfg!(target_os = "macos"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- On macOS, hide cycling tray extras by setting NSStatusItem length to 0 instead of destroying the item every 15s. Non-macOS still removes the tray.

Fixes #105

## Verification

- [x] `cargo test macos_keeps_hidden`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)