### PR TITLE
fix(deps): pin ccstats cost and quota to one rev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Pin Codex weekly quota and local cost summaries to one ccstats revision so pricing and dedup stay aligned.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -471,25 +471,6 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.5.0"
-source = "git+https://github.com/majiayu000/ccstats.git?rev=2c67efd32508bd7e0e7c5605c9ac4ba989632818#2c67efd32508bd7e0e7c5605c9ac4ba989632818"
-dependencies = [
- "chrono",
- "chrono-tz",
- "clap",
- "comfy-table",
- "dirs 6.0.0",
- "glob",
- "rayon",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "toml 1.0.1+spec-1.1.0",
- "ureq",
-]
-
-[[package]]
-name = "ccstats"
 version = "0.5.1"
 source = "git+https://github.com/majiayu000/ccstats.git?rev=6bec20d035a10efbc8914d36001c7621570d1066#6bec20d035a10efbc8914d36001c7621570d1066"
 dependencies = [
@@ -3404,8 +3385,7 @@ name = "quotabar"
 version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
- "ccstats 0.5.0",
- "ccstats 0.5.1",
+ "ccstats",
  "chrono",
  "dirs 5.0.1",
  "image",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,6 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 once_cell = "1.19"
 ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "6bec20d035a10efbc8914d36001c7621570d1066" }
-ccstats-quota = { package = "ccstats", git = "https://github.com/majiayu000/ccstats.git", rev = "2c67efd32508bd7e0e7c5605c9ac4ba989632818" }
 tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -45,18 +45,18 @@ pub async fn get_codex_weekly_quota() -> Result<CodexWeeklyQuotaData, String> {
         None
     };
     let data =
-        tauri::async_runtime::spawn_blocking(move || match ccstats_quota::load_codex_weekly_quota(
-            Some(&codex_home),
-        ) {
-            Ok(quota) => {
-                let value_estimate = codex_weekly::estimate_codex_weekly_value(
-                    &codex_home,
-                    &quota,
-                    official.as_ref(),
-                );
-                CodexWeeklyQuotaData::available(quota, value_estimate)
+        tauri::async_runtime::spawn_blocking(move || {
+            match ccstats::load_codex_weekly_quota(Some(&codex_home)) {
+                Ok(quota) => {
+                    let value_estimate = codex_weekly::estimate_codex_weekly_value(
+                        &codex_home,
+                        &quota,
+                        official.as_ref(),
+                    );
+                    CodexWeeklyQuotaData::available(quota, value_estimate)
+                }
+                Err(error) => CodexWeeklyQuotaData::unavailable(error.to_string()),
             }
-            Err(error) => CodexWeeklyQuotaData::unavailable(error.to_string()),
         })
         .await
         .map_err(|err| format!("Codex weekly quota task failed: {err}"))?;

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -199,8 +199,8 @@ pub struct CodexWeeklyQuotaData {
 
 impl CodexWeeklyQuotaData {
     pub fn available(
-        quota: ccstats_quota::CodexWeeklyQuota,
-        value_estimate: Result<ccstats_quota::CodexWeeklyValueEstimate, String>,
+        quota: ccstats::CodexWeeklyQuota,
+        value_estimate: Result<ccstats::CodexWeeklyValueEstimate, String>,
     ) -> Self {
         let (value_estimate, value_estimate_error) = match value_estimate {
             Ok(estimate) => (Some(CodexWeeklyValueEstimate::from(estimate)), None),
@@ -224,8 +224,8 @@ impl CodexWeeklyQuotaData {
     }
 }
 
-impl From<ccstats_quota::CodexWeeklyValueEstimate> for CodexWeeklyValueEstimate {
-    fn from(estimate: ccstats_quota::CodexWeeklyValueEstimate) -> Self {
+impl From<ccstats::CodexWeeklyValueEstimate> for CodexWeeklyValueEstimate {
+    fn from(estimate: ccstats::CodexWeeklyValueEstimate) -> Self {
         Self {
             observed_at: estimate.observed_at.to_rfc3339(),
             window_started_at: estimate.window_started_at.to_rfc3339(),
@@ -239,8 +239,8 @@ impl From<ccstats_quota::CodexWeeklyValueEstimate> for CodexWeeklyValueEstimate 
     }
 }
 
-impl From<ccstats_quota::CodexWeeklyQuota> for CodexWeeklyQuota {
-    fn from(quota: ccstats_quota::CodexWeeklyQuota) -> Self {
+impl From<ccstats::CodexWeeklyQuota> for CodexWeeklyQuota {
+    fn from(quota: ccstats::CodexWeeklyQuota) -> Self {
         Self {
             observed_at: quota.observed_at.to_rfc3339(),
             resets_at: quota.resets_at.to_rfc3339(),

--- a/src-tauri/src/services/codex_weekly.rs
+++ b/src-tauri/src/services/codex_weekly.rs
@@ -15,7 +15,7 @@ const OFFICIAL_USED_TOLERANCE_PCT: f64 = 1.0;
 const SUCCESS_CACHE_TTL: Duration = Duration::from_secs(300);
 const ERROR_CACHE_TTL: Duration = Duration::from_secs(60);
 
-type WeeklyValueResult = Result<ccstats_quota::CodexWeeklyValueEstimate, String>;
+type WeeklyValueResult = Result<ccstats::CodexWeeklyValueEstimate, String>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct WeeklyQuotaIdentity {
@@ -24,8 +24,8 @@ struct WeeklyQuotaIdentity {
     used_pct_bits: u64,
 }
 
-impl From<&ccstats_quota::CodexWeeklyQuota> for WeeklyQuotaIdentity {
-    fn from(quota: &ccstats_quota::CodexWeeklyQuota) -> Self {
+impl From<&ccstats::CodexWeeklyQuota> for WeeklyQuotaIdentity {
+    fn from(quota: &ccstats::CodexWeeklyQuota) -> Self {
         Self {
             observed_at: quota.observed_at,
             resets_at: quota.resets_at,
@@ -35,7 +35,7 @@ impl From<&ccstats_quota::CodexWeeklyQuota> for WeeklyQuotaIdentity {
 }
 
 impl WeeklyQuotaIdentity {
-    fn matches_estimate(&self, estimate: &ccstats_quota::CodexWeeklyValueEstimate) -> bool {
+    fn matches_estimate(&self, estimate: &ccstats::CodexWeeklyValueEstimate) -> bool {
         self.observed_at == estimate.observed_at
             && self.resets_at == estimate.resets_at
             && self.used_pct_bits == estimate.used_pct.to_bits()
@@ -105,7 +105,7 @@ pub(crate) fn official_weekly_window(limits: &CodexRateLimits) -> Option<&CodexR
 
 pub fn estimate_codex_weekly_value(
     codex_home: &Path,
-    quota: &ccstats_quota::CodexWeeklyQuota,
+    quota: &ccstats::CodexWeeklyQuota,
     official: Option<&OfficialWeeklySnapshot>,
 ) -> WeeklyValueResult {
     let quota_identity = WeeklyQuotaIdentity::from(quota);
@@ -158,7 +158,7 @@ fn should_fallback_to_official(error: &str) -> bool {
 }
 
 fn quota_matches_official(
-    quota: &ccstats_quota::CodexWeeklyQuota,
+    quota: &ccstats::CodexWeeklyQuota,
     official: &CodexRateLimitWindow,
 ) -> bool {
     weekly_windows_match(
@@ -190,7 +190,7 @@ fn estimate_from_local_snapshot(
     codex_home: &Path,
     quota_identity: &WeeklyQuotaIdentity,
 ) -> WeeklyValueResult {
-    ccstats_quota::estimate_codex_weekly_value(Some(codex_home), false, false)
+    ccstats::estimate_codex_weekly_value(Some(codex_home), false, false)
         .map_err(|error| error.to_string())
         .and_then(|estimate| {
             if quota_identity.matches_estimate(&estimate) {
@@ -221,8 +221,8 @@ fn estimate_from_official_window(
     if snapshot.observed_at >= resets {
         return Err("The official weekly quota window has expired.".to_string());
     }
-    ccstats_quota::estimate_codex_weekly_value_for_window(
-        &ccstats_quota::CodexWeeklyValueWindow {
+    ccstats::estimate_codex_weekly_value_for_window(
+        &ccstats::CodexWeeklyValueWindow {
             observed_at: snapshot.observed_at,
             resets_at: resets,
             window_minutes,
@@ -239,8 +239,8 @@ fn estimate_from_official_window(
 mod tests {
     use super::*;
 
-    fn estimate() -> ccstats_quota::CodexWeeklyValueEstimate {
-        ccstats_quota::CodexWeeklyValueEstimate {
+    fn estimate() -> ccstats::CodexWeeklyValueEstimate {
+        ccstats::CodexWeeklyValueEstimate {
             observed_at: chrono::DateTime::UNIX_EPOCH,
             window_started_at: chrono::DateTime::UNIX_EPOCH,
             resets_at: chrono::DateTime::UNIX_EPOCH + chrono::Duration::days(7),


### PR DESCRIPTION
## Summary

- Drop the second ccstats git pin. Cost summaries and Codex weekly quota now use `ccstats` @ `6bec20d`, which already exports the weekly quota SDK.

Fixes #107

## Verification

- [x] `cargo check`; `cargo test quota_identity`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)