### PR TITLE
fix(codex): stamp last-good info to auth.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Scope Codex last-good account info to the current `auth.json` stamp so a transient read cannot show the previous account.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -11,11 +11,16 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
+struct LastGoodInfo {
+    stamp: AuthFileStamp,
+    data: CodexData,
+}
+
 /// Most recent successful fetch results, retained without TTL so a transient
 /// polling failure does not erase quota that was already displayed.
-static LAST_GOOD_INFO: OnceLock<Mutex<Option<CodexData>>> = OnceLock::new();
+static LAST_GOOD_INFO: OnceLock<Mutex<Option<LastGoodInfo>>> = OnceLock::new();
 
-fn last_good_info() -> &'static Mutex<Option<CodexData>> {
+fn last_good_info() -> &'static Mutex<Option<LastGoodInfo>> {
     LAST_GOOD_INFO.get_or_init(|| Mutex::new(None))
 }
 
@@ -173,20 +178,40 @@ fn parse_rate_limit_window(window: &serde_json::Value) -> Option<CodexRateLimitW
     })
 }
 
-fn fallback_or_disconnected_info(error: String) -> CodexData {
-    if is_transient_os_error(&error) {
-        if let Ok(guard) = last_good_info().lock() {
-            if let Some(stale) = guard.as_ref() {
-                return stale.clone();
+fn retain_last_good_info(
+    cached: Option<&LastGoodInfo>,
+    stamp: Option<&AuthFileStamp>,
+    error: String,
+    transient: bool,
+) -> CodexData {
+    if transient {
+        if let (Some(stale), Some(current_stamp)) = (cached, stamp) {
+            if stale.stamp == *current_stamp {
+                let mut data = stale.data.clone();
+                data.error = Some(error);
+                return data;
             }
         }
     }
     CodexData::disconnected(error)
 }
 
+fn fallback_or_disconnected_info(error: StampedAuthReadError) -> CodexData {
+    let transient = is_transient_os_error(&error.message);
+    if let Ok(guard) = last_good_info().lock() {
+        return retain_last_good_info(
+            guard.as_ref(),
+            error.pre_read_stamp.as_ref(),
+            error.message,
+            transient,
+        );
+    }
+    CodexData::disconnected(error.message)
+}
+
 pub async fn fetch_codex_info() -> CodexData {
-    let auth_json = match read_auth_json() {
-        Ok(v) => v,
+    let (auth_json, auth_stamp) = match read_auth_json_with_stamp() {
+        Ok(auth) => auth,
         Err(error) => return fallback_or_disconnected_info(error),
     };
 
@@ -218,7 +243,10 @@ pub async fn fetch_codex_info() -> CodexData {
     };
 
     if let Ok(mut guard) = last_good_info().lock() {
-        *guard = Some(info.clone());
+        *guard = Some(LastGoodInfo {
+            stamp: auth_stamp,
+            data: info.clone(),
+        });
     }
     info
 }
@@ -520,10 +548,12 @@ pub async fn fetch_codex_reset_credits() -> CodexResetCredits {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_rate_limit_window, parse_reset_credit, should_preserve_for_status,
-        should_preserve_transport_failure,
+        parse_rate_limit_window, parse_reset_credit, retain_last_good_info,
+        should_preserve_for_status, should_preserve_transport_failure, AuthFileStamp, CodexData,
+        LastGoodInfo,
     };
     use serde_json::json;
+    use std::time::{Duration, SystemTime};
 
     #[test]
     fn only_rate_limiting_is_a_preservable_http_failure() {
@@ -613,5 +643,65 @@ mod tests {
 
         assert_eq!(high.used_percent, 100.0);
         assert_eq!(low.used_percent, 0.0);
+    }
+
+    fn auth_stamp(len: u64, secs: u64) -> AuthFileStamp {
+        AuthFileStamp {
+            len,
+            modified: SystemTime::UNIX_EPOCH + Duration::from_secs(secs),
+        }
+    }
+
+    fn connected_info(email: &str) -> CodexData {
+        CodexData {
+            connected: true,
+            plan_type: Some("plus".to_string()),
+            account_id: Some("acct-a".to_string()),
+            subscription_until: None,
+            email: Some(email.to_string()),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn last_good_codex_info_stays_on_the_same_auth_file() {
+        let cached = LastGoodInfo {
+            stamp: auth_stamp(128, 10),
+            data: connected_info("one@example.com"),
+        };
+        let retained = retain_last_good_info(
+            Some(&cached),
+            Some(&auth_stamp(128, 10)),
+            "Failed to read auth.json: Too many open files (os error 24)".to_string(),
+            true,
+        );
+        assert!(retained.connected);
+        assert_eq!(retained.email.as_deref(), Some("one@example.com"));
+        assert!(retained
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("Too many open files"));
+    }
+
+    #[test]
+    fn last_good_codex_info_is_dropped_after_account_file_changes() {
+        let cached = LastGoodInfo {
+            stamp: auth_stamp(128, 10),
+            data: connected_info("one@example.com"),
+        };
+        let switched = retain_last_good_info(
+            Some(&cached),
+            Some(&auth_stamp(256, 11)),
+            "Failed to read auth.json: Too many open files (os error 24)".to_string(),
+            true,
+        );
+        assert!(!switched.connected);
+        assert_eq!(switched.email, None);
+        assert!(switched
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("Too many open files"));
     }
 }


### PR DESCRIPTION
## Summary

- Keep Codex last-good account info only when the current `auth.json` stamp still matches, so a transient read after an account switch cannot show the previous account.

Fixes #109

## Verification

- [x] `cargo test last_good_codex_info`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)