### PR TITLE
fix: move tray recv and Claude keychain off tokio workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Move Claude keychain reads and tray main-thread waits off Tokio worker threads, and rotate the Claude log at 2MB.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/src-tauri/src/services/claude.rs
+++ b/src-tauri/src/services/claude.rs
@@ -2,6 +2,7 @@ use crate::domain::models::{QuotaData, UsageInfo};
 use crate::services::http::{is_transient_os_error, shared_http_client};
 use std::fs::OpenOptions;
 use std::io::Write as IoWrite;
+use std::path::Path;
 #[cfg(target_os = "macos")]
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -13,6 +14,7 @@ const QUOTA_CACHE_TTL: Duration = Duration::from_secs(120);
 const CLAUDE_TOKEN_ENV_KEY: &str = "CLAUDE_CODE_OAUTH_TOKEN";
 const CLAUDE_AUTH_RELOGIN_MESSAGE: &str =
     "Claude OAuth token expired or invalid. Please re-login to Claude Code, then click Refresh.";
+const MAX_LOG_BYTES: u64 = 2 * 1024 * 1024;
 
 const CREDENTIAL_NAMES: [&str; 4] = [
     "Claude Code-credentials",
@@ -35,6 +37,23 @@ fn last_request_time() -> &'static Mutex<Option<Instant>> {
     LAST_REQUEST_TIME.get_or_init(|| Mutex::new(None))
 }
 
+fn rotate_log_if_needed(path: &Path) {
+    rotate_log_if_needed_with_limit(path, MAX_LOG_BYTES);
+}
+
+fn rotate_log_if_needed_with_limit(path: &Path, max_bytes: u64) {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return;
+    };
+    if metadata.len() <= max_bytes {
+        return;
+    }
+    let rotated = path.with_extension("log.1");
+    if let Err(error) = std::fs::rename(path, &rotated) {
+        eprintln!("[log] failed to rotate log: {error}");
+    }
+}
+
 fn log_msg(msg: &str) {
     let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
     let line = format!("[{timestamp}] {msg}\n");
@@ -49,11 +68,10 @@ fn log_msg(msg: &str) {
         return;
     }
 
-    match OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_dir.join("claude.log"))
-    {
+    let log_path = log_dir.join("claude.log");
+    rotate_log_if_needed(&log_path);
+
+    match OpenOptions::new().create(true).append(true).open(&log_path) {
         Ok(mut file) => {
             if let Err(e) = file.write_all(line.as_bytes()) {
                 eprintln!("[log] failed to write log: {e}");
@@ -454,11 +472,15 @@ pub async fn fetch_quota() -> QuotaData {
         return cached;
     }
 
-    let access_token = match get_oauth_token(false) {
-        Ok(token) => token,
-        Err(error) => {
+    let access_token = match tauri::async_runtime::spawn_blocking(|| get_oauth_token(false)).await {
+        Ok(Ok(token)) => token,
+        Ok(Err(error)) => {
             log_msg(&format!("[Quota] get_oauth_token failed: {error}"));
             return fallback_or_disconnected(error);
+        }
+        Err(error) => {
+            log_msg(&format!("[Quota] oauth token task failed: {error}"));
+            return QuotaData::disconnected(format!("OAuth token task failed: {error}"));
         }
     };
 
@@ -488,13 +510,18 @@ pub async fn fetch_quota() -> QuotaData {
         log_msg(&format!(
             "[Quota] auth error ({status}), step 1: force re-read from keychain"
         ));
-        let fresh_access_token = match get_oauth_token(true) {
-            Ok(token) => token,
-            Err(error) => {
-                log_msg(&format!("[Quota] keychain re-read failed: {error}"));
-                return fallback_or_disconnected(error);
-            }
-        };
+        let fresh_access_token =
+            match tauri::async_runtime::spawn_blocking(|| get_oauth_token(true)).await {
+                Ok(Ok(token)) => token,
+                Ok(Err(error)) => {
+                    log_msg(&format!("[Quota] keychain re-read failed: {error}"));
+                    return fallback_or_disconnected(error);
+                }
+                Err(error) => {
+                    log_msg(&format!("[Quota] oauth token retry task failed: {error}"));
+                    return fallback_or_disconnected(format!("OAuth token task failed: {error}"));
+                }
+            };
 
         response = match request_quota(&fresh_access_token).await {
             Ok(resp) => resp,
@@ -720,5 +747,25 @@ mod tests {
 
         assert_eq!(window.percentage, 28.0);
         assert_eq!(window.reset_time.as_deref(), Some("2026-07-09T00:00:00Z"));
+    }
+
+    #[test]
+    fn rotates_oversized_claude_logs() {
+        use super::rotate_log_if_needed_with_limit;
+        let dir = std::env::temp_dir().join(format!(
+            "quotabar-claude-log-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("claude.log");
+        std::fs::write(&path, vec![b'x'; 32]).unwrap();
+        rotate_log_if_needed_with_limit(&path, 16);
+        assert!(!path.exists());
+        assert!(dir.join("claude.log.1").exists());
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src-tauri/src/services/tray.rs
+++ b/src-tauri/src/services/tray.rs
@@ -504,7 +504,9 @@ pub async fn update_tray_icon(
     })
     .map_err(|e| e.to_string())?;
 
-    rx.recv()
+    tauri::async_runtime::spawn_blocking(move || rx.recv())
+        .await
+        .map_err(|_| "tray update task failed".to_string())?
         .map_err(|_| "failed to receive tray update result".to_string())?
 }
 


### PR DESCRIPTION
## Summary

- Run tray `rx.recv()` and Claude keychain reads on `spawn_blocking`, and rotate `claude.log` at 2MB so a blocked recv or keychain prompt cannot stall Tokio workers.

Fixes #111

## Verification

- [x] `cargo test rotates_oversized_claude_logs`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)