### PR TITLE
fix(grok): drop unreachable estimate field cross-checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Stop Grok panel validation from comparing estimate fields that the backend copies from the same official payload.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/src/components/GrokPanel.tsx
+++ b/src/components/GrokPanel.tsx
@@ -3,12 +3,13 @@ import { backend } from '../services/backend';
 import ProviderDetailHeader from './ProviderDetailHeader';
 import ResetTimeline from './ResetTimeline';
 import SmartTip from './SmartTip';
-import type { GrokData, GrokValueEstimate } from '../types/models';
+import type { GrokData } from '../types/models';
 import { buildGrokQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
 import { getHighUsageTip } from '../services/detail_helpers';
 import { formatResetTime, getProgressStyle } from '../utils/quota_format';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
 import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';
+import { validateGrokValueEstimate } from '../services/grok_value_estimate';
 
 interface GrokPanelProps {
   onConnectionChange?: (connected: boolean) => void;
@@ -44,55 +45,6 @@ function periodValueTitle(periodType?: string): string {
   if (periodType === 'monthly') return 'API-equivalent month';
   if (periodType === 'weekly') return 'API-equivalent week';
   return 'API-equivalent period';
-}
-
-function validateGrokValueEstimate(
-  estimate: GrokValueEstimate,
-  data: GrokData,
-): string | null {
-  if (
-    !Number.isFinite(estimate.observedCostUsd)
-    || estimate.observedCostUsd <= 0
-    || !Number.isFinite(estimate.estimatedPeriodValueUsd)
-    || estimate.estimatedPeriodValueUsd <= 0
-    || !Number.isFinite(estimate.observedTokens)
-    || estimate.observedTokens <= 0
-    || !Number.isFinite(estimate.estimatedPeriodTokens)
-    || estimate.estimatedPeriodTokens <= 0
-  ) {
-    return 'The local Grok pool estimate contains invalid totals.';
-  }
-  if (data.percentage == null || Math.abs(estimate.usedPct - data.percentage) > 5) {
-    return 'The local Grok pool estimate does not match the official usage.';
-  }
-  const estimateObservedAt = Date.parse(estimate.observedAt);
-  const now = Date.now();
-  if (
-    !Number.isFinite(estimateObservedAt)
-    || estimateObservedAt > now + 5 * 60 * 1000
-    || now - estimateObservedAt > 10 * 60 * 1000
-  ) {
-    return 'The local Grok pool estimate is stale or has an invalid observation time.';
-  }
-  const estimateReset = Date.parse(estimate.resetsAt);
-  const officialReset = data.resetAt ? Date.parse(data.resetAt) : Number.NaN;
-  if (
-    !Number.isFinite(estimateReset)
-    || !Number.isFinite(officialReset)
-    || Math.abs(estimateReset - officialReset) > 5 * 60 * 1000
-  ) {
-    return 'The local Grok pool estimate does not match the official reset.';
-  }
-  const estimateStart = Date.parse(estimate.windowStartedAt);
-  const officialStart = data.periodStartedAt ? Date.parse(data.periodStartedAt) : Number.NaN;
-  if (
-    !Number.isFinite(estimateStart)
-    || !Number.isFinite(officialStart)
-    || Math.abs(estimateStart - officialStart) > 5 * 60 * 1000
-  ) {
-    return 'The local Grok pool estimate does not match the official period start.';
-  }
-  return null;
 }
 
 export default function GrokPanel({
@@ -171,7 +123,7 @@ export default function GrokPanel({
     ? formatResetTime(grokData.resetAt, { expiredLabel: 'soon' })
     : '';
   const grokValueValidationError = grokData && grokData.valueEstimate
-    ? validateGrokValueEstimate(grokData.valueEstimate, grokData)
+    ? validateGrokValueEstimate(grokData.valueEstimate)
     : null;
   const displayedGrokValueEstimate = grokValueValidationError
     ? null

--- a/src/services/grok_value_estimate.ts
+++ b/src/services/grok_value_estimate.ts
@@ -1,0 +1,33 @@
+import type { GrokValueEstimate } from '../types/models';
+
+const STALE_AFTER_MS = 10 * 60 * 1000;
+const FUTURE_SKEW_MS = 5 * 60 * 1000;
+
+export function validateGrokValueEstimate(
+  estimate: GrokValueEstimate,
+  now: number = Date.now(),
+): string | null {
+  if (
+    !Number.isFinite(estimate.observedCostUsd)
+    || estimate.observedCostUsd <= 0
+    || !Number.isFinite(estimate.estimatedPeriodValueUsd)
+    || estimate.estimatedPeriodValueUsd <= 0
+    || !Number.isFinite(estimate.observedTokens)
+    || estimate.observedTokens <= 0
+    || !Number.isFinite(estimate.estimatedPeriodTokens)
+    || estimate.estimatedPeriodTokens <= 0
+  ) {
+    return 'The local Grok pool estimate contains invalid totals.';
+  }
+
+  const estimateObservedAt = Date.parse(estimate.observedAt);
+  if (
+    !Number.isFinite(estimateObservedAt)
+    || estimateObservedAt > now + FUTURE_SKEW_MS
+    || now - estimateObservedAt > STALE_AFTER_MS
+  ) {
+    return 'The local Grok pool estimate is stale or has an invalid observation time.';
+  }
+
+  return null;
+}

--- a/tests/grok_value_estimate.test.ts
+++ b/tests/grok_value_estimate.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+import { validateGrokValueEstimate } from '../src/services/grok_value_estimate';
+import type { GrokValueEstimate } from '../src/types/models';
+
+const NOW = Date.parse('2026-09-04T07:00:00Z');
+
+function estimate(overrides: Partial<GrokValueEstimate> = {}): GrokValueEstimate {
+  return {
+    observedAt: new Date(NOW - 60_000).toISOString(),
+    windowStartedAt: '2026-08-23T15:25:10.879Z',
+    resetsAt: '2026-08-30T15:25:10.879Z',
+    usedPct: 40,
+    observedCostUsd: 12.5,
+    estimatedPeriodValueUsd: 31.25,
+    observedTokens: 1000,
+    estimatedPeriodTokens: 2500,
+    ...overrides,
+  };
+}
+
+describe('validateGrokValueEstimate', () => {
+  test('accepts a finite in-window estimate', () => {
+    expect(validateGrokValueEstimate(estimate(), NOW)).toBeNull();
+  });
+
+  test('rejects invalid totals', () => {
+    expect(validateGrokValueEstimate(estimate({ observedCostUsd: 0 }), NOW))
+      .toContain('invalid totals');
+  });
+
+  test('rejects stale observation times', () => {
+    expect(validateGrokValueEstimate(
+      estimate({ observedAt: new Date(NOW - 11 * 60 * 1000).toISOString() }),
+      NOW,
+    )).toContain('stale');
+  });
+
+  test('does not compare copied official usedPct or reset fields', () => {
+    expect(validateGrokValueEstimate(estimate({
+      usedPct: 4,
+      resetsAt: '2099-01-01T00:00:00Z',
+      windowStartedAt: '1999-01-01T00:00:00Z',
+    }), NOW)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Validate Grok pool estimates on finite numbers and `observedAt` freshness only. Remove copied-field comparisons against billing payload that could never fail.

Fixes #113

## Verification

- [x] `npx vitest run tests/grok_value_estimate.test.ts`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)