### PR TITLE
fix(ui): persist settings outside React updaters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Persist settings and events outside React state updaters, and only clear a toast when it is still the active message.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import {
   saveTrayStyle,
   type TrayStyle,
 } from './services/tray_style';
-import { getSavedEvents, recordEvent, type AppEvent, type EventLevel } from './services/event_log';
+import { appendEvent, getSavedEvents, persistEvents, type AppEvent, type EventLevel } from './services/event_log';
 import {
   getSavedSwitcherVisibility,
   saveSwitcherVisibility,
@@ -156,6 +156,7 @@ export default function App() {
   const [trayEnabled, setTrayEnabled] = useState<TrayEnabledState>(getInitialTrayEnabledState);
   const [toast, setToastState] = useState<ToastValue>(null);
   const switcherGuardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timedToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const setToast = useCallback<ToastSetter>((value) => {
     setToastState((current) => {
       const next = typeof value === 'function' ? value(current) : value;
@@ -229,10 +230,20 @@ export default function App() {
     return setters;
   }, []);
 
+  const showTimedToast = useCallback((message: string, delayMs = TRAY_GUARD_TOAST_MS) => {
+    if (timedToastTimerRef.current !== null) {
+      clearTimeout(timedToastTimerRef.current);
+    }
+    setToast(message);
+    timedToastTimerRef.current = setTimeout(() => {
+      timedToastTimerRef.current = null;
+      setToast((current) => current === message ? null : current);
+    }, delayMs);
+  }, [setToast]);
+
   const showStorageWriteFailure = useCallback(() => {
-    setToast(STORAGE_WRITE_FAILURE_MESSAGE);
-    setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS);
-  }, []);
+    showTimedToast(STORAGE_WRITE_FAILURE_MESSAGE);
+  }, [showTimedToast]);
 
   useEffect(() => {
     return subscribeStorageWriteFailures(showStorageWriteFailure);
@@ -367,8 +378,14 @@ export default function App() {
   }, [trayCycle]);
 
   const logEvent = useCallback((level: EventLevel, text: string) => {
-    setEvents((prev) => recordEvent(prev, level, text));
+    const now = Date.now();
+    const id = `${now}-${Math.random().toString(36).slice(2, 8)}`;
+    setEvents((prev) => appendEvent(prev, level, text, now, id));
   }, []);
+
+  useEffect(() => {
+    persistEvents(events);
+  }, [events]);
 
   useServiceEvents(quota, connected, usedPercent, notifSettings, logEvent);
 
@@ -387,6 +404,10 @@ export default function App() {
     if (switcherGuardTimerRef.current !== null) {
       clearTimeout(switcherGuardTimerRef.current);
       switcherGuardTimerRef.current = null;
+    }
+    if (timedToastTimerRef.current !== null) {
+      clearTimeout(timedToastTimerRef.current);
+      timedToastTimerRef.current = null;
     }
   }, []);
 
@@ -409,12 +430,10 @@ export default function App() {
   }, [activeView, switcherVisibility, setAndPersistTab]);
 
   const handleNotificationToggle = useCallback((key: NotificationKey) => {
-    setNotifSettings((prev) => {
-      const next = { ...prev, [key]: !prev[key] };
-      saveNotificationSettings(next);
-      return next;
-    });
-  }, []);
+    const next = { ...notifSettings, [key]: !notifSettings[key] };
+    saveNotificationSettings(next);
+    setNotifSettings(next);
+  }, [notifSettings]);
 
   const handleBonusExpiring = useCallback((daysLeft: number) => {
     const text = daysLeft <= 0
@@ -432,13 +451,11 @@ export default function App() {
   }, []);
 
   const handleTrayCycleToggle = useCallback(() => {
-    setTrayCycle((prev) => {
-      const next = !prev;
-      saveTrayCycle(next);
-      return next;
-    });
+    const next = !trayCycle;
+    saveTrayCycle(next);
+    setTrayCycle(next);
     setTrayCycleIndex(0);
-  }, []);
+  }, [trayCycle]);
 
   const handleThemeChange = useCallback((newTheme: ThemeName) => {
     setTheme(newTheme);
@@ -452,49 +469,34 @@ export default function App() {
   }, [dockHidden]);
 
   const handleDockToggle = useCallback(() => {
-    setDockHidden((prev) => {
-      const newValue = !prev;
-      saveDockHidden(newValue);
-      return newValue;
-    });
-  }, []);
+    const newValue = !dockHidden;
+    saveDockHidden(newValue);
+    setDockHidden(newValue);
+  }, [dockHidden]);
 
   const showTrayGuardToast = useCallback(() => {
-    setToast(TRAY_GUARD_MESSAGE);
-    setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS);
-  }, []);
+    showTimedToast(TRAY_GUARD_MESSAGE);
+  }, [showTimedToast]);
 
   const handleTrayToggle = useCallback((service: TrayServiceName) => {
-    let blocked = false;
-
-    setTrayEnabled((prev) => {
-      const nextValue = !prev[service];
-      const someOtherEnabled = SERVICES.some((other) => other !== service && prev[other]);
-
-      if (!nextValue && !someOtherEnabled) {
-        blocked = true;
-        return prev;
-      }
-
-      saveTrayEnabled(service, nextValue);
-      return {
-        ...prev,
-        [service]: nextValue,
-      };
-    });
-
-    if (blocked) {
+    const nextValue = !trayEnabled[service];
+    const someOtherEnabled = SERVICES.some((other) => other !== service && trayEnabled[other]);
+    if (!nextValue && !someOtherEnabled) {
       showTrayGuardToast();
+      return;
     }
-  }, [showTrayGuardToast]);
+    saveTrayEnabled(service, nextValue);
+    setTrayEnabled((prev) => ({
+      ...prev,
+      [service]: nextValue,
+    }));
+  }, [showTrayGuardToast, trayEnabled]);
 
   const handlePanelSectionToggle = useCallback((key: PanelSectionKey) => {
-    setPanelSections((prev) => {
-      const next = { ...prev, [key]: !prev[key] };
-      savePanelSections(next);
-      return next;
-    });
-  }, []);
+    const next = { ...panelSections, [key]: !panelSections[key] };
+    savePanelSections(next);
+    setPanelSections(next);
+  }, [panelSections]);
 
   const handleTabChange = useCallback((tab: TabName) => {
     setAndPersistTab(tab);
@@ -575,18 +577,15 @@ export default function App() {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to open dashboard';
-      setToast(message);
-      setTimeout(() => setToast(null), 2000);
+      showTimedToast(message);
     }
-  }, [activeProvider]);
+  }, [activeProvider, showTimedToast]);
 
   const handleSettingsViewToggle = useCallback(() => {
-    setActiveView((prev) => {
-      const opening = prev !== 'settings';
-      saveSettingsExpanded(opening);
-      return opening ? 'settings' : getSavedTab();
-    });
-  }, []);
+    const opening = activeView !== 'settings';
+    saveSettingsExpanded(opening);
+    setActiveView(opening ? 'settings' : getSavedTab());
+  }, [activeView]);
 
   const handleCloseSettings = useCallback(() => {
     saveSettingsExpanded(false);

--- a/src/services/event_log.ts
+++ b/src/services/event_log.ts
@@ -39,32 +39,46 @@ function isAppEvent(value: unknown): value is AppEvent {
 /**
  * Prepends an event and returns the updated list (newest first).
  * Repeats of the same text inside the dedupe window are dropped.
+ * This function is pure: persist separately with `persistEvents`.
  */
-export function recordEvent(
+export function appendEvent(
   events: AppEvent[],
   level: EventLevel,
   text: string,
   now: number = Date.now(),
+  id: string = `${now}-${Math.random().toString(36).slice(2, 8)}`,
 ): AppEvent[] {
   const duplicate = events.find(
     (event) => event.text === text && now - Date.parse(event.time) < DEDUPE_WINDOW_MS,
   );
   if (duplicate) return events;
 
-  const next = [
+  return [
     {
-      id: `${now}-${Math.random().toString(36).slice(2, 8)}`,
+      id,
       time: new Date(now).toISOString(),
       level,
       text,
     },
     ...events,
   ].slice(0, MAX_EVENTS);
+}
 
-  writeStorageItem(STORAGE_KEY, JSON.stringify(next), {
+export function persistEvents(events: AppEvent[]): boolean {
+  return writeStorageItem(STORAGE_KEY, JSON.stringify(events), {
     preserveSessionValue: true,
     notifyUser: false,
   });
+}
+
+export function recordEvent(
+  events: AppEvent[],
+  level: EventLevel,
+  text: string,
+  now: number = Date.now(),
+): AppEvent[] {
+  const next = appendEvent(events, level, text, now);
+  persistEvents(next);
   return next;
 }
 


### PR DESCRIPTION
## Summary

- Move localStorage writes and event persistence out of React state updaters, generate event ids before `setState`, and only clear a timed toast when it is still the same message.

Fixes #112

## Verification

- [x] `npx vitest run tests/event_log.test.ts`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)