### PR TITLE
Merge GH100–GH113 bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Scale local Grok CLI cost by the Build product share instead of the full-pool used percent, and stop treating missing product percents as zero in the official total.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Persist settings and events outside React state updaters, and only clear a toast when it is still the active message.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Toggle the macOS popover from a tray click instead of hiding-on-blur then immediately showing again.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Scope Codex last-good account info to the current `auth.json` stamp so a transient read cannot show the previous account.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Return Claude last-good quota with an error and a 15-minute age cap instead of presenting hours-old data as a fresh success.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Detect transient OS errors by errno and error-chain source instead of `os error 24` substrings.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Pin Codex weekly quota and local cost summaries to one ccstats revision so pricing and dedup stay aligned.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Saturate Codex `limit_window_seconds` when converting to minutes so huge API values cannot overflow.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Keep last-good Cursor usage across 5xx and 429 responses instead of flashing disconnected.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Move Claude keychain reads and tray main-thread waits off Tokio worker threads, and rotate the Claude log at 2MB.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Keep tray-enabled providers on a 60s poll while the popover is hidden, and stop writing a wall-clock "Updated" stamp onto unchanged tray data.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Collapse cycling macOS tray icons by status-item length instead of removing and recreating NSStatusItems.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Stop Grok panel validation from comparing estimate fields that the backend copies from the same official payload.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Stop caching disconnected Cursor payloads so a transient empty body cannot pin "not connected" for 120s.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 
 ## 0.4.1 - 2026-09-01

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -471,25 +471,6 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.5.0"
-source = "git+https://github.com/majiayu000/ccstats.git?rev=2c67efd32508bd7e0e7c5605c9ac4ba989632818#2c67efd32508bd7e0e7c5605c9ac4ba989632818"
-dependencies = [
- "chrono",
- "chrono-tz",
- "clap",
- "comfy-table",
- "dirs 6.0.0",
- "glob",
- "rayon",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "toml 1.0.1+spec-1.1.0",
- "ureq",
-]
-
-[[package]]
-name = "ccstats"
 version = "0.5.1"
 source = "git+https://github.com/majiayu000/ccstats.git?rev=6bec20d035a10efbc8914d36001c7621570d1066#6bec20d035a10efbc8914d36001c7621570d1066"
 dependencies = [
@@ -3404,8 +3385,7 @@ name = "quotabar"
 version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
- "ccstats 0.5.0",
- "ccstats 0.5.1",
+ "ccstats",
  "chrono",
  "dirs 5.0.1",
  "image",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,5 +38,5 @@ tauri-plugin-notification = "2.3.3"
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSStatusItem"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSStatusItem", "objc2-core-foundation"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString", "NSUserDefaults"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,6 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 once_cell = "1.19"
 ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "6bec20d035a10efbc8914d36001c7621570d1066" }
-ccstats-quota = { package = "ccstats", git = "https://github.com/majiayu000/ccstats.git", rev = "2c67efd32508bd7e0e7c5605c9ac4ba989632818" }
 tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -45,18 +45,18 @@ pub async fn get_codex_weekly_quota() -> Result<CodexWeeklyQuotaData, String> {
         None
     };
     let data =
-        tauri::async_runtime::spawn_blocking(move || match ccstats_quota::load_codex_weekly_quota(
-            Some(&codex_home),
-        ) {
-            Ok(quota) => {
-                let value_estimate = codex_weekly::estimate_codex_weekly_value(
-                    &codex_home,
-                    &quota,
-                    official.as_ref(),
-                );
-                CodexWeeklyQuotaData::available(quota, value_estimate)
+        tauri::async_runtime::spawn_blocking(move || {
+            match ccstats::load_codex_weekly_quota(Some(&codex_home)) {
+                Ok(quota) => {
+                    let value_estimate = codex_weekly::estimate_codex_weekly_value(
+                        &codex_home,
+                        &quota,
+                        official.as_ref(),
+                    );
+                    CodexWeeklyQuotaData::available(quota, value_estimate)
+                }
+                Err(error) => CodexWeeklyQuotaData::unavailable(error.to_string()),
             }
-            Err(error) => CodexWeeklyQuotaData::unavailable(error.to_string()),
         })
         .await
         .map_err(|err| format!("Codex weekly quota task failed: {err}"))?;

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -199,8 +199,8 @@ pub struct CodexWeeklyQuotaData {
 
 impl CodexWeeklyQuotaData {
     pub fn available(
-        quota: ccstats_quota::CodexWeeklyQuota,
-        value_estimate: Result<ccstats_quota::CodexWeeklyValueEstimate, String>,
+        quota: ccstats::CodexWeeklyQuota,
+        value_estimate: Result<ccstats::CodexWeeklyValueEstimate, String>,
     ) -> Self {
         let (value_estimate, value_estimate_error) = match value_estimate {
             Ok(estimate) => (Some(CodexWeeklyValueEstimate::from(estimate)), None),
@@ -224,8 +224,8 @@ impl CodexWeeklyQuotaData {
     }
 }
 
-impl From<ccstats_quota::CodexWeeklyValueEstimate> for CodexWeeklyValueEstimate {
-    fn from(estimate: ccstats_quota::CodexWeeklyValueEstimate) -> Self {
+impl From<ccstats::CodexWeeklyValueEstimate> for CodexWeeklyValueEstimate {
+    fn from(estimate: ccstats::CodexWeeklyValueEstimate) -> Self {
         Self {
             observed_at: estimate.observed_at.to_rfc3339(),
             window_started_at: estimate.window_started_at.to_rfc3339(),
@@ -239,8 +239,8 @@ impl From<ccstats_quota::CodexWeeklyValueEstimate> for CodexWeeklyValueEstimate 
     }
 }
 
-impl From<ccstats_quota::CodexWeeklyQuota> for CodexWeeklyQuota {
-    fn from(quota: ccstats_quota::CodexWeeklyQuota) -> Self {
+impl From<ccstats::CodexWeeklyQuota> for CodexWeeklyQuota {
+    fn from(quota: ccstats::CodexWeeklyQuota) -> Self {
         Self {
             observed_at: quota.observed_at.to_rfc3339(),
             resets_at: quota.resets_at.to_rfc3339(),

--- a/src-tauri/src/services/claude.rs
+++ b/src-tauri/src/services/claude.rs
@@ -2,6 +2,7 @@ use crate::domain::models::{QuotaData, UsageInfo};
 use crate::services::http::{is_transient_os_error, shared_http_client};
 use std::fs::OpenOptions;
 use std::io::Write as IoWrite;
+use std::path::Path;
 #[cfg(target_os = "macos")]
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -13,6 +14,7 @@ const QUOTA_CACHE_TTL: Duration = Duration::from_secs(120);
 const CLAUDE_TOKEN_ENV_KEY: &str = "CLAUDE_CODE_OAUTH_TOKEN";
 const CLAUDE_AUTH_RELOGIN_MESSAGE: &str =
     "Claude OAuth token expired or invalid. Please re-login to Claude Code, then click Refresh.";
+const MAX_LOG_BYTES: u64 = 2 * 1024 * 1024;
 
 const CREDENTIAL_NAMES: [&str; 4] = [
     "Claude Code-credentials",
@@ -35,6 +37,23 @@ fn last_request_time() -> &'static Mutex<Option<Instant>> {
     LAST_REQUEST_TIME.get_or_init(|| Mutex::new(None))
 }
 
+fn rotate_log_if_needed(path: &Path) {
+    rotate_log_if_needed_with_limit(path, MAX_LOG_BYTES);
+}
+
+fn rotate_log_if_needed_with_limit(path: &Path, max_bytes: u64) {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return;
+    };
+    if metadata.len() <= max_bytes {
+        return;
+    }
+    let rotated = path.with_extension("log.1");
+    if let Err(error) = std::fs::rename(path, &rotated) {
+        eprintln!("[log] failed to rotate log: {error}");
+    }
+}
+
 fn log_msg(msg: &str) {
     let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
     let line = format!("[{timestamp}] {msg}\n");
@@ -49,11 +68,10 @@ fn log_msg(msg: &str) {
         return;
     }
 
-    match OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_dir.join("claude.log"))
-    {
+    let log_path = log_dir.join("claude.log");
+    rotate_log_if_needed(&log_path);
+
+    match OpenOptions::new().create(true).append(true).open(&log_path) {
         Ok(mut file) => {
             if let Err(e) = file.write_all(line.as_bytes()) {
                 eprintln!("[log] failed to write log: {e}");
@@ -454,11 +472,15 @@ pub async fn fetch_quota() -> QuotaData {
         return cached;
     }
 
-    let access_token = match get_oauth_token(false) {
-        Ok(token) => token,
-        Err(error) => {
+    let access_token = match tauri::async_runtime::spawn_blocking(|| get_oauth_token(false)).await {
+        Ok(Ok(token)) => token,
+        Ok(Err(error)) => {
             log_msg(&format!("[Quota] get_oauth_token failed: {error}"));
             return fallback_or_disconnected(error);
+        }
+        Err(error) => {
+            log_msg(&format!("[Quota] oauth token task failed: {error}"));
+            return QuotaData::disconnected(format!("OAuth token task failed: {error}"));
         }
     };
 
@@ -488,13 +510,18 @@ pub async fn fetch_quota() -> QuotaData {
         log_msg(&format!(
             "[Quota] auth error ({status}), step 1: force re-read from keychain"
         ));
-        let fresh_access_token = match get_oauth_token(true) {
-            Ok(token) => token,
-            Err(error) => {
-                log_msg(&format!("[Quota] keychain re-read failed: {error}"));
-                return fallback_or_disconnected(error);
-            }
-        };
+        let fresh_access_token =
+            match tauri::async_runtime::spawn_blocking(|| get_oauth_token(true)).await {
+                Ok(Ok(token)) => token,
+                Ok(Err(error)) => {
+                    log_msg(&format!("[Quota] keychain re-read failed: {error}"));
+                    return fallback_or_disconnected(error);
+                }
+                Err(error) => {
+                    log_msg(&format!("[Quota] oauth token retry task failed: {error}"));
+                    return fallback_or_disconnected(format!("OAuth token task failed: {error}"));
+                }
+            };
 
         response = match request_quota(&fresh_access_token).await {
             Ok(resp) => resp,
@@ -720,5 +747,25 @@ mod tests {
 
         assert_eq!(window.percentage, 28.0);
         assert_eq!(window.reset_time.as_deref(), Some("2026-07-09T00:00:00Z"));
+    }
+
+    #[test]
+    fn rotates_oversized_claude_logs() {
+        use super::rotate_log_if_needed_with_limit;
+        let dir = std::env::temp_dir().join(format!(
+            "quotabar-claude-log-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("claude.log");
+        std::fs::write(&path, vec![b'x'; 32]).unwrap();
+        rotate_log_if_needed_with_limit(&path, 16);
+        assert!(!path.exists());
+        assert!(dir.join("claude.log.1").exists());
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src-tauri/src/services/claude.rs
+++ b/src-tauri/src/services/claude.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 const TOKEN_CACHE_TTL: Duration = Duration::from_secs(300);
 const QUOTA_CACHE_TTL: Duration = Duration::from_secs(120);
+const MAX_STALE_QUOTA_AGE: Duration = Duration::from_secs(15 * 60);
 const CLAUDE_TOKEN_ENV_KEY: &str = "CLAUDE_CODE_OAUTH_TOKEN";
 const CLAUDE_AUTH_RELOGIN_MESSAGE: &str =
     "Claude OAuth token expired or invalid. Please re-login to Claude Code, then click Refresh.";
@@ -407,19 +408,41 @@ fn get_cached_quota() -> Option<QuotaData> {
     }
 }
 
+fn stale_quota_usable(connected: bool, age: Duration) -> bool {
+    connected && age < MAX_STALE_QUOTA_AGE
+}
+
 fn get_stale_cached_quota() -> Option<QuotaData> {
     let guard = quota_cache().lock().ok()?;
     let cached = guard.as_ref()?;
-    if cached.data.connected {
-        let age = cached.cached_at.elapsed();
+    let age = cached.cached_at.elapsed();
+    if stale_quota_usable(cached.data.connected, age) {
         log_msg(&format!(
             "[Quota] returning stale cache as fallback, age={:.0}s",
             age.as_secs_f64()
         ));
         Some(cached.data.clone())
     } else {
+        if cached.data.connected {
+            log_msg(&format!(
+                "[Quota] stale cache too old to use as fallback, age={:.0}s",
+                age.as_secs_f64()
+            ));
+        }
         None
     }
+}
+
+fn mark_quota_fetch_error(mut data: QuotaData, error: String) -> QuotaData {
+    data.error = Some(error);
+    data
+}
+
+fn stale_or_disconnected(error: String) -> QuotaData {
+    if let Some(stale) = get_stale_cached_quota() {
+        return mark_quota_fetch_error(stale, error);
+    }
+    QuotaData::disconnected(error)
 }
 
 fn save_quota_cache(data: &QuotaData) {
@@ -439,9 +462,7 @@ fn is_rate_limited(status: reqwest::StatusCode) -> bool {
 /// QuotaData instead of surfacing the error to the UI.
 fn fallback_or_disconnected(error: String) -> QuotaData {
     if is_transient_os_error(&error) {
-        if let Some(stale) = get_stale_cached_quota() {
-            return stale;
-        }
+        return stale_or_disconnected(error);
     }
     QuotaData::disconnected(error)
 }
@@ -466,7 +487,7 @@ pub async fn fetch_quota() -> QuotaData {
         Ok(resp) => resp,
         Err(error) => {
             log_msg(&format!("[Quota] initial request failed: {error}"));
-            return get_stale_cached_quota().unwrap_or_else(|| QuotaData::disconnected(error));
+            return stale_or_disconnected(error);
         }
     };
 
@@ -477,9 +498,8 @@ pub async fn fetch_quota() -> QuotaData {
     // so the frontend can trigger adaptive backoff
     if is_rate_limited(status) {
         log_msg("[Quota] 429 rate limited, returning stale cache if available");
-        if let Some(mut stale) = get_stale_cached_quota() {
-            stale.error = Some("API error: 429 Too Many Requests".to_string());
-            return stale;
+        if let Some(stale) = get_stale_cached_quota() {
+            return mark_quota_fetch_error(stale, "API error: 429 Too Many Requests".to_string());
         }
         return QuotaData::disconnected("API error: 429 Too Many Requests");
     }
@@ -513,9 +533,11 @@ pub async fn fetch_quota() -> QuotaData {
 
         if is_rate_limited(status2) {
             log_msg("[Quota] 429 after keychain retry, returning stale cache");
-            if let Some(mut stale) = get_stale_cached_quota() {
-                stale.error = Some("API error: 429 Too Many Requests".to_string());
-                return stale;
+            if let Some(stale) = get_stale_cached_quota() {
+                return mark_quota_fetch_error(
+                    stale,
+                    "API error: 429 Too Many Requests".to_string(),
+                );
             }
             return QuotaData::disconnected("API error: 429 Too Many Requests");
         }
@@ -531,7 +553,7 @@ pub async fn fetch_quota() -> QuotaData {
     if !response.status().is_success() {
         let final_status = response.status();
         log_msg(&format!("[Quota] non-success response: {final_status}"));
-        return QuotaData::disconnected(format!("API error: {final_status}"));
+        return stale_or_disconnected(format!("API error: {final_status}"));
     }
 
     let data = match response.json::<serde_json::Value>().await {
@@ -593,9 +615,10 @@ pub async fn fetch_quota() -> QuotaData {
 #[cfg(test)]
 mod tests {
     use super::{
-        oauth_cache_hit_diagnostic, oauth_env_source_diagnostic, oauth_keychain_source_diagnostic,
-        parse_first_quota_window, parse_quota_window, parse_weekly_scoped_model_quota,
-        request_quota_diagnostic, FABLE5_QUOTA_KEYS,
+        mark_quota_fetch_error, oauth_cache_hit_diagnostic, oauth_env_source_diagnostic,
+        oauth_keychain_source_diagnostic, parse_first_quota_window, parse_quota_window,
+        parse_weekly_scoped_model_quota, request_quota_diagnostic, stale_quota_usable,
+        FABLE5_QUOTA_KEYS, MAX_STALE_QUOTA_AGE,
     };
     use serde_json::{json, Value};
     use std::time::Duration;
@@ -720,5 +743,38 @@ mod tests {
 
         assert_eq!(window.percentage, 28.0);
         assert_eq!(window.reset_time.as_deref(), Some("2026-07-09T00:00:00Z"));
+    }
+
+    #[test]
+    fn stale_quota_rejects_disconnected_and_expired_snapshots() {
+        assert!(stale_quota_usable(true, Duration::from_secs(60)));
+        assert!(!stale_quota_usable(false, Duration::from_secs(1)));
+        assert!(!stale_quota_usable(true, MAX_STALE_QUOTA_AGE));
+        assert!(stale_quota_usable(
+            true,
+            MAX_STALE_QUOTA_AGE - Duration::from_secs(1)
+        ));
+    }
+
+    #[test]
+    fn stale_quota_fallback_keeps_connected_data_and_sets_error() {
+        let stale = mark_quota_fetch_error(
+            crate::domain::models::QuotaData {
+                connected: true,
+                session: None,
+                weekly_total: None,
+                weekly_opus: None,
+                weekly_sonnet: None,
+                weekly_design: None,
+                weekly_fable5: None,
+                error: None,
+            },
+            "Network error: connection reset".to_string(),
+        );
+        assert!(stale.connected);
+        assert_eq!(
+            stale.error.as_deref(),
+            Some("Network error: connection reset")
+        );
     }
 }

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -3,7 +3,7 @@ use crate::domain::models::{
     CodexResetCredits,
 };
 use crate::services::codex_cache::{self, AuthFileStamp};
-use crate::services::http::{is_transient_os_error, shared_http_client};
+use crate::services::http::{error_is_transient, is_transient_os_error, shared_http_client};
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
@@ -309,7 +309,7 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
             let should_preserve = should_preserve_transport_failure(
                 err.is_timeout(),
                 err.is_connect(),
-                is_transient_os_error(&error),
+                error_is_transient(&err),
             );
             log_msg(&format!(
                 "[RateLimits] request failed: latency={:.1}s, preservable={should_preserve}, error={error}",
@@ -358,7 +358,7 @@ pub async fn fetch_codex_rate_limits() -> CodexRateLimits {
             let should_preserve = should_preserve_transport_failure(
                 err.is_timeout(),
                 err.is_connect(),
-                is_transient_os_error(&err.to_string()),
+                error_is_transient(&err),
             );
             let error = if should_preserve {
                 format!("Failed to read response body: {err}")

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -159,6 +159,10 @@ fn parse_used_percent(window: &serde_json::Value) -> Option<f64> {
         .map(|value| value.clamp(0.0, 100.0))
 }
 
+fn window_minutes_from_seconds(seconds: i64) -> i64 {
+    seconds.saturating_add(59) / 60
+}
+
 fn parse_rate_limit_window(window: &serde_json::Value) -> Option<CodexRateLimitWindow> {
     if window.is_null() || !window.is_object() {
         return None;
@@ -168,7 +172,7 @@ fn parse_rate_limit_window(window: &serde_json::Value) -> Option<CodexRateLimitW
         used_percent: parse_used_percent(window)?,
         window_minutes: window["limit_window_seconds"]
             .as_i64()
-            .map(|s| (s + 59) / 60),
+            .map(window_minutes_from_seconds),
         resets_at: window["reset_at"].as_i64(),
     })
 }
@@ -521,7 +525,7 @@ pub async fn fetch_codex_reset_credits() -> CodexResetCredits {
 mod tests {
     use super::{
         parse_rate_limit_window, parse_reset_credit, should_preserve_for_status,
-        should_preserve_transport_failure,
+        should_preserve_transport_failure, window_minutes_from_seconds,
     };
     use serde_json::json;
 
@@ -598,6 +602,22 @@ mod tests {
         assert_eq!(window.used_percent, 61.8);
         assert_eq!(window.window_minutes, Some(300));
         assert_eq!(window.resets_at, Some(1_781_000_000));
+    }
+
+    #[test]
+    fn window_minutes_saturate_instead_of_overflowing() {
+        assert_eq!(window_minutes_from_seconds(18_000), 300);
+        assert_eq!(window_minutes_from_seconds(1), 1);
+        assert_eq!(window_minutes_from_seconds(i64::MAX), i64::MAX / 60);
+        let parsed = parse_rate_limit_window(&json!({
+            "used_percent": 10,
+            "limit_window_seconds": i64::MAX
+        }));
+        let window = match parsed {
+            Some(window) => window,
+            None => panic!("max limit_window_seconds should parse"),
+        };
+        assert!(window.window_minutes.is_some_and(|minutes| minutes > 0));
     }
 
     #[test]

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -11,11 +11,16 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
+struct LastGoodInfo {
+    stamp: AuthFileStamp,
+    data: CodexData,
+}
+
 /// Most recent successful fetch results, retained without TTL so a transient
 /// polling failure does not erase quota that was already displayed.
-static LAST_GOOD_INFO: OnceLock<Mutex<Option<CodexData>>> = OnceLock::new();
+static LAST_GOOD_INFO: OnceLock<Mutex<Option<LastGoodInfo>>> = OnceLock::new();
 
-fn last_good_info() -> &'static Mutex<Option<CodexData>> {
+fn last_good_info() -> &'static Mutex<Option<LastGoodInfo>> {
     LAST_GOOD_INFO.get_or_init(|| Mutex::new(None))
 }
 
@@ -173,20 +178,40 @@ fn parse_rate_limit_window(window: &serde_json::Value) -> Option<CodexRateLimitW
     })
 }
 
-fn fallback_or_disconnected_info(error: String) -> CodexData {
-    if is_transient_os_error(&error) {
-        if let Ok(guard) = last_good_info().lock() {
-            if let Some(stale) = guard.as_ref() {
-                return stale.clone();
+fn retain_last_good_info(
+    cached: Option<&LastGoodInfo>,
+    stamp: Option<&AuthFileStamp>,
+    error: String,
+    transient: bool,
+) -> CodexData {
+    if transient {
+        if let (Some(stale), Some(current_stamp)) = (cached, stamp) {
+            if stale.stamp == *current_stamp {
+                let mut data = stale.data.clone();
+                data.error = Some(error);
+                return data;
             }
         }
     }
     CodexData::disconnected(error)
 }
 
+fn fallback_or_disconnected_info(error: StampedAuthReadError) -> CodexData {
+    let transient = is_transient_os_error(&error.message);
+    if let Ok(guard) = last_good_info().lock() {
+        return retain_last_good_info(
+            guard.as_ref(),
+            error.pre_read_stamp.as_ref(),
+            error.message,
+            transient,
+        );
+    }
+    CodexData::disconnected(error.message)
+}
+
 pub async fn fetch_codex_info() -> CodexData {
-    let auth_json = match read_auth_json() {
-        Ok(v) => v,
+    let (auth_json, auth_stamp) = match read_auth_json_with_stamp() {
+        Ok(auth) => auth,
         Err(error) => return fallback_or_disconnected_info(error),
     };
 
@@ -218,7 +243,10 @@ pub async fn fetch_codex_info() -> CodexData {
     };
 
     if let Ok(mut guard) = last_good_info().lock() {
-        *guard = Some(info.clone());
+        *guard = Some(LastGoodInfo {
+            stamp: auth_stamp,
+            data: info.clone(),
+        });
     }
     info
 }
@@ -520,10 +548,12 @@ pub async fn fetch_codex_reset_credits() -> CodexResetCredits {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_rate_limit_window, parse_reset_credit, should_preserve_for_status,
-        should_preserve_transport_failure,
+        parse_rate_limit_window, parse_reset_credit, retain_last_good_info,
+        should_preserve_for_status, should_preserve_transport_failure, AuthFileStamp, CodexData,
+        LastGoodInfo,
     };
     use serde_json::json;
+    use std::time::{Duration, SystemTime};
 
     #[test]
     fn only_rate_limiting_is_a_preservable_http_failure() {
@@ -613,5 +643,65 @@ mod tests {
 
         assert_eq!(high.used_percent, 100.0);
         assert_eq!(low.used_percent, 0.0);
+    }
+
+    fn auth_stamp(len: u64, secs: u64) -> AuthFileStamp {
+        AuthFileStamp {
+            len,
+            modified: SystemTime::UNIX_EPOCH + Duration::from_secs(secs),
+        }
+    }
+
+    fn connected_info(email: &str) -> CodexData {
+        CodexData {
+            connected: true,
+            plan_type: Some("plus".to_string()),
+            account_id: Some("acct-a".to_string()),
+            subscription_until: None,
+            email: Some(email.to_string()),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn last_good_codex_info_stays_on_the_same_auth_file() {
+        let cached = LastGoodInfo {
+            stamp: auth_stamp(128, 10),
+            data: connected_info("one@example.com"),
+        };
+        let retained = retain_last_good_info(
+            Some(&cached),
+            Some(&auth_stamp(128, 10)),
+            "Failed to read auth.json: Too many open files (os error 24)".to_string(),
+            true,
+        );
+        assert!(retained.connected);
+        assert_eq!(retained.email.as_deref(), Some("one@example.com"));
+        assert!(retained
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("Too many open files"));
+    }
+
+    #[test]
+    fn last_good_codex_info_is_dropped_after_account_file_changes() {
+        let cached = LastGoodInfo {
+            stamp: auth_stamp(128, 10),
+            data: connected_info("one@example.com"),
+        };
+        let switched = retain_last_good_info(
+            Some(&cached),
+            Some(&auth_stamp(256, 11)),
+            "Failed to read auth.json: Too many open files (os error 24)".to_string(),
+            true,
+        );
+        assert!(!switched.connected);
+        assert_eq!(switched.email, None);
+        assert!(switched
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("Too many open files"));
     }
 }

--- a/src-tauri/src/services/codex_weekly.rs
+++ b/src-tauri/src/services/codex_weekly.rs
@@ -153,8 +153,10 @@ pub fn estimate_codex_weekly_value(
 }
 
 fn should_fallback_to_official(error: &str) -> bool {
-    error.contains("used percentage is zero")
-        || error.contains("no Codex token usage matched the active weekly quota window")
+    let lowered = error.to_ascii_lowercase();
+    lowered.contains("used percentage is zero")
+        || lowered.contains("no codex token usage matched")
+        || lowered.contains("no token usage matched the active weekly")
 }
 
 fn quota_matches_official(

--- a/src-tauri/src/services/codex_weekly.rs
+++ b/src-tauri/src/services/codex_weekly.rs
@@ -15,7 +15,7 @@ const OFFICIAL_USED_TOLERANCE_PCT: f64 = 1.0;
 const SUCCESS_CACHE_TTL: Duration = Duration::from_secs(300);
 const ERROR_CACHE_TTL: Duration = Duration::from_secs(60);
 
-type WeeklyValueResult = Result<ccstats_quota::CodexWeeklyValueEstimate, String>;
+type WeeklyValueResult = Result<ccstats::CodexWeeklyValueEstimate, String>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct WeeklyQuotaIdentity {
@@ -24,8 +24,8 @@ struct WeeklyQuotaIdentity {
     used_pct_bits: u64,
 }
 
-impl From<&ccstats_quota::CodexWeeklyQuota> for WeeklyQuotaIdentity {
-    fn from(quota: &ccstats_quota::CodexWeeklyQuota) -> Self {
+impl From<&ccstats::CodexWeeklyQuota> for WeeklyQuotaIdentity {
+    fn from(quota: &ccstats::CodexWeeklyQuota) -> Self {
         Self {
             observed_at: quota.observed_at,
             resets_at: quota.resets_at,
@@ -35,7 +35,7 @@ impl From<&ccstats_quota::CodexWeeklyQuota> for WeeklyQuotaIdentity {
 }
 
 impl WeeklyQuotaIdentity {
-    fn matches_estimate(&self, estimate: &ccstats_quota::CodexWeeklyValueEstimate) -> bool {
+    fn matches_estimate(&self, estimate: &ccstats::CodexWeeklyValueEstimate) -> bool {
         self.observed_at == estimate.observed_at
             && self.resets_at == estimate.resets_at
             && self.used_pct_bits == estimate.used_pct.to_bits()
@@ -105,7 +105,7 @@ pub(crate) fn official_weekly_window(limits: &CodexRateLimits) -> Option<&CodexR
 
 pub fn estimate_codex_weekly_value(
     codex_home: &Path,
-    quota: &ccstats_quota::CodexWeeklyQuota,
+    quota: &ccstats::CodexWeeklyQuota,
     official: Option<&OfficialWeeklySnapshot>,
 ) -> WeeklyValueResult {
     let quota_identity = WeeklyQuotaIdentity::from(quota);
@@ -158,7 +158,7 @@ fn should_fallback_to_official(error: &str) -> bool {
 }
 
 fn quota_matches_official(
-    quota: &ccstats_quota::CodexWeeklyQuota,
+    quota: &ccstats::CodexWeeklyQuota,
     official: &CodexRateLimitWindow,
 ) -> bool {
     weekly_windows_match(
@@ -190,7 +190,7 @@ fn estimate_from_local_snapshot(
     codex_home: &Path,
     quota_identity: &WeeklyQuotaIdentity,
 ) -> WeeklyValueResult {
-    ccstats_quota::estimate_codex_weekly_value(Some(codex_home), false, false)
+    ccstats::estimate_codex_weekly_value(Some(codex_home), false, false)
         .map_err(|error| error.to_string())
         .and_then(|estimate| {
             if quota_identity.matches_estimate(&estimate) {
@@ -221,8 +221,8 @@ fn estimate_from_official_window(
     if snapshot.observed_at >= resets {
         return Err("The official weekly quota window has expired.".to_string());
     }
-    ccstats_quota::estimate_codex_weekly_value_for_window(
-        &ccstats_quota::CodexWeeklyValueWindow {
+    ccstats::estimate_codex_weekly_value_for_window(
+        &ccstats::CodexWeeklyValueWindow {
             observed_at: snapshot.observed_at,
             resets_at: resets,
             window_minutes,
@@ -239,8 +239,8 @@ fn estimate_from_official_window(
 mod tests {
     use super::*;
 
-    fn estimate() -> ccstats_quota::CodexWeeklyValueEstimate {
-        ccstats_quota::CodexWeeklyValueEstimate {
+    fn estimate() -> ccstats::CodexWeeklyValueEstimate {
+        ccstats::CodexWeeklyValueEstimate {
             observed_at: chrono::DateTime::UNIX_EPOCH,
             window_started_at: chrono::DateTime::UNIX_EPOCH,
             resets_at: chrono::DateTime::UNIX_EPOCH + chrono::Duration::days(7),

--- a/src-tauri/src/services/cursor.rs
+++ b/src-tauri/src/services/cursor.rs
@@ -230,6 +230,10 @@ fn is_transient_cursor_error(message: &str) -> bool {
         || lowercase.contains("database table is locked")
 }
 
+fn is_transient_cursor_status(status: reqwest::StatusCode) -> bool {
+    status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+}
+
 fn fallback_or_disconnected(error: impl Into<String>) -> CursorData {
     let error = error.into();
     if is_transient_cursor_error(&error) {
@@ -283,7 +287,11 @@ pub async fn fetch_cursor_info() -> CursorData {
         return CursorData::disconnected("Cursor session expired. Re-open Cursor and sign in.");
     }
     if !status.is_success() {
-        return CursorData::disconnected(format!("Cursor API error: {status}"));
+        let error = format!("Cursor API error: {status}");
+        if is_transient_cursor_status(status) {
+            return fallback_or_disconnected(error);
+        }
+        return CursorData::disconnected(error);
     }
 
     let data = match response.json::<serde_json::Value>().await {
@@ -657,6 +665,12 @@ mod tests {
             "Failed to read state.vscdb: database table is locked"
         ));
         assert!(!is_transient_cursor_error("Cursor session not found"));
+        assert!(is_transient_cursor_status(reqwest::StatusCode::BAD_GATEWAY));
+        assert!(is_transient_cursor_status(
+            reqwest::StatusCode::TOO_MANY_REQUESTS
+        ));
+        assert!(!is_transient_cursor_status(reqwest::StatusCode::FORBIDDEN));
+        assert!(!is_transient_cursor_status(reqwest::StatusCode::NOT_FOUND));
     }
 
     #[test]

--- a/src-tauri/src/services/cursor.rs
+++ b/src-tauri/src/services/cursor.rs
@@ -240,7 +240,14 @@ fn fallback_or_disconnected(error: impl Into<String>) -> CursorData {
     CursorData::disconnected(error)
 }
 
+fn should_persist_cursor_cache(data: &CursorData) -> bool {
+    data.connected
+}
+
 fn save_cursor_cache(data: &CursorData) {
+    if !should_persist_cursor_cache(data) {
+        return;
+    }
     if let Ok(mut guard) = cursor_cache().lock() {
         *guard = Some(CachedCursor {
             data: data.clone(),
@@ -642,6 +649,22 @@ mod tests {
                 Some("Cursor API returned no usage fields.")
             );
         }
+    }
+
+    #[test]
+    fn disconnected_payloads_are_not_persisted() {
+        let empty = parse_cursor_payload(&serde_json::json!({}));
+        assert!(!empty.connected);
+        assert!(!should_persist_cursor_cache(&empty));
+
+        let connected = parse_cursor_payload(&serde_json::json!({
+            "membershipType": "pro",
+            "individualUsage": {
+                "plan": { "totalPercentUsed": 12.0 }
+            }
+        }));
+        assert!(connected.connected);
+        assert!(should_persist_cursor_cache(&connected));
     }
 
     #[test]

--- a/src-tauri/src/services/grok.rs
+++ b/src-tauri/src/services/grok.rs
@@ -226,6 +226,28 @@ fn parse_products(value: &serde_json::Value) -> Vec<GrokProductUsage> {
         .collect()
 }
 
+fn product_usage_percents_complete(value: &serde_json::Value) -> bool {
+    value.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .all(|item| parse_percent(&item["usagePercent"]).is_some())
+    })
+}
+
+fn scale_used_pct(pool_pct: Option<f64>, products: &[GrokProductUsage]) -> Result<f64, String> {
+    let build = products
+        .iter()
+        .find(|product| product.product == "build")
+        .map(|product| product.usage_percent)
+        .filter(|pct| pct.is_finite() && *pct > 0.0);
+    if let Some(pct) = build {
+        return Ok(pct);
+    }
+    pool_pct
+        .filter(|pct| pct.is_finite() && *pct > 0.0)
+        .ok_or_else(|| "The official Grok pool usage is unavailable.".to_string())
+}
+
 fn period_from_config(
     config: &serde_json::Value,
 ) -> (
@@ -300,11 +322,13 @@ fn scale_observed_usage(
 
 fn estimate_grok_period_value(
     used_pct: Option<f64>,
+    products: Vec<GrokProductUsage>,
     started_at: Option<&str>,
     reset_at: Option<&str>,
 ) -> Result<GrokValueEstimate, String> {
-    let used_pct =
+    let display_pct =
         used_pct.ok_or_else(|| "The official Grok pool usage is unavailable.".to_string())?;
+    let scale_pct = scale_used_pct(used_pct, &products)?;
     let started = started_at
         .and_then(parse_rfc3339)
         .ok_or_else(|| "The official Grok period start is unavailable.".to_string())?;
@@ -318,12 +342,12 @@ fn estimate_grok_period_value(
     }
     let usage = grok_local::sum_period(started, observed_at)?;
     let (period_usd, period_tokens) =
-        scale_observed_usage(usage.observed_cost_usd, usage.observed_tokens, used_pct)?;
+        scale_observed_usage(usage.observed_cost_usd, usage.observed_tokens, scale_pct)?;
     Ok(GrokValueEstimate {
         observed_at: observed_at.to_rfc3339(),
         window_started_at: started.to_rfc3339(),
         resets_at: resets.to_rfc3339(),
-        used_pct,
+        used_pct: display_pct,
         observed_cost_usd: usage.observed_cost_usd,
         estimated_period_value_usd: period_usd,
         observed_tokens: usage.observed_tokens,
@@ -340,7 +364,7 @@ fn parse_billing_payload(data: &serde_json::Value, email: Option<String>) -> Gro
 
     let products = parse_products(&config["productUsage"]);
     let percentage = parse_percent(&config["creditUsagePercent"]).or_else(|| {
-        if products.is_empty() {
+        if products.is_empty() || !product_usage_percents_complete(&config["productUsage"]) {
             None
         } else {
             Some(clamp_percent(
@@ -479,8 +503,14 @@ pub async fn fetch_grok_info() -> GrokData {
         let used_pct = result.percentage;
         let started_at = result.period_started_at.clone();
         let reset_at = result.reset_at.clone();
+        let products = result.products.clone();
         match tauri::async_runtime::spawn_blocking(move || {
-            estimate_grok_period_value(used_pct, started_at.as_deref(), reset_at.as_deref())
+            estimate_grok_period_value(
+                used_pct,
+                products,
+                started_at.as_deref(),
+                reset_at.as_deref(),
+            )
         })
         .await
         {
@@ -497,7 +527,8 @@ pub async fn fetch_grok_info() -> GrokData {
 
 #[cfg(test)]
 mod tests {
-    use super::{map_product, parse_billing_payload, pick_credential};
+    use super::{map_product, parse_billing_payload, pick_credential, scale_used_pct};
+    use crate::domain::models::GrokProductUsage;
     use serde_json::json;
 
     #[test]
@@ -580,6 +611,25 @@ mod tests {
     }
 
     #[test]
+    fn omitted_percent_does_not_sum_missing_product_fields() {
+        let payload = json!({
+            "config": {
+                "currentPeriod": {
+                    "type": "USAGE_PERIOD_TYPE_MONTHLY",
+                    "end": "2026-09-01T00:00:00Z"
+                },
+                "productUsage": [
+                    {"product": "PRODUCT_GROK_BUILD", "usagePercent": 12.5},
+                    {"product": "PRODUCT_GROK_CHAT"}
+                ]
+            }
+        });
+        let data = parse_billing_payload(&payload, None);
+        assert_eq!(data.percentage, None);
+        assert_eq!(data.products[1].usage_percent, 0.0);
+    }
+
+    #[test]
     fn extra_credits_surface_when_nonzero() {
         let payload = json!({
             "config": {
@@ -627,6 +677,24 @@ mod tests {
     }
 
     #[test]
+    fn scale_used_pct_prefers_build_share() {
+        let products = vec![
+            GrokProductUsage {
+                product: "build".to_string(),
+                label: "Build".to_string(),
+                usage_percent: 4.0,
+            },
+            GrokProductUsage {
+                product: "chat".to_string(),
+                label: "Chat".to_string(),
+                usage_percent: 21.0,
+            },
+        ];
+        assert_eq!(scale_used_pct(Some(25.0), &products).unwrap(), 4.0);
+        assert_eq!(scale_used_pct(Some(25.0), &[]).unwrap(), 25.0);
+    }
+
+    #[test]
     fn scale_observed_usage_projects_from_official_used_percent() {
         let (usd, tokens) = super::scale_observed_usage(8.0, 2_000, 4.0).expect("scaled");
         assert_eq!(usd, 200.0);
@@ -641,9 +709,13 @@ mod tests {
 
     #[test]
     fn estimate_requires_period_start() {
-        let error =
-            super::estimate_grok_period_value(Some(4.0), None, Some("2026-08-30T15:25:10Z"))
-                .expect_err("missing start");
+        let error = super::estimate_grok_period_value(
+            Some(4.0),
+            Vec::new(),
+            None,
+            Some("2026-08-30T15:25:10Z"),
+        )
+        .expect_err("missing start");
         assert!(error.contains("period start"));
     }
 

--- a/src-tauri/src/services/http.rs
+++ b/src-tauri/src/services/http.rs
@@ -5,6 +5,7 @@
 //! combined with 4 services polling on independent timers used to push the
 //! per-process FD count uncomfortably close to the macOS 256 soft limit.
 
+use std::io::ErrorKind;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -27,34 +28,106 @@ pub fn shared_http_client() -> &'static reqwest::Client {
 }
 
 /// Recognize transient OS errors that should not surface to the UI:
-/// EMFILE (24), ENFILE (23), EAGAIN (35 on macOS, 11 on linux), EWOULDBLOCK.
+/// EMFILE, ENFILE, EAGAIN / EWOULDBLOCK.
 /// These typically clear themselves within one poll cycle as the kernel
 /// reclaims descriptors / restarts blocked syscalls.
 pub fn is_transient_os_error(message: &str) -> bool {
-    message.contains("os error 24")
-        || message.contains("os error 23")
-        || message.contains("os error 35")
-        || message.contains("os error 11")
-        || message.contains("Too many open files")
+    message.contains("Too many open files")
         || message.contains("Resource temporarily unavailable")
+        || parsed_os_error_code(message).is_some_and(is_transient_os_code)
+}
+
+/// Walk an error chain so reqwest/hyper wrappers still count as transient
+/// when the underlying IO error is EMFILE / EAGAIN.
+pub fn error_is_transient(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(error);
+    while let Some(err) = current {
+        if let Some(io_error) = err.downcast_ref::<std::io::Error>() {
+            if io_error_is_transient(io_error) {
+                return true;
+            }
+        }
+        if is_transient_os_error(&err.to_string()) {
+            return true;
+        }
+        current = err.source();
+    }
+    false
+}
+
+fn io_error_is_transient(error: &std::io::Error) -> bool {
+    matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::Interrupted)
+        || error.raw_os_error().is_some_and(is_transient_os_code)
+}
+
+fn parsed_os_error_code(message: &str) -> Option<i32> {
+    const MARKER: &str = "os error ";
+    let start = message.find(MARKER)? + MARKER.len();
+    let digits: String = message[start..]
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+fn is_transient_os_code(code: i32) -> bool {
+    #[cfg(unix)]
+    {
+        code == libc::EMFILE
+            || code == libc::ENFILE
+            || code == libc::EAGAIN
+            || code == libc::EWOULDBLOCK
+    }
+    #[cfg(not(unix))]
+    {
+        matches!(code, 11 | 23 | 24)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Error, ErrorKind};
 
     #[test]
     fn detects_emfile_messages() {
         assert!(is_transient_os_error(
             "Failed to read auth.json: Too many open files (os error 24)"
         ));
+        #[cfg(target_os = "macos")]
         assert!(is_transient_os_error("Network error: os error 35"));
+        #[cfg(target_os = "linux")]
+        assert!(is_transient_os_error("os error 11"));
     }
 
     #[test]
-    fn rejects_other_errors() {
+    fn rejects_other_errors_and_digit_prefixes() {
         assert!(!is_transient_os_error("API error: 429 Too Many Requests"));
         assert!(!is_transient_os_error("Token expired"));
-        assert!(!is_transient_os_error("Network error: os error 60")); // ETIMEDOUT
+        assert!(!is_transient_os_error("Network error: os error 60"));
+        assert!(!is_transient_os_error("Network error: os error 240"));
+        assert!(!is_transient_os_error("Network error: os error 230"));
+        #[cfg(all(unix, not(target_os = "macos")))]
+        assert!(!is_transient_os_error("os error 35"));
+    }
+
+    #[test]
+    fn walks_io_source_chain() {
+        assert!(io_error_is_transient(&Error::new(
+            ErrorKind::WouldBlock,
+            "blocked"
+        )));
+        assert!(!error_is_transient(&Error::new(
+            ErrorKind::TimedOut,
+            "timed out"
+        )));
+        #[cfg(unix)]
+        {
+            let io_error = Error::from_raw_os_error(libc::EMFILE);
+            assert!(error_is_transient(&io_error));
+        }
     }
 }

--- a/src-tauri/src/services/tray.rs
+++ b/src-tauri/src/services/tray.rs
@@ -504,7 +504,9 @@ pub async fn update_tray_icon(
     })
     .map_err(|e| e.to_string())?;
 
-    rx.recv()
+    tauri::async_runtime::spawn_blocking(move || rx.recv())
+        .await
+        .map_err(|_| "tray update task failed".to_string())?
         .map_err(|_| "failed to receive tray update result".to_string())?
 }
 

--- a/src-tauri/src/services/tray.rs
+++ b/src-tauri/src/services/tray.rs
@@ -536,6 +536,14 @@ pub async fn update_tray_icon(
                 return Err(format!("missing tray icon for {}", service.label()));
             };
 
+            let icon = Image::from_bytes(&tray_icon::generate_tray_icon(
+                service.icon_identity(),
+                percentage,
+                ICON_SIZE,
+                style,
+            ))
+            .map_err(|e| e.to_string())?;
+
             tray.set_icon(Some(icon)).map_err(|e| e.to_string())?;
             tray.set_icon_as_template(false)
                 .map_err(|e| e.to_string())?;

--- a/src-tauri/src/services/tray.rs
+++ b/src-tauri/src/services/tray.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 
 use super::tray_icon;
@@ -12,6 +13,23 @@ use tauri::{
 
 const ICON_SIZE: u32 = 44;
 const TRAY_SERVICE_ACTIVATED_EVENT: &str = "tray-service-activated";
+
+static IGNORE_NEXT_UNFOCUS: AtomicBool = AtomicBool::new(false);
+static TRAY_CLICK_WAS_VISIBLE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TrayClickAction {
+    Hide,
+    Show,
+}
+
+fn tray_click_action(was_visible: bool) -> TrayClickAction {
+    if was_visible {
+        TrayClickAction::Hide
+    } else {
+        TrayClickAction::Show
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct TraySnapshot {
@@ -267,6 +285,7 @@ fn position_window_near_tray(app: &AppHandle, tray: &tauri::tray::TrayIcon) {
 }
 
 fn toggle_main_window(app: &AppHandle) {
+    IGNORE_NEXT_UNFOCUS.store(true, Ordering::SeqCst);
     if let Some(window) = app.get_webview_window("main") {
         if window.is_visible().unwrap_or(false) {
             let _ = window.hide();
@@ -275,6 +294,15 @@ fn toggle_main_window(app: &AppHandle) {
             let _ = window.set_focus();
         }
     }
+}
+
+fn remember_tray_click_visibility(app: &AppHandle) {
+    let visible = app
+        .get_webview_window("main")
+        .and_then(|window| window.is_visible().ok())
+        .unwrap_or(false);
+    TRAY_CLICK_WAS_VISIBLE.store(visible, Ordering::SeqCst);
+    IGNORE_NEXT_UNFOCUS.store(true, Ordering::SeqCst);
 }
 
 #[cfg(target_os = "macos")]
@@ -348,28 +376,41 @@ fn build_service_tray(app: &AppHandle, service: TrayService) -> tauri::Result<()
             id if id == menu_service.quit_menu_id() => app.exit(0),
             _ => {}
         })
-        .on_tray_icon_event(move |tray, event| {
-            if let TrayIconEvent::Click {
+        .on_tray_icon_event(move |tray, event| match event {
+            TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Down,
+                ..
+            } => {
+                remember_tray_click_visibility(tray.app_handle());
+            }
+            TrayIconEvent::Click {
                 button: MouseButton::Left,
                 button_state: MouseButtonState::Up,
                 ..
-            } = event
-            {
+            } => {
                 let app = tray.app_handle();
                 emit_tray_service_activated(app, click_service);
+                let was_visible = TRAY_CLICK_WAS_VISIBLE.load(Ordering::SeqCst);
+                IGNORE_NEXT_UNFOCUS.store(false, Ordering::SeqCst);
                 match app.get_webview_window("main") {
-                    Some(window) => {
-                        position_window_near_tray(app, tray);
-                        let shown = window.show();
-                        let focused = window.set_focus();
-                        eprintln!(
-                            "[Tray] {} clicked: show={:?} focus={:?} pos={:?}",
-                            click_service.label(),
-                            shown,
-                            focused,
-                            window.outer_position()
-                        );
-                    }
+                    Some(window) => match tray_click_action(was_visible) {
+                        TrayClickAction::Hide => {
+                            let _ = window.hide();
+                        }
+                        TrayClickAction::Show => {
+                            position_window_near_tray(app, tray);
+                            let shown = window.show();
+                            let focused = window.set_focus();
+                            eprintln!(
+                                "[Tray] {} clicked: show={:?} focus={:?} pos={:?}",
+                                click_service.label(),
+                                shown,
+                                focused,
+                                window.outer_position()
+                            );
+                        }
+                    },
                     None => {
                         eprintln!(
                             "[Tray] {} clicked but main window is missing",
@@ -378,6 +419,7 @@ fn build_service_tray(app: &AppHandle, service: TrayService) -> tauri::Result<()
                     }
                 }
             }
+            _ => {}
         })
         .build(app)?;
 
@@ -396,6 +438,9 @@ pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
         let window_clone = window.clone();
         window.on_window_event(move |event| {
             if let tauri::WindowEvent::Focused(false) = event {
+                if IGNORE_NEXT_UNFOCUS.swap(false, Ordering::SeqCst) {
+                    return;
+                }
                 let _ = window_clone.hide();
             }
         });
@@ -510,7 +555,10 @@ pub async fn update_tray_icon(
 
 #[cfg(test)]
 mod tests {
-    use super::{format_tooltip, TrayRuntimeState, TrayService, TraySnapshot};
+    use super::{
+        format_tooltip, tray_click_action, TrayClickAction, TrayRuntimeState, TrayService,
+        TraySnapshot,
+    };
     use crate::services::tray_icon::TrayIconStyle;
 
     #[test]
@@ -560,6 +608,12 @@ mod tests {
 
         assert!(state.should_skip_update(TrayService::Claude, snapshot, false));
         assert!(!state.should_skip_update(TrayService::Claude, snapshot, true));
+    }
+
+    #[test]
+    fn tray_click_hides_when_the_popover_was_already_visible() {
+        assert_eq!(tray_click_action(true), TrayClickAction::Hide);
+        assert_eq!(tray_click_action(false), TrayClickAction::Show);
     }
 
     #[test]

--- a/src-tauri/src/services/tray.rs
+++ b/src-tauri/src/services/tray.rs
@@ -1,7 +1,6 @@
 use std::sync::{mpsc, Arc, Mutex};
 
 use super::tray_icon;
-use chrono::Local;
 use serde::{Deserialize, Serialize};
 use tauri::{
     image::Image,
@@ -467,26 +466,13 @@ pub async fn update_tray_icon(
                 return Err(format!("missing tray icon for {}", service.label()));
             };
 
-            let icon = Image::from_bytes(&tray_icon::generate_tray_icon(
-                service.icon_identity(),
-                percentage,
-                ICON_SIZE,
-                style,
-            ))
-            .map_err(|e| e.to_string())?;
-            let updated_at = Local::now().format("%H:%M:%S").to_string();
-
             tray.set_icon(Some(icon)).map_err(|e| e.to_string())?;
             tray.set_icon_as_template(false)
                 .map_err(|e| e.to_string())?;
             tray.set_title(Some(service.extra_title()))
                 .map_err(|e| e.to_string())?;
-            tray.set_tooltip(Some(format!(
-                "{}\nUpdated: {}",
-                format_tooltip(service, percentage),
-                updated_at
-            )))
-            .map_err(|e| e.to_string())?;
+            tray.set_tooltip(Some(format_tooltip(service, percentage)))
+                .map_err(|e| e.to_string())?;
             tray.set_visible(true).map_err(|e| e.to_string())?;
 
             {

--- a/src-tauri/src/services/tray.rs
+++ b/src-tauri/src/services/tray.rs
@@ -306,6 +306,24 @@ fn apply_status_item_autosave(app: AppHandle, tray_id: &'static str) {
     });
 }
 
+fn destroy_hidden_tray() -> bool {
+    !cfg!(target_os = "macos")
+}
+
+#[cfg(target_os = "macos")]
+fn set_status_item_collapsed(app: &AppHandle, tray_id: &str, collapsed: bool) {
+    let Some(tray) = app.tray_by_id(tray_id) else {
+        return;
+    };
+    let _ = tray.with_inner_tray_icon(move |inner| {
+        if let Some(item) = inner.ns_status_item() {
+            // NSVariableStatusItemLength == -1. Length 0 hides without destroying
+            // the extras-region item (set_visible(false) removes it on macOS 26).
+            item.setLength(if collapsed { 0.0 } else { -1.0 });
+        }
+    });
+}
+
 fn format_tooltip(service: TrayService, percentage: Option<u8>) -> String {
     match percentage {
         Some(value) => format!("{}: {}% used", service.label(), value),
@@ -447,7 +465,12 @@ pub async fn update_tray_icon(
             }
 
             if !visible {
-                let _ = app_handle.remove_tray_by_id(service.tray_id());
+                if destroy_hidden_tray() {
+                    let _ = app_handle.remove_tray_by_id(service.tray_id());
+                } else {
+                    #[cfg(target_os = "macos")]
+                    set_status_item_collapsed(&app_handle, service.tray_id(), true);
+                }
                 {
                     let mut state = runtime
                         .lock()
@@ -462,6 +485,8 @@ pub async fn update_tray_icon(
             if app_handle.tray_by_id(service.tray_id()).is_none() {
                 build_service_tray(&app_handle, service).map_err(|e| e.to_string())?;
             }
+            #[cfg(target_os = "macos")]
+            set_status_item_collapsed(&app_handle, service.tray_id(), false);
 
             let Some(tray) = app_handle.tray_by_id(service.tray_id()) else {
                 return Err(format!("missing tray icon for {}", service.label()));
@@ -510,7 +535,7 @@ pub async fn update_tray_icon(
 
 #[cfg(test)]
 mod tests {
-    use super::{format_tooltip, TrayRuntimeState, TrayService, TraySnapshot};
+    use super::{destroy_hidden_tray, format_tooltip, TrayRuntimeState, TrayService, TraySnapshot};
     use crate::services::tray_icon::TrayIconStyle;
 
     #[test]
@@ -560,6 +585,11 @@ mod tests {
 
         assert!(state.should_skip_update(TrayService::Claude, snapshot, false));
         assert!(!state.should_skip_update(TrayService::Claude, snapshot, true));
+    }
+
+    #[test]
+    fn macos_keeps_hidden_status_items_alive() {
+        assert_eq!(destroy_hidden_tray(), !cfg!(target_os = "macos"));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,6 @@ import './redesign-settings.css';
 
 import {
   AUTO_REFRESH_INTERVAL_MS,
-  BACKGROUND_REFRESH_INTERVAL_MS,
   TRAY_CYCLE_INTERVAL_MS,
   TRAY_FORCE_SYNC_INTERVAL_MS,
   TRAY_GUARD_MESSAGE,
@@ -76,6 +75,7 @@ import {
   getSavedTab,
   getSavedTheme,
   isMacOSPlatform,
+  providerRefreshIntervalMs,
   saveActiveTab,
   saveDockHidden,
   saveSettingsExpanded,
@@ -104,6 +104,7 @@ export {
   BACKGROUND_REFRESH_INTERVAL_MS,
   getClaudeRefreshIntervalMs,
   getClaudeTrayUsedPercent,
+  providerRefreshIntervalMs,
 } from './services/app_state';
 
 type ToastValue = string | null;
@@ -644,9 +645,6 @@ export default function App() {
     ...panelLoading,
     claude: claudeLoading,
   };
-  const nonClaudeRefreshIntervalMs = windowVisible
-    ? AUTO_REFRESH_INTERVAL_MS
-    : BACKGROUND_REFRESH_INTERVAL_MS;
   const { footerStatus, footerStatusTitle } = useFooterStatus(windowVisible, activeLoading, lastUpdatedAt);
   const providerSummaries = buildProviderSummaries(tabConnected, serviceLoading, serviceUsage);
   const switcherSummaries = providerSummaries.filter((summary) => switcherVisibility[summary.id]);
@@ -719,7 +717,7 @@ export default function App() {
                   onLoadingChange={loadingSetters.codex}
                   onQuotaWindowsChange={quotaWindowSetters.codex}
                   manualRefreshNonce={refreshNonces.codex}
-                  autoRefreshIntervalMs={nonClaudeRefreshIntervalMs}
+                  autoRefreshIntervalMs={providerRefreshIntervalMs(windowVisible, trayEnabled.codex)}
                   showCostSummary={windowVisible && activeView === 'codex'}
                   sections={panelSections}
                   onBonusExpiring={handleBonusExpiring}
@@ -733,7 +731,7 @@ export default function App() {
                   onLoadingChange={loadingSetters.cursor}
                   onQuotaWindowsChange={quotaWindowSetters.cursor}
                   manualRefreshNonce={refreshNonces.cursor}
-                  autoRefreshIntervalMs={nonClaudeRefreshIntervalMs}
+                  autoRefreshIntervalMs={providerRefreshIntervalMs(windowVisible, trayEnabled.cursor)}
                   showCostSummary={windowVisible && activeView === 'cursor'}
                   sections={panelSections}
                 />
@@ -746,7 +744,7 @@ export default function App() {
                   onLoadingChange={loadingSetters.grok}
                   onQuotaWindowsChange={quotaWindowSetters.grok}
                   manualRefreshNonce={refreshNonces.grok}
-                  autoRefreshIntervalMs={nonClaudeRefreshIntervalMs}
+                  autoRefreshIntervalMs={providerRefreshIntervalMs(windowVisible, trayEnabled.grok)}
                   sections={panelSections}
                 />
               </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ import {
   defaultServiceMap,
   getClaudeRefreshIntervalMs,
   getClaudeTrayUsedPercent,
+  keepClaudeQuotaOnError,
   getInitialTrayEnabledState,
   getSavedDockHidden,
   getSavedSettingsExpanded,
@@ -104,6 +105,7 @@ export {
   BACKGROUND_REFRESH_INTERVAL_MS,
   getClaudeRefreshIntervalMs,
   getClaudeTrayUsedPercent,
+  keepClaudeQuotaOnError,
 } from './services/app_state';
 
 type ToastValue = string | null;
@@ -287,7 +289,11 @@ export default function App() {
 
       if (data.error) {
         setClaudeError(data.error);
-        if (!data.error.includes('429')) {
+        if (keepClaudeQuotaOnError(data)) {
+          if (data.connected) {
+            setQuota(data);
+          }
+        } else {
           setQuota(null);
         }
         claudeIntervalRef.current = getClaudeRefreshIntervalMs(data.error);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import {
   saveTrayStyle,
   type TrayStyle,
 } from './services/tray_style';
-import { getSavedEvents, recordEvent, type AppEvent, type EventLevel } from './services/event_log';
+import { appendEvent, getSavedEvents, persistEvents, type AppEvent, type EventLevel } from './services/event_log';
 import {
   getSavedSwitcherVisibility,
   saveSwitcherVisibility,
@@ -156,6 +156,7 @@ export default function App() {
   const [trayEnabled, setTrayEnabled] = useState<TrayEnabledState>(getInitialTrayEnabledState);
   const [toast, setToastState] = useState<ToastValue>(null);
   const switcherGuardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timedToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const setToast = useCallback<ToastSetter>((value) => {
     setToastState((current) => {
       const next = typeof value === 'function' ? value(current) : value;
@@ -229,10 +230,20 @@ export default function App() {
     return setters;
   }, []);
 
+  const showTimedToast = useCallback((message: string, delayMs = TRAY_GUARD_TOAST_MS) => {
+    if (timedToastTimerRef.current !== null) {
+      clearTimeout(timedToastTimerRef.current);
+    }
+    setToast(message);
+    timedToastTimerRef.current = setTimeout(() => {
+      timedToastTimerRef.current = null;
+      setToast((current) => current === message ? null : current);
+    }, delayMs);
+  }, [setToast]);
+
   const showStorageWriteFailure = useCallback(() => {
-    setToast(STORAGE_WRITE_FAILURE_MESSAGE);
-    setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS);
-  }, []);
+    showTimedToast(STORAGE_WRITE_FAILURE_MESSAGE);
+  }, [showTimedToast]);
 
   useEffect(() => {
     return subscribeStorageWriteFailures(showStorageWriteFailure);
@@ -367,8 +378,14 @@ export default function App() {
   }, [trayCycle]);
 
   const logEvent = useCallback((level: EventLevel, text: string) => {
-    setEvents((prev) => recordEvent(prev, level, text));
+    const now = Date.now();
+    const id = `${now}-${Math.random().toString(36).slice(2, 8)}`;
+    setEvents((prev) => appendEvent(prev, level, text, now, id));
   }, []);
+
+  useEffect(() => {
+    persistEvents(events);
+  }, [events]);
 
   useServiceEvents(quota, connected, usedPercent, notifSettings, logEvent);
 
@@ -387,6 +404,10 @@ export default function App() {
     if (switcherGuardTimerRef.current !== null) {
       clearTimeout(switcherGuardTimerRef.current);
       switcherGuardTimerRef.current = null;
+    }
+    if (timedToastTimerRef.current !== null) {
+      clearTimeout(timedToastTimerRef.current);
+      timedToastTimerRef.current = null;
     }
   }, []);
 
@@ -409,12 +430,10 @@ export default function App() {
   }, [activeView, switcherVisibility, setAndPersistTab]);
 
   const handleNotificationToggle = useCallback((key: NotificationKey) => {
-    setNotifSettings((prev) => {
-      const next = { ...prev, [key]: !prev[key] };
-      saveNotificationSettings(next);
-      return next;
-    });
-  }, []);
+    const next = { ...notifSettings, [key]: !notifSettings[key] };
+    saveNotificationSettings(next);
+    setNotifSettings(next);
+  }, [notifSettings]);
 
   const handleBonusExpiring = useCallback((daysLeft: number) => {
     const text = daysLeft <= 0
@@ -432,13 +451,11 @@ export default function App() {
   }, []);
 
   const handleTrayCycleToggle = useCallback(() => {
-    setTrayCycle((prev) => {
-      const next = !prev;
-      saveTrayCycle(next);
-      return next;
-    });
+    const next = !trayCycle;
+    saveTrayCycle(next);
+    setTrayCycle(next);
     setTrayCycleIndex(0);
-  }, []);
+  }, [trayCycle]);
 
   const handleThemeChange = useCallback((newTheme: ThemeName) => {
     setTheme(newTheme);
@@ -452,49 +469,34 @@ export default function App() {
   }, [dockHidden]);
 
   const handleDockToggle = useCallback(() => {
-    setDockHidden((prev) => {
-      const newValue = !prev;
-      saveDockHidden(newValue);
-      return newValue;
-    });
-  }, []);
+    const newValue = !dockHidden;
+    saveDockHidden(newValue);
+    setDockHidden(newValue);
+  }, [dockHidden]);
 
   const showTrayGuardToast = useCallback(() => {
-    setToast(TRAY_GUARD_MESSAGE);
-    setTimeout(() => setToast(null), TRAY_GUARD_TOAST_MS);
-  }, []);
+    showTimedToast(TRAY_GUARD_MESSAGE);
+  }, [showTimedToast]);
 
   const handleTrayToggle = useCallback((service: TrayServiceName) => {
-    let blocked = false;
-
-    setTrayEnabled((prev) => {
-      const nextValue = !prev[service];
-      const someOtherEnabled = SERVICES.some((other) => other !== service && prev[other]);
-
-      if (!nextValue && !someOtherEnabled) {
-        blocked = true;
-        return prev;
-      }
-
-      saveTrayEnabled(service, nextValue);
-      return {
-        ...prev,
-        [service]: nextValue,
-      };
-    });
-
-    if (blocked) {
+    const nextValue = !trayEnabled[service];
+    const someOtherEnabled = SERVICES.some((other) => other !== service && trayEnabled[other]);
+    if (!nextValue && !someOtherEnabled) {
       showTrayGuardToast();
+      return;
     }
-  }, [showTrayGuardToast]);
+    saveTrayEnabled(service, nextValue);
+    setTrayEnabled((prev) => ({
+      ...prev,
+      [service]: nextValue,
+    }));
+  }, [showTrayGuardToast, trayEnabled]);
 
   const handlePanelSectionToggle = useCallback((key: PanelSectionKey) => {
-    setPanelSections((prev) => {
-      const next = { ...prev, [key]: !prev[key] };
-      savePanelSections(next);
-      return next;
-    });
-  }, []);
+    const next = { ...panelSections, [key]: !panelSections[key] };
+    savePanelSections(next);
+    setPanelSections(next);
+  }, [panelSections]);
 
   const handleTabChange = useCallback((tab: TabName) => {
     setAndPersistTab(tab);
@@ -575,18 +577,15 @@ export default function App() {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to open dashboard';
-      setToast(message);
-      setTimeout(() => setToast(null), 2000);
+      showTimedToast(message);
     }
-  }, [activeProvider]);
+  }, [activeProvider, showTimedToast]);
 
   const handleSettingsViewToggle = useCallback(() => {
-    setActiveView((prev) => {
-      const opening = prev !== 'settings';
-      saveSettingsExpanded(opening);
-      return opening ? 'settings' : getSavedTab();
-    });
-  }, []);
+    const opening = activeView !== 'settings';
+    saveSettingsExpanded(opening);
+    setActiveView(opening ? 'settings' : getSavedTab());
+  }, [activeView]);
 
   const handleCloseSettings = useCallback(() => {
     saveSettingsExpanded(false);

--- a/src/components/GrokPanel.tsx
+++ b/src/components/GrokPanel.tsx
@@ -3,12 +3,13 @@ import { backend } from '../services/backend';
 import ProviderDetailHeader from './ProviderDetailHeader';
 import ResetTimeline from './ResetTimeline';
 import SmartTip from './SmartTip';
-import type { GrokData, GrokValueEstimate } from '../types/models';
+import type { GrokData } from '../types/models';
 import { buildGrokQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
 import { getHighUsageTip } from '../services/detail_helpers';
 import { formatResetTime, getProgressStyle } from '../utils/quota_format';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
 import { useLatestRequestGeneration } from '../hooks/use_latest_request_generation';
+import { validateGrokValueEstimate } from '../services/grok_value_estimate';
 
 interface GrokPanelProps {
   onConnectionChange?: (connected: boolean) => void;
@@ -44,55 +45,6 @@ function periodValueTitle(periodType?: string): string {
   if (periodType === 'monthly') return 'API-equivalent month';
   if (periodType === 'weekly') return 'API-equivalent week';
   return 'API-equivalent period';
-}
-
-function validateGrokValueEstimate(
-  estimate: GrokValueEstimate,
-  data: GrokData,
-): string | null {
-  if (
-    !Number.isFinite(estimate.observedCostUsd)
-    || estimate.observedCostUsd <= 0
-    || !Number.isFinite(estimate.estimatedPeriodValueUsd)
-    || estimate.estimatedPeriodValueUsd <= 0
-    || !Number.isFinite(estimate.observedTokens)
-    || estimate.observedTokens <= 0
-    || !Number.isFinite(estimate.estimatedPeriodTokens)
-    || estimate.estimatedPeriodTokens <= 0
-  ) {
-    return 'The local Grok pool estimate contains invalid totals.';
-  }
-  if (data.percentage == null || Math.abs(estimate.usedPct - data.percentage) > 5) {
-    return 'The local Grok pool estimate does not match the official usage.';
-  }
-  const estimateObservedAt = Date.parse(estimate.observedAt);
-  const now = Date.now();
-  if (
-    !Number.isFinite(estimateObservedAt)
-    || estimateObservedAt > now + 5 * 60 * 1000
-    || now - estimateObservedAt > 10 * 60 * 1000
-  ) {
-    return 'The local Grok pool estimate is stale or has an invalid observation time.';
-  }
-  const estimateReset = Date.parse(estimate.resetsAt);
-  const officialReset = data.resetAt ? Date.parse(data.resetAt) : Number.NaN;
-  if (
-    !Number.isFinite(estimateReset)
-    || !Number.isFinite(officialReset)
-    || Math.abs(estimateReset - officialReset) > 5 * 60 * 1000
-  ) {
-    return 'The local Grok pool estimate does not match the official reset.';
-  }
-  const estimateStart = Date.parse(estimate.windowStartedAt);
-  const officialStart = data.periodStartedAt ? Date.parse(data.periodStartedAt) : Number.NaN;
-  if (
-    !Number.isFinite(estimateStart)
-    || !Number.isFinite(officialStart)
-    || Math.abs(estimateStart - officialStart) > 5 * 60 * 1000
-  ) {
-    return 'The local Grok pool estimate does not match the official period start.';
-  }
-  return null;
 }
 
 export default function GrokPanel({
@@ -171,7 +123,7 @@ export default function GrokPanel({
     ? formatResetTime(grokData.resetAt, { expiredLabel: 'soon' })
     : '';
   const grokValueValidationError = grokData && grokData.valueEstimate
-    ? validateGrokValueEstimate(grokData.valueEstimate, grokData)
+    ? validateGrokValueEstimate(grokData.valueEstimate)
     : null;
   const displayedGrokValueEstimate = grokValueValidationError
     ? null

--- a/src/services/app_state.ts
+++ b/src/services/app_state.ts
@@ -180,3 +180,7 @@ export function getClaudeRefreshIntervalMs(error?: string | null): number {
 
   return AUTO_REFRESH_INTERVAL_MS;
 }
+
+export function keepClaudeQuotaOnError(data: QuotaData): boolean {
+  return data.connected || (data.error?.includes('429') ?? false);
+}

--- a/src/services/app_state.ts
+++ b/src/services/app_state.ts
@@ -180,3 +180,10 @@ export function getClaudeRefreshIntervalMs(error?: string | null): number {
 
   return AUTO_REFRESH_INTERVAL_MS;
 }
+
+export function providerRefreshIntervalMs(windowVisible: boolean, trayEnabled: boolean): number {
+  if (windowVisible || trayEnabled) {
+    return AUTO_REFRESH_INTERVAL_MS;
+  }
+  return BACKGROUND_REFRESH_INTERVAL_MS;
+}

--- a/src/services/event_log.ts
+++ b/src/services/event_log.ts
@@ -39,32 +39,46 @@ function isAppEvent(value: unknown): value is AppEvent {
 /**
  * Prepends an event and returns the updated list (newest first).
  * Repeats of the same text inside the dedupe window are dropped.
+ * This function is pure: persist separately with `persistEvents`.
  */
-export function recordEvent(
+export function appendEvent(
   events: AppEvent[],
   level: EventLevel,
   text: string,
   now: number = Date.now(),
+  id: string = `${now}-${Math.random().toString(36).slice(2, 8)}`,
 ): AppEvent[] {
   const duplicate = events.find(
     (event) => event.text === text && now - Date.parse(event.time) < DEDUPE_WINDOW_MS,
   );
   if (duplicate) return events;
 
-  const next = [
+  return [
     {
-      id: `${now}-${Math.random().toString(36).slice(2, 8)}`,
+      id,
       time: new Date(now).toISOString(),
       level,
       text,
     },
     ...events,
   ].slice(0, MAX_EVENTS);
+}
 
-  writeStorageItem(STORAGE_KEY, JSON.stringify(next), {
+export function persistEvents(events: AppEvent[]): boolean {
+  return writeStorageItem(STORAGE_KEY, JSON.stringify(events), {
     preserveSessionValue: true,
     notifyUser: false,
   });
+}
+
+export function recordEvent(
+  events: AppEvent[],
+  level: EventLevel,
+  text: string,
+  now: number = Date.now(),
+): AppEvent[] {
+  const next = appendEvent(events, level, text, now);
+  persistEvents(next);
   return next;
 }
 

--- a/src/services/grok_value_estimate.ts
+++ b/src/services/grok_value_estimate.ts
@@ -1,0 +1,33 @@
+import type { GrokValueEstimate } from '../types/models';
+
+const STALE_AFTER_MS = 10 * 60 * 1000;
+const FUTURE_SKEW_MS = 5 * 60 * 1000;
+
+export function validateGrokValueEstimate(
+  estimate: GrokValueEstimate,
+  now: number = Date.now(),
+): string | null {
+  if (
+    !Number.isFinite(estimate.observedCostUsd)
+    || estimate.observedCostUsd <= 0
+    || !Number.isFinite(estimate.estimatedPeriodValueUsd)
+    || estimate.estimatedPeriodValueUsd <= 0
+    || !Number.isFinite(estimate.observedTokens)
+    || estimate.observedTokens <= 0
+    || !Number.isFinite(estimate.estimatedPeriodTokens)
+    || estimate.estimatedPeriodTokens <= 0
+  ) {
+    return 'The local Grok pool estimate contains invalid totals.';
+  }
+
+  const estimateObservedAt = Date.parse(estimate.observedAt);
+  if (
+    !Number.isFinite(estimateObservedAt)
+    || estimateObservedAt > now + FUTURE_SKEW_MS
+    || now - estimateObservedAt > STALE_AFTER_MS
+  ) {
+    return 'The local Grok pool estimate is stale or has an invalid observation time.';
+  }
+
+  return null;
+}

--- a/tests/claude_tray_percent.test.ts
+++ b/tests/claude_tray_percent.test.ts
@@ -5,6 +5,7 @@ import {
   BACKOFF_REFRESH_INTERVAL_MS,
   getClaudeRefreshIntervalMs,
   getClaudeTrayUsedPercent,
+  keepClaudeQuotaOnError,
 } from '../src/App';
 import type { QuotaData, UsageInfo } from '../src/types/models';
 
@@ -73,5 +74,28 @@ describe('getClaudeRefreshIntervalMs', () => {
       'Claude OAuth token expired or invalid. Please re-login to Claude Code, then click Refresh.',
     )).toBe(AUTH_REFRESH_INTERVAL_MS);
     expect(getClaudeRefreshIntervalMs('API error: 401 Unauthorized')).toBe(AUTH_REFRESH_INTERVAL_MS);
+  });
+});
+
+describe('keepClaudeQuotaOnError', () => {
+  test('keeps connected stale snapshots even when an error is present', () => {
+    expect(keepClaudeQuotaOnError({
+      connected: true,
+      error: 'Network error: connection reset',
+    })).toBe(true);
+  });
+
+  test('keeps prior quota for 429 even when disconnected', () => {
+    expect(keepClaudeQuotaOnError({
+      connected: false,
+      error: 'API error: 429 Too Many Requests',
+    })).toBe(true);
+  });
+
+  test('clears quota for disconnected non-429 errors', () => {
+    expect(keepClaudeQuotaOnError({
+      connected: false,
+      error: 'API error: 401 Unauthorized',
+    })).toBe(false);
   });
 });

--- a/tests/grok_value_estimate.test.ts
+++ b/tests/grok_value_estimate.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+import { validateGrokValueEstimate } from '../src/services/grok_value_estimate';
+import type { GrokValueEstimate } from '../src/types/models';
+
+const NOW = Date.parse('2026-09-04T07:00:00Z');
+
+function estimate(overrides: Partial<GrokValueEstimate> = {}): GrokValueEstimate {
+  return {
+    observedAt: new Date(NOW - 60_000).toISOString(),
+    windowStartedAt: '2026-08-23T15:25:10.879Z',
+    resetsAt: '2026-08-30T15:25:10.879Z',
+    usedPct: 40,
+    observedCostUsd: 12.5,
+    estimatedPeriodValueUsd: 31.25,
+    observedTokens: 1000,
+    estimatedPeriodTokens: 2500,
+    ...overrides,
+  };
+}
+
+describe('validateGrokValueEstimate', () => {
+  test('accepts a finite in-window estimate', () => {
+    expect(validateGrokValueEstimate(estimate(), NOW)).toBeNull();
+  });
+
+  test('rejects invalid totals', () => {
+    expect(validateGrokValueEstimate(estimate({ observedCostUsd: 0 }), NOW))
+      .toContain('invalid totals');
+  });
+
+  test('rejects stale observation times', () => {
+    expect(validateGrokValueEstimate(
+      estimate({ observedAt: new Date(NOW - 11 * 60 * 1000).toISOString() }),
+      NOW,
+    )).toContain('stale');
+  });
+
+  test('does not compare copied official usedPct or reset fields', () => {
+    expect(validateGrokValueEstimate(estimate({
+      usedPct: 4,
+      resetsAt: '2099-01-01T00:00:00Z',
+      windowStartedAt: '1999-01-01T00:00:00Z',
+    }), NOW)).toBeNull();
+  });
+});

--- a/tests/provider_refresh_interval.test.ts
+++ b/tests/provider_refresh_interval.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import {
+  AUTO_REFRESH_INTERVAL_MS,
+  BACKGROUND_REFRESH_INTERVAL_MS,
+  providerRefreshIntervalMs,
+} from '../src/services/app_state';
+
+describe('providerRefreshIntervalMs', () => {
+  test('keeps tray-backed providers on the live poll while the popover is hidden', () => {
+    expect(providerRefreshIntervalMs(false, true)).toBe(AUTO_REFRESH_INTERVAL_MS);
+  });
+
+  test('slows down only when the popover and tray are both hidden', () => {
+    expect(providerRefreshIntervalMs(false, false)).toBe(BACKGROUND_REFRESH_INTERVAL_MS);
+  });
+
+  test('uses the live poll while the popover is visible', () => {
+    expect(providerRefreshIntervalMs(true, false)).toBe(AUTO_REFRESH_INTERVAL_MS);
+  });
+});

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -688,7 +688,7 @@ describe('Grok period value', () => {
     await unmount(renderer);
   });
 
-  it('rejects a Grok pool estimate that does not match official usage', async () => {
+  it('still shows a Grok pool estimate when usedPct differs from official usage', async () => {
     const renderer = await render_grok({
       connected: true,
       percentage: 4,
@@ -707,12 +707,13 @@ describe('Grok period value', () => {
       },
     });
 
-    expect(rendered_text(renderer)).toContain('does not match the official usage');
-    expect(rendered_text(renderer)).not.toContain('API-equivalent week');
+    expect(rendered_text(renderer)).toContain('API-equivalent period');
+    expect(rendered_text(renderer)).toContain('$8.00');
+    expect(rendered_text(renderer)).not.toContain('does not match the official usage');
     await unmount(renderer);
   });
 
-  it('rejects a Grok pool estimate from a different official period', async () => {
+  it('still shows a Grok pool estimate when copied period fields differ', async () => {
     const renderer = await render_grok({
       connected: true,
       percentage: 4,
@@ -731,8 +732,9 @@ describe('Grok period value', () => {
       },
     });
 
-    expect(rendered_text(renderer)).toContain('does not match the official period start');
-    expect(rendered_text(renderer)).not.toContain('API-equivalent period');
+    expect(rendered_text(renderer)).toContain('API-equivalent period');
+    expect(rendered_text(renderer)).toContain('$200.00');
+    expect(rendered_text(renderer)).not.toContain('does not match the official period start');
     await unmount(renderer);
   });
 });


### PR DESCRIPTION
## Summary

- Merge the 14 independent bugfix PRs in the overlapping-file order, resolving CHANGELOG / `app_state.ts` / test-module unions along the way.
- Restore tray PNG generation that PR #124 accidentally deleted with the fake `Updated` tooltip stamp.
- Stop panel tests from expecting Grok estimate rejection on copied official `usedPct` / period fields after PR #126.

Fixes #100
Fixes #101
Fixes #102
Fixes #103
Fixes #104
Fixes #105
Fixes #106
Fixes #107
Fixes #108
Fixes #109
Fixes #110
Fixes #111
Fixes #112
Fixes #113

Merge order: #117 → #116 → #118 → #119 → #114 → #124 → #125 → #127 → #115 → #121 → #122 → #123 → #120 → #126

This PR is a merge commit (not squash) so the original fix commits stay on `main` and the individual PRs can close as merged.

## Test plan

- [x] `npm test` (425 passed)
- [x] `cd src-tauri && cargo test` (94 passed)
- [ ] Confirm GitHub marks PRs #114–#127 merged after this lands
- [ ] Local Grok WIP (`refs/backup/grok-wip` / `stash@{0}`) is restored after merge, not included here


Made with [Cursor](https://cursor.com)