### PR TITLE
fix(cursor): show Cursor Models usage on the tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Drive the Cursor tray from the Cursor Models pool instead of the highest dashboard bar.
 - Stop caching disconnected Cursor payloads so a transient empty body cannot pin "not connected" for 120s.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.
 - Keep last-good Cursor usage across 5xx and 429 responses instead of flashing disconnected.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ This `v0.4.0` screenshot was refreshed on 2026-08-31 from the production React U
   - prefers `secondary_window.used_percent`
   - falls back to `primary_window.used_percent`
 - Cursor tray value:
-  - uses Cursor quota percentage when available
+  - prefers Cursor Models (`autoPercent`)
+  - falls back to the overall Cursor quota percentage
 - Grok tray value:
   - uses the shared SuperGrok credits pool percent (`creditUsagePercent`)
 - Antigravity tray value:

--- a/src/components/CursorPanel.tsx
+++ b/src/components/CursorPanel.tsx
@@ -6,7 +6,7 @@ import ProviderDetailHeader from './ProviderDetailHeader';
 import ResetTimeline from './ResetTimeline';
 import SmartTip from './SmartTip';
 import type { CursorData } from '../types/models';
-import { buildCursorQuotaWindows, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
+import { buildCursorQuotaWindows, getCursorTrayUsedPercent, sortMostConstrained, type QuotaWindowSummary } from '../services/provider_summary';
 import { getHighUsageTip } from '../services/detail_helpers';
 import { clampProgressValue, formatPlanType, getProgressStyle } from '../utils/quota_format';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
@@ -86,7 +86,7 @@ export default function CursorPanel({
         setError(data.error);
       }
       onConnectionChange?.(data.connected);
-      onUsageChange?.(data.percentage ?? null);
+      onUsageChange?.(getCursorTrayUsedPercent(data));
       onQuotaWindowsChange?.(buildCursorQuotaWindows(data));
     } catch (err) {
       if (!request_generation.isCurrent(generation)) return;

--- a/src/services/provider_summary.ts
+++ b/src/services/provider_summary.ts
@@ -168,6 +168,13 @@ export function buildCursorQuotaWindows(cursorData: CursorData | null): QuotaWin
   }];
 }
 
+export function getCursorTrayUsedPercent(cursorData: CursorData | null): number | null {
+  if (!cursorData) return null;
+  if (typeof cursorData.autoPercent === 'number') return cursorData.autoPercent;
+  if (typeof cursorData.percentage === 'number') return cursorData.percentage;
+  return null;
+}
+
 export function buildGrokQuotaWindows(grokData: GrokData | null): QuotaWindowSummary[] {
   if (!grokData?.connected || typeof grokData.percentage !== 'number') return [];
   const windows: QuotaWindowSummary[] = [{

--- a/tests/panel_status_ui.test.tsx
+++ b/tests/panel_status_ui.test.tsx
@@ -414,6 +414,29 @@ describe('provider status UI', () => {
     await act(async () => renderer.unmount());
   });
 
+  it('reports Cursor Models usage to the tray instead of Other Models', async () => {
+    vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({
+      connected: true,
+      autoPercent: 17,
+      apiPercent: 100,
+      percentage: 100,
+    });
+    const onUsageChange = vi.fn();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CursorPanel, {
+        autoRefreshIntervalMs: 0,
+        showCostSummary: false,
+        sections: hiddenSections,
+        onUsageChange,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(onUsageChange).toHaveBeenCalledWith(17);
+    await act(async () => renderer.unmount());
+  });
+
   it('formats enabled Cursor on-demand usage as US dollars', async () => {
     vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({
       connected: true,

--- a/tests/provider_summary.test.ts
+++ b/tests/provider_summary.test.ts
@@ -4,6 +4,7 @@ import {
   buildClaudeQuotaWindows,
   buildCursorQuotaWindows,
   buildGrokQuotaWindows,
+  getCursorTrayUsedPercent,
   sortMostConstrained,
   sortUpcomingResets,
 } from '../src/services/provider_summary';
@@ -68,6 +69,23 @@ describe('provider summary helpers', () => {
       ['Cursor Models', 3],
       ['Other Models', 91],
     ]);
+  });
+
+  test('drives the Cursor tray from Cursor Models, not Other Models', () => {
+    expect(getCursorTrayUsedPercent({
+      connected: true,
+      percentage: 100,
+      autoPercent: 17,
+      apiPercent: 100,
+    })).toBe(17);
+  });
+
+  test('falls back to overall Cursor percentage when Cursor Models is missing', () => {
+    expect(getCursorTrayUsedPercent({
+      connected: true,
+      percentage: 46.2,
+    })).toBe(46.2);
+    expect(getCursorTrayUsedPercent(null)).toBeNull();
   });
 
   test('uses a neutral label for summary fallback usage', () => {


### PR DESCRIPTION
## Summary

- Drive the Cursor tray icon from the Cursor Models pool (`autoPercent`) instead of the highest of the two dashboard bars.
- Keep the panel labels unchanged: Cursor Models and Other Models still show separately.
- Fall back to the overall Cursor percentage when Cursor Models is missing.

## Test plan

- [x] `npx vitest run tests/provider_summary.test.ts tests/panel_status_ui.test.tsx`
- [ ] Open the Cursor panel and confirm Other Models can still read 100% while the Cursor tray shows Cursor Models (e.g. 17%).
- [ ] `npm test`
- [ ] `npm run build`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.


Made with [Cursor](https://cursor.com)