### PR TITLE
feat(settings): add Launch at Login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Add a Settings Launch at Login toggle backed by the OS login item.
 - Drive the Cursor tray from the Cursor Models pool instead of the highest dashboard bar.
 - Stop caching disconnected Cursor payloads so a transient empty body cannot pin "not connected" for 120s.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Website: https://majiayu000.github.io/quotabar/
 - Local cost tracking: today, week, and month estimates for Claude Code, Codex, and Cursor.
 - Per-provider tray icons: independent menu bar indicators for supported providers.
 - Tray controls: enable or hide each tray while keeping at least one entry point.
-- Settings view: theme, macOS Hide Dock, and per-provider tray controls keep their existing storage keys.
+- Settings view: theme, macOS Hide Dock, Launch at Login, and per-provider tray controls. Launch at Login uses the OS login item rather than a local storage key.
 - Background polling: refreshes every 60 seconds, backs off to 5 minutes on 429, and backs off to 1 hour on Claude auth failures.
 - Read-only Claude OAuth: reads Claude Code credentials from the correct source, but never refreshes or writes OAuth tokens.
 - Read-only Grok auth: reads `~/.grok/auth.json`, but never refreshes or writes tokens.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.1",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",
+        "@tauri-apps/plugin-autostart": "2.5.1",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "2.5.3",
         "react": "^19.1.0",
@@ -1400,6 +1401,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-autostart": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-autostart/-/plugin-autostart-2.5.1.tgz",
+      "integrity": "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-notification": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "2.10.1",
+    "@tauri-apps/plugin-autostart": "2.5.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "2.5.3",
     "react": "^19.1.0",

--- a/specs/GH96/product.md
+++ b/specs/GH96/product.md
@@ -1,0 +1,33 @@
+# GH-96 Product Spec: Launch QuotaBar at login
+
+Linked issue: https://github.com/majiayu000/quotabar/issues/96
+
+## Goals
+
+- Add a Launch at Login toggle under Settings → Activity & system.
+- Persist the choice in the OS login item via `tauri-plugin-autostart`, not a new `claude-quota-*` key.
+- Fail closed and visibly if status cannot be read or the login item cannot be registered.
+
+## Non-Goals
+
+- Independent Settings window.
+- Refresh-interval / Adaptive polling controls.
+- Auto-enabling login on first launch without an explicit toggle.
+- Changing Hide Dock, tray guards, or notification keys.
+
+## Behavior Invariants
+
+1. `B-001` Settings shows Launch at Login in Activity & system on every desktop platform. The switch reflects the plugin/OS login item, not localStorage.
+2. `B-002` First launch does not register a login item. The toggle starts from `isEnabled()`.
+3. `B-003` A successful toggle calls enable/disable, then re-reads `isEnabled()`. The switch only moves when that re-read matches the requested state.
+4. `B-004` Permission, plugin, or registration failure leaves the previous switch value, shows the fixed error copy in Settings, and surfaces the same copy as a toast. User-visible text never includes OS error strings, paths, or tokens.
+5. `B-005` Browser preview (`hasTauriBackend() === false`) keeps the switch off and does not show a status-read error. A preview toggle still fail-closes with the update error.
+6. `B-006` Hide Dock stays macOS-only. Launch at Login does not add a storage key or change existing settings keys.
+
+## Acceptance Criteria
+
+- Activity & system contains Launch at Login above Hide Dock.
+- Enabling and disabling round-trip through the autostart plugin.
+- Failed reads render the switch off with visible copy.
+- Failed writes do not flip the switch.
+- `npx tsc --noEmit`, `npm test`, and `cargo check --manifest-path src-tauri/Cargo.toml` pass.

--- a/specs/GH96/tasks.md
+++ b/specs/GH96/tasks.md
@@ -1,0 +1,5 @@
+# GH-96 Tasks: Launch QuotaBar at login
+
+- [x] `SP96-T1` Add autostart plugin, capabilities, and typed frontend adapter.
+- [x] `SP96-T2` Render Launch at Login in Activity & system; fail closed with toast + inline copy.
+- [x] `SP96-T3` Tests for plugin success, backend-unavailable, read/write failure, and switch fail-closed.

--- a/specs/GH96/tech.md
+++ b/specs/GH96/tech.md
@@ -1,0 +1,34 @@
+# GH-96 Tech Spec: Launch QuotaBar at login
+
+Linked issue: https://github.com/majiayu000/quotabar/issues/96
+
+## Approach
+
+Register `tauri-plugin-autostart` with `MacosLauncher::LaunchAgent` and no extra argv. The frontend talks to the plugin through `src/services/autostart.ts`, matching the dynamic-import style of `notifications.ts`. Settings owns the switch state; App only receives failure copy for the existing timed toast.
+
+## Files
+
+- `src-tauri/Cargo.toml` / `Cargo.lock` — `tauri-plugin-autostart` 2.5.1
+- `src-tauri/src/lib.rs` — plugin init
+- `src-tauri/capabilities/default.json` — `autostart:default`
+- `package.json` / lockfile — `@tauri-apps/plugin-autostart` 2.5.1
+- `src/services/autostart.ts` — typed read/write, fixed failure messages
+- `src/components/SettingsView.tsx` — Startup row
+- `src/App.tsx` — `onAutostartNotice={showTimedToast}`
+- `src/redesign-settings.css` — alert hint color
+- `tests/autostart.test.ts`, `tests/autostart_settings.test.tsx`, `tests/panel_shell_ui.test.tsx`
+- `CHANGELOG.md`, `README.md`
+
+## Failure copy
+
+- Status read: `Launch at Login status could not be read. The toggle stays off.`
+- Update: `Launch at Login could not be updated. The system login item was left unchanged.`
+
+Console errors use the same fixed strings. Do not log the original exception.
+
+## Verification
+
+- `npx vitest run tests/autostart.test.ts tests/autostart_settings.test.tsx tests/panel_shell_ui.test.tsx`
+- `npx tsc --noEmit`
+- `npm test`
+- `cargo check --manifest-path src-tauri/Cargo.toml`

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -256,6 +256,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
 
 [[package]]
 name = "autocfg"
@@ -940,6 +951,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -954,6 +974,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -977,7 +1008,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1092,7 +1123,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1161,7 +1192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3399,6 +3430,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
 ]
@@ -3766,7 +3798,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4570,6 +4602,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4729,10 +4775,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5605,7 +5651,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6097,6 +6143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 once_cell = "1.19"
 ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "6bec20d035a10efbc8914d36001c7621570d1066" }
 tauri-plugin-notification = "2.3.3"
+tauri-plugin-autostart = "2.5.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "notification:default"
+    "notification:default",
+    "autostart:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,10 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .manage(TrayState::default())
         .invoke_handler(tauri::generate_handler![
             commands::get_quota,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -690,6 +690,7 @@ export default function App() {
               onTrayCycleToggle={handleTrayCycleToggle}
               onNotificationToggle={handleNotificationToggle}
               onSwitcherToggle={handleSwitcherToggle}
+              onAutostartNotice={showTimedToast}
             />
           </div>
         ) : (

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ThemeSelector, { type ThemeName } from './ThemeSelector';
 import type { TrayToggleEntry } from './TrayToggles';
 import ProviderIcon from './ProviderIcon';
 import type { TrayServiceName } from '../services/tray_visibility';
+import { readAutostartEnabled, setAutostartEnabled } from '../services/autostart';
 import {
   BUDGET_SOURCES,
   getSavedMonthlyBudgets,
@@ -46,6 +47,7 @@ interface SettingsViewProps {
   onTrayCycleToggle: () => void;
   onNotificationToggle: (key: NotificationKey) => void;
   onSwitcherToggle: (service: TrayServiceName) => void;
+  onAutostartNotice?: (message: string) => void;
 }
 
 export default function SettingsView({
@@ -68,10 +70,46 @@ export default function SettingsView({
   onTrayCycleToggle,
   onNotificationToggle,
   onSwitcherToggle,
+  onAutostartNotice,
 }: SettingsViewProps) {
   const [budgets, setBudgets] = useState<MonthlyBudgets>(getSavedMonthlyBudgets);
+  const [launchAtLogin, setLaunchAtLogin] = useState(false);
+  const [autostartError, setAutostartError] = useState<string | null>(null);
+  const [autostartBusy, setAutostartBusy] = useState(false);
   const enabledSwitcherCount = SERVICES.filter((service) => switcherVisibility[service]).length;
   const trayByService = new Map(trayEntries.map((entry) => [entry.service, entry]));
+
+  useEffect(() => {
+    let cancelled = false;
+    void readAutostartEnabled().then((result) => {
+      if (cancelled) return;
+      if (result.status === 'ok') {
+        setLaunchAtLogin(result.enabled);
+        setAutostartError(null);
+        return;
+      }
+      setLaunchAtLogin(false);
+      setAutostartError(result.status === 'failure' ? result.message : null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleLaunchAtLoginToggle = async () => {
+    if (autostartBusy) return;
+    const requested = !launchAtLogin;
+    setAutostartBusy(true);
+    const result = await setAutostartEnabled(requested);
+    setAutostartBusy(false);
+    if (result.status === 'ok') {
+      setLaunchAtLogin(result.enabled);
+      setAutostartError(null);
+      return;
+    }
+    setAutostartError(result.message);
+    onAutostartNotice?.(result.message);
+  };
 
   const handleBudgetChange = (source: CostSource, raw: string) => {
     setBudgets((prev) => {
@@ -302,6 +340,27 @@ export default function SettingsView({
         ) : (
           <div className="settings-hint">No events yet.</div>
         )}
+
+        <div className="settings-subsection-title settings-subsection-divider">Startup</div>
+        <div className="settings-line">
+          <span>Launch at Login</span>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={launchAtLogin}
+            aria-label="Launch at Login"
+            disabled={autostartBusy}
+            className={`target-switch ${launchAtLogin ? 'on' : ''}`}
+            onClick={() => {
+              void handleLaunchAtLoginToggle();
+            }}
+          >
+            <span />
+          </button>
+        </div>
+        {autostartError ? (
+          <div className="settings-hint" role="alert">{autostartError}</div>
+        ) : null}
 
         {isMacOS && (
           <>

--- a/src/redesign-settings.css
+++ b/src/redesign-settings.css
@@ -476,6 +476,10 @@
   line-height: 13px;
 }
 
+.settings-group .settings-hint[role="alert"] {
+  color: var(--color-critical);
+}
+
 .settings-group .settings-seg {
   display: flex;
   padding: 2px;

--- a/src/services/autostart.ts
+++ b/src/services/autostart.ts
@@ -1,0 +1,65 @@
+import { hasTauriBackend } from './backend';
+
+export const AUTOSTART_STATUS_FAILURE_MESSAGE =
+  'Launch at Login status could not be read. The toggle stays off.';
+export const AUTOSTART_UPDATE_FAILURE_MESSAGE =
+  'Launch at Login could not be updated. The system login item was left unchanged.';
+
+export type AutostartReadResult =
+  | { status: 'ok'; enabled: boolean }
+  | { status: 'unavailable' }
+  | { status: 'failure'; message: string };
+
+export type AutostartWriteResult =
+  | { status: 'ok'; enabled: boolean }
+  | { status: 'failure'; message: string };
+
+type AutostartPlugin = typeof import('@tauri-apps/plugin-autostart');
+let autostartPluginPromise: Promise<AutostartPlugin> | undefined;
+
+async function loadAutostartPlugin(): Promise<AutostartPlugin> {
+  autostartPluginPromise ??= import('@tauri-apps/plugin-autostart');
+  try {
+    return await autostartPluginPromise;
+  } catch {
+    autostartPluginPromise = undefined;
+    throw new Error(AUTOSTART_STATUS_FAILURE_MESSAGE);
+  }
+}
+
+export async function readAutostartEnabled(): Promise<AutostartReadResult> {
+  if (!hasTauriBackend()) {
+    return { status: 'unavailable' };
+  }
+  try {
+    const { isEnabled } = await loadAutostartPlugin();
+    return { status: 'ok', enabled: await isEnabled() };
+  } catch {
+    console.error(AUTOSTART_STATUS_FAILURE_MESSAGE);
+    return { status: 'failure', message: AUTOSTART_STATUS_FAILURE_MESSAGE };
+  }
+}
+
+export async function setAutostartEnabled(enabled: boolean): Promise<AutostartWriteResult> {
+  if (!hasTauriBackend()) {
+    console.error(AUTOSTART_UPDATE_FAILURE_MESSAGE);
+    return { status: 'failure', message: AUTOSTART_UPDATE_FAILURE_MESSAGE };
+  }
+  try {
+    const { enable, disable, isEnabled } = await loadAutostartPlugin();
+    if (enabled) {
+      await enable();
+    } else {
+      await disable();
+    }
+    const actual = await isEnabled();
+    if (actual !== enabled) {
+      console.error(AUTOSTART_UPDATE_FAILURE_MESSAGE);
+      return { status: 'failure', message: AUTOSTART_UPDATE_FAILURE_MESSAGE };
+    }
+    return { status: 'ok', enabled: actual };
+  } catch {
+    console.error(AUTOSTART_UPDATE_FAILURE_MESSAGE);
+    return { status: 'failure', message: AUTOSTART_UPDATE_FAILURE_MESSAGE };
+  }
+}

--- a/tests/autostart.test.ts
+++ b/tests/autostart.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AUTOSTART_STATUS_FAILURE_MESSAGE,
+  AUTOSTART_UPDATE_FAILURE_MESSAGE,
+  readAutostartEnabled,
+  setAutostartEnabled,
+} from '../src/services/autostart';
+
+const autostartPlugin = vi.hoisted(() => ({
+  enable: vi.fn(),
+  disable: vi.fn(),
+  isEnabled: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-autostart', () => autostartPlugin);
+
+function installDesktopBackend(): void {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { __TAURI_INTERNALS__: {} },
+  });
+}
+
+beforeEach(() => {
+  installDesktopBackend();
+  autostartPlugin.enable.mockReset().mockResolvedValue(undefined);
+  autostartPlugin.disable.mockReset().mockResolvedValue(undefined);
+  autostartPlugin.isEnabled.mockReset().mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (globalThis as Record<string, unknown>).window;
+});
+
+describe('autostart adapter', () => {
+  it('reads the OS login item without writing local storage', async () => {
+    autostartPlugin.isEnabled.mockResolvedValue(true);
+    const setItem = vi.fn();
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: { getItem: vi.fn(), setItem },
+    });
+
+    await expect(readAutostartEnabled()).resolves.toEqual({ status: 'ok', enabled: true });
+    expect(setItem).not.toHaveBeenCalled();
+    delete (globalThis as Record<string, unknown>).localStorage;
+  });
+
+  it('treats browser preview as unavailable without a status error', async () => {
+    delete (globalThis as Record<string, unknown>).window;
+    await expect(readAutostartEnabled()).resolves.toEqual({ status: 'unavailable' });
+    expect(autostartPlugin.isEnabled).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on status read errors without leaking the original exception', async () => {
+    autostartPlugin.isEnabled.mockRejectedValue(new Error('launch-agent-token'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(readAutostartEnabled()).resolves.toEqual({
+      status: 'failure',
+      message: AUTOSTART_STATUS_FAILURE_MESSAGE,
+    });
+    expect(consoleError).toHaveBeenCalledExactlyOnceWith(AUTOSTART_STATUS_FAILURE_MESSAGE);
+  });
+
+  it('enables only after the plugin re-read confirms the login item', async () => {
+    autostartPlugin.isEnabled.mockResolvedValue(true);
+
+    await expect(setAutostartEnabled(true)).resolves.toEqual({ status: 'ok', enabled: true });
+    expect(autostartPlugin.enable).toHaveBeenCalledTimes(1);
+    expect(autostartPlugin.disable).not.toHaveBeenCalled();
+    expect(autostartPlugin.isEnabled).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when enable succeeds but the login item stays off', async () => {
+    autostartPlugin.isEnabled.mockResolvedValue(false);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(setAutostartEnabled(true)).resolves.toEqual({
+      status: 'failure',
+      message: AUTOSTART_UPDATE_FAILURE_MESSAGE,
+    });
+    expect(consoleError).toHaveBeenCalledExactlyOnceWith(AUTOSTART_UPDATE_FAILURE_MESSAGE);
+  });
+
+  it('fails closed on plugin write errors in desktop and preview', async () => {
+    autostartPlugin.enable.mockRejectedValue(new Error('permission-token'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(setAutostartEnabled(true)).resolves.toEqual({
+      status: 'failure',
+      message: AUTOSTART_UPDATE_FAILURE_MESSAGE,
+    });
+
+    delete (globalThis as Record<string, unknown>).window;
+    await expect(setAutostartEnabled(true)).resolves.toEqual({
+      status: 'failure',
+      message: AUTOSTART_UPDATE_FAILURE_MESSAGE,
+    });
+    expect(autostartPlugin.enable).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls.flat()).toEqual([
+      AUTOSTART_UPDATE_FAILURE_MESSAGE,
+      AUTOSTART_UPDATE_FAILURE_MESSAGE,
+    ]);
+  });
+});

--- a/tests/autostart_settings.test.tsx
+++ b/tests/autostart_settings.test.tsx
@@ -1,0 +1,141 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SettingsView from '../src/components/SettingsView';
+import {
+  AUTOSTART_STATUS_FAILURE_MESSAGE,
+  AUTOSTART_UPDATE_FAILURE_MESSAGE,
+} from '../src/services/autostart';
+import type { TrayToggleEntry } from '../src/components/TrayToggles';
+
+const autostart = vi.hoisted(() => ({
+  readAutostartEnabled: vi.fn(),
+  setAutostartEnabled: vi.fn(),
+}));
+
+vi.mock('../src/services/autostart', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/autostart')>();
+  return {
+    ...actual,
+    readAutostartEnabled: autostart.readAutostartEnabled,
+    setAutostartEnabled: autostart.setAutostartEnabled,
+  };
+});
+
+const trayEntries: TrayToggleEntry[] = [
+  { service: 'claude', label: 'Claude Tray', enabled: true, canDisable: true, connected: true, connectedHint: 'Ready', disconnectedHint: 'Sign in' },
+];
+
+function settingsProps(overrides: Partial<Parameters<typeof SettingsView>[0]> = {}) {
+  return {
+    isMacOS: true,
+    theme: 'light' as const,
+    dockHidden: false,
+    trayEntries,
+    panelSections: { timeline: true, cost: true, trend: true, tips: true },
+    trayStyle: 'percent' as const,
+    trayCycle: false,
+    events: [],
+    notificationSettings: { q80: true, q95: true, bonus: false },
+    switcherVisibility: { claude: true, codex: true, cursor: true, grok: true, antigravity: true },
+    onClose: () => {},
+    onThemeChange: () => {},
+    onDockToggle: () => {},
+    onTrayToggle: () => {},
+    onPanelSectionToggle: () => {},
+    onTrayStyleChange: () => {},
+    onTrayCycleToggle: () => {},
+    onNotificationToggle: () => {},
+    onSwitcherToggle: () => {},
+    ...overrides,
+  };
+}
+
+function launchSwitch(renderer: ReactTestRenderer) {
+  return renderer.root.findByProps({ 'aria-label': 'Launch at Login' });
+}
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+  autostart.readAutostartEnabled.mockReset().mockResolvedValue({ status: 'ok', enabled: false });
+  autostart.setAutostartEnabled.mockReset().mockResolvedValue({ status: 'ok', enabled: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Launch at Login settings row', () => {
+  it('reflects an existing OS login item after load', async () => {
+    autostart.readAutostartEnabled.mockResolvedValue({ status: 'ok', enabled: true });
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(SettingsView, settingsProps()));
+      await Promise.resolve();
+    });
+
+    expect(launchSwitch(renderer).props['aria-checked']).toBe(true);
+    await act(async () => renderer.unmount());
+  });
+
+  it('keeps the switch off and shows copy when status cannot be read', async () => {
+    autostart.readAutostartEnabled.mockResolvedValue({
+      status: 'failure',
+      message: AUTOSTART_STATUS_FAILURE_MESSAGE,
+    });
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(SettingsView, settingsProps()));
+      await Promise.resolve();
+    });
+
+    expect(launchSwitch(renderer).props['aria-checked']).toBe(false);
+    expect(renderer.root.findByProps({ role: 'alert' }).props.children).toBe(
+      AUTOSTART_STATUS_FAILURE_MESSAGE,
+    );
+    await act(async () => renderer.unmount());
+  });
+
+  it('does not flip the switch when registration fails', async () => {
+    const onAutostartNotice = vi.fn();
+    autostart.setAutostartEnabled.mockResolvedValue({
+      status: 'failure',
+      message: AUTOSTART_UPDATE_FAILURE_MESSAGE,
+    });
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(SettingsView, settingsProps({ onAutostartNotice })));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      launchSwitch(renderer).props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(launchSwitch(renderer).props['aria-checked']).toBe(false);
+    expect(onAutostartNotice).toHaveBeenCalledExactlyOnceWith(AUTOSTART_UPDATE_FAILURE_MESSAGE);
+    expect(renderer.root.findByProps({ role: 'alert' }).props.children).toBe(
+      AUTOSTART_UPDATE_FAILURE_MESSAGE,
+    );
+    await act(async () => renderer.unmount());
+  });
+
+  it('turns on after a confirmed login-item write', async () => {
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(SettingsView, settingsProps()));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      launchSwitch(renderer).props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(autostart.setAutostartEnabled).toHaveBeenCalledExactlyOnceWith(true);
+    expect(launchSwitch(renderer).props['aria-checked']).toBe(true);
+    expect(renderer.root.findAllByProps({ role: 'alert' })).toHaveLength(0);
+    await act(async () => renderer.unmount());
+  });
+});

--- a/tests/panel_shell_ui.test.tsx
+++ b/tests/panel_shell_ui.test.tsx
@@ -143,12 +143,15 @@ describe('panel shell UI', () => {
     expect(html).toContain('>Ready<');
     expect(html).toContain('>Sign in<');
     expect(html).toContain('>Preview<');
+    expect(html).toContain('>Launch at Login<');
+    expect(html).toContain('aria-label="Launch at Login"');
   });
 
   it('keeps compact settings controls visually self-contained at panel width', () => {
     const css = readFileSync(new URL('../src/redesign-settings.css', import.meta.url), 'utf8');
 
     expect(css).toMatch(/\.settings-group \.settings-line \{[^}]*display: flex;/s);
+    expect(css).toMatch(/\.settings-group \.settings-hint\[role="alert"\] \{[^}]*color: var\(--color-critical\);/s);
     expect(css).toMatch(/\.settings-group \.target-switch \{[^}]*background: var\(--track\);/s);
     expect(css).toMatch(/\.settings-group \.target-switch span \{[^}]*border-radius: 50%;/s);
     expect(css).toMatch(/\.settings-group \.target-switch\.on \{[^}]*background: #34c759;/s);


### PR DESCRIPTION
## Summary

- Add a Launch at Login toggle under Settings → Activity & system.
- Persist through `tauri-plugin-autostart` (macOS Launch Agent), not a new `claude-quota-*` key.
- Fail closed: the switch only moves after a confirmed `isEnabled()` re-read; permission/plugin failures keep the previous value and show fixed copy in Settings plus a toast.

Closes #96

## Verification

- [x] `npm test`
- [x] `npm run build`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.


Made with [Cursor](https://cursor.com)