### PR TITLE
docs: record exhausted panel, alerts, and settings presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 ## Unreleased
 
 - Add a Settings Launch at Login toggle backed by the OS login item.
+- Add All / single-service settings presets, and split monthly budgets from alerts.
+- Notify at 100% used and when a Codex bonus reset is unused at 100%.
+- Keep last Codex weekly value visible as Last estimate when the official week is exhausted, and make leftover bonus resets a dashboard jump.
 - Drive the Cursor tray from the Cursor Models pool instead of the highest dashboard bar.
 - Stop caching disconnected Cursor payloads so a transient empty body cannot pin "not connected" for 120s.
 - Keep Grok pool value available when valid `turn_completed` records omit the optional usage object.

--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ Website: https://majiayu000.github.io/quotabar/
 - Overview: glass popover shell with provider summary tiles and real-data quota windows.
 - Provider switcher: overview plus full-name cards for Claude, Codex, Cursor, Grok, and Antigravity.
 - Claude quota: 5-hour, 7-day, Opus, Sonnet, and Claude Design windows.
-- Codex quota: short and weekly ChatGPT usage windows, plus local weekly pace and API-equivalent value estimates sourced from Codex CLI session data.
+- Codex quota: short and weekly ChatGPT usage windows, local weekly pace and API-equivalent value estimates, and an exhausted-week layout that keeps the last estimate and a clickable bonus reset.
 - Cursor quota: signed-in Cursor usage and request-limit windows when session data is available.
 - Grok quota: SuperGrok weekly (or monthly) credits pool, product mix for Build/Chat/Imagine/Voice/API, extra credits, and an API-equivalent value estimate from ccstats' durable inference ledger.
 - Antigravity panel: placeholder provider status while quota tracking is pending.
 - Local cost tracking: today, week, and month estimates for Claude Code, Codex, and Cursor.
 - Per-provider tray icons: independent menu bar indicators for supported providers.
 - Tray controls: enable or hide each tray while keeping at least one entry point.
-- Settings view: theme, macOS Hide Dock, Launch at Login, and per-provider tray controls. Launch at Login uses the OS login item rather than a local storage key.
+- Settings view: theme, macOS Hide Dock, Launch at Login, All / single-service presets, Limits vs Alerts, and per-provider tray controls. Launch at Login uses the OS login item rather than a local storage key.
+- Notifications: 80%, 95%, 100%, unused bonus reset, and bonus-expiry alerts.
 - Background polling: refreshes every 60 seconds, backs off to 5 minutes on 429, and backs off to 1 hour on Claude auth failures.
 - Read-only Claude OAuth: reads Claude Code credentials from the correct source, but never refreshes or writes OAuth tokens.
 - Read-only Grok auth: reads `~/.grok/auth.json`, but never refreshes or writes tokens.


### PR DESCRIPTION
## Summary

- Add Unreleased changelog lines for #93–#95, which landed without notes.
- Update README features for exhausted Codex weeks, lifecycle alerts, and All / single-service presets.

## Verification

- [x] `npm test` not required for docs-only copy
- Browser preview: Settings shows Limits, Alerts, Launch at Login; toggling Launch at Login in preview fail-closes with the fixed copy.

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.


Made with [Cursor](https://cursor.com)