### PR TITLE
fix(codex): align weekly estimates and pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Website: https://majiayu000.github.io/quotabar/
 - Provider switcher: overview plus full-name cards for Claude, Codex, Cursor, Grok, and Antigravity.
 - Claude quota: 5-hour, 7-day, Opus, Sonnet, and Claude Design windows.
 - Codex quota: short and weekly ChatGPT usage windows, local weekly pace and API-equivalent value estimates, and an exhausted-week layout that keeps the last estimate and a clickable bonus reset.
+  Observed usage is valued at standard API token prices; the full-week value is a rough extrapolation from an official quota snapshot, not a bill or an official dollar allowance. Fast-mode premiums and purchased credits are not represented by this estimate.
 - Cursor quota: signed-in Cursor usage and request-limit windows when session data is available.
 - Grok quota: SuperGrok weekly (or monthly) credits pool, product mix for Build/Chat/Imagine/Voice/API, extra credits, and an API-equivalent value estimate from ccstats' durable inference ledger.
 - Antigravity panel: placeholder provider status while quota tracking is pending.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -482,8 +482,8 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.5.1"
-source = "git+https://github.com/majiayu000/ccstats.git?rev=6bec20d035a10efbc8914d36001c7621570d1066#6bec20d035a10efbc8914d36001c7621570d1066"
+version = "0.5.2"
+source = "git+https://github.com/majiayu000/ccstats.git?rev=0dfddefec11ecea5dfad5efd2e5725022fb52035#0dfddefec11ecea5dfad5efd2e5725022fb52035"
 dependencies = [
  "base64 0.23.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ dirs = "5"
 rusqlite = { version = "0.40", features = ["bundled"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 once_cell = "1.19"
-ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "6bec20d035a10efbc8914d36001c7621570d1066" }
+ccstats = { git = "https://github.com/majiayu000/ccstats.git", rev = "0dfddefec11ecea5dfad5efd2e5725022fb52035" }
 tauri-plugin-notification = "2.3.3"
 tauri-plugin-autostart = "2.5.1"
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -37,29 +37,23 @@ pub async fn get_codex_weekly_quota() -> Result<CodexWeeklyQuotaData, String> {
             "Could not find the Codex home directory",
         ));
     };
-    let official_observed_at = chrono::Utc::now();
     let fetched_official = codex::fetch_codex_rate_limits().await;
     let official = if fetched_official.error.is_none() {
-        codex_weekly::OfficialWeeklySnapshot::from_limits(&fetched_official, official_observed_at)
+        codex_weekly::OfficialWeeklySnapshot::from_limits(&fetched_official, chrono::Utc::now())
     } else {
         None
     };
-    let data =
-        tauri::async_runtime::spawn_blocking(move || {
-            match ccstats::load_codex_weekly_quota(Some(&codex_home)) {
-                Ok(quota) => {
-                    let value_estimate = codex_weekly::estimate_codex_weekly_value(
-                        &codex_home,
-                        &quota,
-                        official.as_ref(),
-                    );
-                    CodexWeeklyQuotaData::available(quota, value_estimate)
-                }
-                Err(error) => CodexWeeklyQuotaData::unavailable(error.to_string()),
-            }
-        })
-        .await
-        .map_err(|err| format!("Codex weekly quota task failed: {err}"))?;
+    let data = tauri::async_runtime::spawn_blocking(move || {
+        let quota =
+            ccstats::load_codex_weekly_quota(Some(&codex_home)).map_err(|error| error.to_string());
+        let value_estimate = match fetched_official.error {
+            Some(error) => Err(error),
+            None => codex_weekly::estimate_codex_weekly_value(&codex_home, official.as_ref()),
+        };
+        CodexWeeklyQuotaData::from_results(quota, value_estimate)
+    })
+    .await
+    .map_err(|err| format!("Codex weekly quota task failed: {err}"))?;
     Ok(data)
 }
 

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -198,19 +198,23 @@ pub struct CodexWeeklyQuotaData {
 }
 
 impl CodexWeeklyQuotaData {
-    pub fn available(
-        quota: ccstats::CodexWeeklyQuota,
+    pub fn from_results(
+        quota: Result<ccstats::CodexWeeklyQuota, String>,
         value_estimate: Result<ccstats::CodexWeeklyValueEstimate, String>,
     ) -> Self {
         let (value_estimate, value_estimate_error) = match value_estimate {
             Ok(estimate) => (Some(CodexWeeklyValueEstimate::from(estimate)), None),
             Err(error) => (None, Some(error.to_string())),
         };
+        let (quota, error) = match quota {
+            Ok(quota) => (Some(CodexWeeklyQuota::from(quota)), None),
+            Err(error) => (None, Some(error)),
+        };
         Self {
-            quota: Some(CodexWeeklyQuota::from(quota)),
+            quota,
             value_estimate,
             value_estimate_error,
-            error: None,
+            error,
         }
     }
 

--- a/src-tauri/src/services/codex_weekly.rs
+++ b/src-tauri/src/services/codex_weekly.rs
@@ -9,50 +9,23 @@ use std::{
 };
 
 const WEEKLY_WINDOW_MINUTES: i64 = 10_080;
-const OFFICIAL_RESET_TOLERANCE_SECONDS: i64 = 5 * 60;
-const OFFICIAL_USED_TOLERANCE_PCT: f64 = 1.0;
 
 const SUCCESS_CACHE_TTL: Duration = Duration::from_secs(300);
 const ERROR_CACHE_TTL: Duration = Duration::from_secs(60);
 
 type WeeklyValueResult = Result<ccstats::CodexWeeklyValueEstimate, String>;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct WeeklyQuotaIdentity {
-    observed_at: chrono::DateTime<chrono::Utc>,
-    resets_at: chrono::DateTime<chrono::Utc>,
-    used_pct_bits: u64,
-}
-
-impl From<&ccstats::CodexWeeklyQuota> for WeeklyQuotaIdentity {
-    fn from(quota: &ccstats::CodexWeeklyQuota) -> Self {
-        Self {
-            observed_at: quota.observed_at,
-            resets_at: quota.resets_at,
-            used_pct_bits: quota.used_pct.to_bits(),
-        }
-    }
-}
-
-impl WeeklyQuotaIdentity {
-    fn matches_estimate(&self, estimate: &ccstats::CodexWeeklyValueEstimate) -> bool {
-        self.observed_at == estimate.observed_at
-            && self.resets_at == estimate.resets_at
-            && self.used_pct_bits == estimate.used_pct.to_bits()
-    }
-}
-
 #[derive(Clone)]
 struct CachedWeeklyValue {
     codex_home: PathBuf,
-    quota: WeeklyQuotaIdentity,
-    official: Option<OfficialWeeklyIdentity>,
+    official: OfficialWeeklyIdentity,
     inserted_at: Instant,
     result: WeeklyValueResult,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct OfficialWeeklyIdentity {
+    observed_at: chrono::DateTime<chrono::Utc>,
     used_pct_bits: u64,
     window_minutes: Option<i64>,
     resets_at: Option<i64>,
@@ -76,9 +49,11 @@ impl OfficialWeeklySnapshot {
     }
 }
 
-impl From<&CodexRateLimitWindow> for OfficialWeeklyIdentity {
-    fn from(window: &CodexRateLimitWindow) -> Self {
+impl From<&OfficialWeeklySnapshot> for OfficialWeeklyIdentity {
+    fn from(snapshot: &OfficialWeeklySnapshot) -> Self {
+        let window = &snapshot.window;
         Self {
+            observed_at: snapshot.observed_at,
             used_pct_bits: window.used_percent.to_bits(),
             window_minutes: window.window_minutes,
             resets_at: window.resets_at,
@@ -105,18 +80,17 @@ pub(crate) fn official_weekly_window(limits: &CodexRateLimits) -> Option<&CodexR
 
 pub fn estimate_codex_weekly_value(
     codex_home: &Path,
-    quota: &ccstats::CodexWeeklyQuota,
     official: Option<&OfficialWeeklySnapshot>,
 ) -> WeeklyValueResult {
-    let quota_identity = WeeklyQuotaIdentity::from(quota);
-    let official_identity = official.map(|snapshot| OfficialWeeklyIdentity::from(&snapshot.window));
+    let official =
+        official.ok_or_else(|| "The official weekly quota snapshot is unavailable.".to_string())?;
+    let official_identity = OfficialWeeklyIdentity::from(official);
     let mut cache = WEEKLY_VALUE_CACHE
         .lock()
         .map_err(|error| format!("Codex weekly value cache unavailable: {error}"))?;
 
     if let Some(cached) = cache.as_ref() {
         if cached.codex_home == codex_home
-            && cached.quota == quota_identity
             && cached.official == official_identity
             && cached.inserted_at.elapsed() < cache_ttl(&cached.result)
         {
@@ -124,27 +98,9 @@ pub fn estimate_codex_weekly_value(
         }
     }
 
-    let result = if quota.used_pct > 0.0
-        && official.is_none_or(|snapshot| quota_matches_official(quota, &snapshot.window))
-    {
-        let local = estimate_from_local_snapshot(codex_home, &quota_identity);
-        match (local, official) {
-            (Err(error), Some(snapshot)) if should_fallback_to_official(&error) => {
-                estimate_from_official_window(codex_home, snapshot)
-            }
-            (result, _) => result,
-        }
-    } else if let Some(snapshot) = official {
-        estimate_from_official_window(codex_home, snapshot)
-    } else {
-        Err(
-            "cannot estimate weekly value while the provider-reported used percentage is zero"
-                .to_string(),
-        )
-    };
+    let result = estimate_from_official_window(codex_home, official);
     *cache = Some(CachedWeeklyValue {
         codex_home: codex_home.to_path_buf(),
-        quota: quota_identity,
         official: official_identity,
         inserted_at: Instant::now(),
         result: result.clone(),
@@ -152,64 +108,22 @@ pub fn estimate_codex_weekly_value(
     result
 }
 
-fn should_fallback_to_official(error: &str) -> bool {
-    let lowered = error.to_ascii_lowercase();
-    lowered.contains("used percentage is zero")
-        || lowered.contains("no codex token usage matched")
-        || lowered.contains("no token usage matched the active weekly")
-}
-
-fn quota_matches_official(
-    quota: &ccstats::CodexWeeklyQuota,
-    official: &CodexRateLimitWindow,
-) -> bool {
-    weekly_windows_match(
-        quota.used_pct,
-        quota.window_minutes,
-        quota.resets_at,
-        official,
-    )
-}
-
-fn weekly_windows_match(
-    used_pct: f64,
-    window_minutes: i64,
-    resets_at: chrono::DateTime<chrono::Utc>,
-    official: &CodexRateLimitWindow,
-) -> bool {
-    let Some(official_reset) = official
-        .resets_at
-        .and_then(|timestamp| chrono::DateTime::from_timestamp(timestamp, 0))
-    else {
-        return false;
-    };
-    official.window_minutes == Some(window_minutes)
-        && (official_reset - resets_at).num_seconds().abs() <= OFFICIAL_RESET_TOLERANCE_SECONDS
-        && (official.used_percent - used_pct).abs() <= OFFICIAL_USED_TOLERANCE_PCT
-}
-
-fn estimate_from_local_snapshot(
-    codex_home: &Path,
-    quota_identity: &WeeklyQuotaIdentity,
-) -> WeeklyValueResult {
-    ccstats::estimate_codex_weekly_value(Some(codex_home), false, false)
-        .map_err(|error| error.to_string())
-        .and_then(|estimate| {
-            if quota_identity.matches_estimate(&estimate) {
-                Ok(estimate)
-            } else {
-                Err(
-                    "Codex weekly quota changed while estimating its local value; refresh to retry"
-                        .to_string(),
-                )
-            }
-        })
-}
-
 fn estimate_from_official_window(
     codex_home: &Path,
     snapshot: &OfficialWeeklySnapshot,
 ) -> WeeklyValueResult {
+    ccstats::estimate_codex_weekly_value_for_window(
+        &value_window(snapshot)?,
+        Some(codex_home),
+        false,
+        false,
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn value_window(
+    snapshot: &OfficialWeeklySnapshot,
+) -> Result<ccstats::CodexWeeklyValueWindow, String> {
     let window_minutes = snapshot
         .window
         .window_minutes
@@ -223,18 +137,12 @@ fn estimate_from_official_window(
     if snapshot.observed_at >= resets {
         return Err("The official weekly quota window has expired.".to_string());
     }
-    ccstats::estimate_codex_weekly_value_for_window(
-        &ccstats::CodexWeeklyValueWindow {
-            observed_at: snapshot.observed_at,
-            resets_at: resets,
-            window_minutes,
-            used_pct: snapshot.window.used_percent,
-        },
-        Some(codex_home),
-        false,
-        false,
-    )
-    .map_err(|error| error.to_string())
+    Ok(ccstats::CodexWeeklyValueWindow {
+        observed_at: snapshot.observed_at,
+        resets_at: resets,
+        window_minutes,
+        used_pct: snapshot.window.used_percent,
+    })
 }
 
 #[cfg(test)]
@@ -256,28 +164,12 @@ mod tests {
         }
     }
 
-    fn identity(used_pct: f64) -> WeeklyQuotaIdentity {
-        WeeklyQuotaIdentity {
-            observed_at: chrono::DateTime::UNIX_EPOCH,
-            resets_at: chrono::DateTime::UNIX_EPOCH + chrono::Duration::days(7),
-            used_pct_bits: used_pct.to_bits(),
-        }
-    }
-
     #[test]
     fn successful_estimates_live_longer_than_errors() {
         let estimate = estimate();
 
         assert_eq!(cache_ttl(&Ok(estimate)), SUCCESS_CACHE_TTL);
         assert_eq!(cache_ttl(&Err("unavailable".to_string())), ERROR_CACHE_TTL);
-    }
-
-    #[test]
-    fn quota_identity_rejects_estimates_from_another_snapshot() {
-        let estimate = estimate();
-
-        assert!(identity(25.0).matches_estimate(&estimate));
-        assert!(!identity(30.0).matches_estimate(&estimate));
     }
 
     fn limits_with(
@@ -315,68 +207,44 @@ mod tests {
     }
 
     #[test]
-    fn official_identity_changes_with_provider_window() {
-        let first = limits_with(Some((25.0, 10_080)), None);
-        let second = limits_with(Some((30.0, 10_080)), None);
-
+    fn cache_identity_changes_when_only_the_observation_advances() {
+        let limits = limits_with(Some((5.0, 10_080)), None);
+        let first = OfficialWeeklySnapshot::from_limits(&limits, chrono::Utc::now()).unwrap();
+        let mut second = first.clone();
+        second.observed_at += chrono::Duration::seconds(1);
         assert_ne!(
-            first.primary.as_ref().map(OfficialWeeklyIdentity::from),
-            second.primary.as_ref().map(OfficialWeeklyIdentity::from),
+            OfficialWeeklyIdentity::from(&first),
+            OfficialWeeklyIdentity::from(&second)
         );
     }
 
-    fn reset_time() -> chrono::DateTime<chrono::Utc> {
-        chrono::DateTime::UNIX_EPOCH + chrono::Duration::seconds(1_787_961_600)
+    #[test]
+    fn missing_official_snapshot_does_not_use_local_usage() {
+        let error = estimate_codex_weekly_value(Path::new("unused"), None).unwrap_err();
+        assert!(error.contains("official weekly quota snapshot is unavailable"));
     }
 
     #[test]
-    fn matching_official_window_keeps_the_atomic_local_snapshot() {
-        let reset = reset_time();
-        let official = CodexRateLimitWindow {
-            used_percent: 26.0,
-            window_minutes: Some(WEEKLY_WINDOW_MINUTES),
-            resets_at: Some(reset.timestamp() + OFFICIAL_RESET_TOLERANCE_SECONDS),
-        };
-
-        assert!(weekly_windows_match(
-            25.0,
-            WEEKLY_WINDOW_MINUTES,
-            reset,
-            &official
-        ));
+    fn value_window_keeps_the_official_percentage_reset_and_observation_together() {
+        let limits = limits_with(Some((5.0, 10_080)), None);
+        let observed_at = chrono::DateTime::from_timestamp(1_787_960_000, 0).unwrap();
+        let snapshot = OfficialWeeklySnapshot::from_limits(&limits, observed_at).unwrap();
+        let window = value_window(&snapshot).unwrap();
+        assert_eq!(window.used_pct, 5.0);
+        assert_eq!(window.resets_at.timestamp(), 1_787_961_600);
+        assert_eq!(window.observed_at, observed_at);
+        assert_eq!(window.window_minutes, 10_080);
     }
 
     #[test]
-    fn divergent_official_usage_requires_the_official_snapshot() {
-        let reset = reset_time();
-        let official = CodexRateLimitWindow {
-            used_percent: 26.01,
-            window_minutes: Some(WEEKLY_WINDOW_MINUTES),
-            resets_at: Some(reset.timestamp()),
-        };
-
-        assert!(!weekly_windows_match(
-            25.0,
-            WEEKLY_WINDOW_MINUTES,
-            reset,
-            &official
-        ));
-    }
-
-    #[test]
-    fn divergent_official_reset_requires_the_official_snapshot() {
-        let reset = reset_time();
-        let official = CodexRateLimitWindow {
-            used_percent: 25.0,
-            window_minutes: Some(WEEKLY_WINDOW_MINUTES),
-            resets_at: Some(reset.timestamp() + OFFICIAL_RESET_TOLERANCE_SECONDS + 1),
-        };
-
-        assert!(!weekly_windows_match(
-            25.0,
-            WEEKLY_WINDOW_MINUTES,
-            reset,
-            &official
-        ));
+    fn missing_local_pace_does_not_discard_an_official_window_estimate() {
+        let data = crate::domain::models::CodexWeeklyQuotaData::from_results(
+            Err("No local quota snapshot".to_string()),
+            Ok(estimate()),
+        );
+        assert!(data.quota.is_none());
+        assert_eq!(data.error.as_deref(), Some("No local quota snapshot"));
+        assert!(data.value_estimate.is_some());
+        assert!(data.value_estimate_error.is_none());
     }
 }

--- a/src-tauri/src/services/cost.rs
+++ b/src-tauri/src/services/cost.rs
@@ -544,6 +544,8 @@ mod tests {
             estimated_cost: None,
             estimated_cost_usd: None,
             cost_kind: "none".to_string(),
+            pricing_source: "unknown".to_string(),
+            grok_api_equivalent_cost: None,
             api_equivalent_cost_coverage: None,
             tokens: TokenBreakdown::default(),
             models: Vec::new(),

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -116,6 +116,17 @@ const COMPACT_TOKEN_FORMAT = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 1,
 });
 
+const ROUGH_USD_FORMAT = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumSignificantDigits: 2,
+});
+
+const ROUGH_TOKEN_FORMAT = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumSignificantDigits: 2,
+});
+
 
 function selectOfficialWeeklyWindow(
   limits: CodexRateLimits | null,
@@ -624,13 +635,13 @@ export default function CodexPanel({
                       <div className="weekly-value-body">
                         <div className="weekly-value-metrics">
                           <span className="weekly-value-amount">
-                          ≈{USD_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyValueUsd)}
+                            ≈{USD_FORMAT.format(displayedWeeklyValueEstimate.observedCostUsd)}
                           </span>
                           <span className="weekly-value-token-row">
                             <strong>
-                              ≈{COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyTokens)}
+                              {COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.observedTokens)}
                             </strong>
-                            <span>tokens at current mix</span>
+                            <span>observed tokens</span>
                           </span>
                         </div>
                         <div
@@ -649,12 +660,18 @@ export default function CodexPanel({
                       </div>
                       <div className="weekly-value-footer weekly-value-footer-basis">
                         <span>
-                          {`Based on ${Math.round(displayedWeeklyValueEstimate.usedPct)}% used · ${USD_FORMAT.format(displayedWeeklyValueEstimate.observedCostUsd)} local`}
+                          Standard API prices · Not a bill
+                        </span>
+                        <span>
+                          {`Rough full week ≈${ROUGH_USD_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyValueUsd)} · ≈${ROUGH_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyTokens)} tokens at current mix`}
+                        </span>
+                        <span>
+                          {`Based on ${Math.round(displayedWeeklyValueEstimate.usedPct)}% used · Not an official allowance`}
                         </span>
                         <span>
                           {valueIsLastEstimate
-                            ? `${COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.observedTokens)} observed tokens · Not an official allowance · snapshot not refreshed`
-                            : `${COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.observedTokens)} observed tokens · Not an official allowance`}
+                            ? 'Observed usage this week · snapshot not refreshed'
+                            : 'Observed usage this week'}
                         </span>
                       </div>
                     </>

--- a/src/services/codex_weekly_display.ts
+++ b/src/services/codex_weekly_display.ts
@@ -32,7 +32,7 @@ export function checkWeeklyValueEstimate(
   ) {
     return { ok: false, kind: 'hard', message: 'The local weekly value estimate contains invalid totals.' };
   }
-  if (Math.abs(estimate.usedPct - official.usedPercent) > 5) {
+  if (estimate.usedPct !== official.usedPercent) {
     return { ok: false, kind: 'hard', message: 'The local weekly value estimate does not match the quota usage.' };
   }
   const estimateObservedAt = Date.parse(estimate.observedAt);
@@ -56,7 +56,7 @@ export function checkWeeklyValueEstimate(
   if (
     !Number.isFinite(estimateReset)
     || officialReset <= 0
-    || Math.abs(estimateReset - officialReset) > 5 * 60 * 1000
+    || estimateReset !== officialReset
   ) {
     return { ok: false, kind: 'hard', message: 'The local weekly value estimate does not match the quota reset.' };
   }

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -382,13 +382,15 @@ describe('Codex weekly pace', () => {
     expect(rendered_text(renderer)).not.toContain('Likely to exhaust');
     expect(rendered_text(renderer)).not.toContain('% at reset');
     expect(rendered_text(renderer)).toContain('API-equivalent week');
-    expect(rendered_text(renderer)).toContain('$200.00');
+    expect(rendered_text(renderer)).toContain('Rough full week ≈$200');
     expect(rendered_text(renderer)).toContain('4M');
     expect(rendered_text(renderer)).toContain('tokens at current mix');
     expect(rendered_text(renderer)).toContain('Local estimate');
     expect(rendered_text(renderer)).toContain('Based on 40% used');
-    expect(rendered_text(renderer)).toContain('$80.00 local');
-    expect(rendered_text(renderer)).toContain('1.6M observed tokens');
+    expect(renderer.root.findByProps({ className: 'weekly-value-amount' }).children.join('')).toBe('≈$80.00');
+    expect(rendered_text(renderer)).toContain('Standard API prices · Not a bill');
+    expect(renderer.root.findByProps({ className: 'weekly-value-token-row' }).findByType('strong').children.join('')).toBe('1.6M');
+    expect(rendered_text(renderer)).toContain('observed tokens');
     expect(rendered_text(renderer)).toContain('Not an official allowance');
     expect(renderer.root.findByProps({
       'aria-label': 'Estimate based on 40% used',
@@ -430,15 +432,36 @@ describe('Codex weekly pace', () => {
     });
 
     expect(rendered_text(renderer)).toContain('API-equivalent week');
-    expect(rendered_text(renderer)).toContain('$200.00');
+    expect(rendered_text(renderer)).toContain('Rough full week ≈$200');
     expect(rendered_text(renderer)).not.toContain('Local pace:');
+    await unmount(renderer);
+  });
+
+  it('rounds the full-week extrapolation while keeping observed cost prominent at low usage', async () => {
+    const renderer = await render_codex({
+      valueEstimate: {
+        observedAt: new Date().toISOString(),
+        windowStartedAt: '2026-08-22T00:00:00Z',
+        resetsAt: '2026-08-29T00:00:00Z',
+        usedPct: 5,
+        observedCostUsd: 123.456,
+        estimatedWeeklyValueUsd: 2469.12,
+        observedTokens: 1_000_000,
+        estimatedWeeklyTokens: 20_000_000,
+      },
+    }, null, { usedPercent: 5, windowMinutes: 10_080, resetsAt: 1_787_961_600 });
+    expect(renderer.root.findByProps({ className: 'weekly-value-amount' }).children.join('')).toBe('≈$123.46');
+    expect(rendered_text(renderer)).toContain('Rough full week ≈$2,500');
+    expect(rendered_text(renderer)).not.toContain('$2,469.12');
     await unmount(renderer);
   });
 
   it.each([
     ['invalid totals', { estimatedWeeklyValueUsd: 0 }],
     ['usage mismatch', { usedPct: 55 }],
+    ['one percentage point mismatch', { usedPct: 39 }],
     ['reset mismatch', { resetsAt: '2026-09-05T00:00:00Z' }],
+    ['one second reset mismatch', { resetsAt: '2026-08-29T00:00:01Z' }],
     ['future observation', { observedAt: new Date(Date.now() + 11 * 60 * 1000).toISOString() }],
   ])('hides a weekly value estimate with %s', async (_case, override) => {
     const renderer = await render_codex({
@@ -495,7 +518,7 @@ describe('Codex weekly pace', () => {
 
     expect(rendered_text(renderer)).toContain('API-equivalent week');
     expect(rendered_text(renderer)).toContain('Last estimate');
-    expect(rendered_text(renderer)).toContain('$200.00');
+    expect(rendered_text(renderer)).toContain('Rough full week ≈$200');
     expect(rendered_text(renderer)).not.toContain('Weekly value unavailable');
     expect(rendered_text(renderer)).toContain('Local extras paused');
     await unmount(renderer);


### PR DESCRIPTION
## Summary

Codex weekly value could use a stale local percentage even when the official snapshot differed by one percentage point. Near 5% usage this materially changes the extrapolation. Always calculate against the official percentage, reset, and observation timestamp together; include observation time in cache identity and reject mismatched estimates in the panel. A missing local pace snapshot no longer discards an otherwise valid official-window value estimate, and official fetch errors remain visible.

Make observed standard API-equivalent cost and observed tokens the primary values. Move the full-week extrapolation to secondary text rounded to two significant digits, and label the card as standard API prices, not a bill or an official allowance. Existing same-window stale estimates remain labeled as last estimates.

Update ccstats to the cache-write and per-request long-context pricing fix in https://github.com/majiayu000/ccstats/pull/176, pinned at `0dfddefec11ecea5dfad5efd2e5725022fb52035`. Merge the upstream PR first. This change does not add Fast-mode premiums or actual purchased-credit billing.

## Verification

- [x] `npm test` — 475 passed
- [x] `npm run build`
- [x] `npm run release:check`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 93 passed, 2 existing manual tests ignored
- [x] Regressions cover low-usage headline/rounding, one-point usage mismatch, one-second reset mismatch, official observation cache identity, missing local pace, and exhausted/stale panels.
- [x] Upstream SDK: 888 tests plus strict Clippy passed; a read-only replay preserved the originally verified usage and cost totals.

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.
- [x] Existing untracked social-preview images are unchanged and excluded.
