### PR TITLE
fix(codex): restore weekly estimate display

### DIFF
--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -116,17 +116,6 @@ const COMPACT_TOKEN_FORMAT = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 1,
 });
 
-const ROUGH_USD_FORMAT = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumSignificantDigits: 2,
-});
-
-const ROUGH_TOKEN_FORMAT = new Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  maximumSignificantDigits: 2,
-});
-
 
 function selectOfficialWeeklyWindow(
   limits: CodexRateLimits | null,
@@ -635,13 +624,13 @@ export default function CodexPanel({
                       <div className="weekly-value-body">
                         <div className="weekly-value-metrics">
                           <span className="weekly-value-amount">
-                            ≈{USD_FORMAT.format(displayedWeeklyValueEstimate.observedCostUsd)}
+                            ≈{USD_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyValueUsd)}
                           </span>
                           <span className="weekly-value-token-row">
                             <strong>
-                              {COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.observedTokens)}
+                              ≈{COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyTokens)}
                             </strong>
-                            <span>observed tokens</span>
+                            <span>tokens at current mix</span>
                           </span>
                         </div>
                         <div
@@ -660,18 +649,15 @@ export default function CodexPanel({
                       </div>
                       <div className="weekly-value-footer weekly-value-footer-basis">
                         <span>
-                          Standard API prices · Not a bill
-                        </span>
-                        <span>
-                          {`Rough full week ≈${ROUGH_USD_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyValueUsd)} · ≈${ROUGH_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.estimatedWeeklyTokens)} tokens at current mix`}
-                        </span>
-                        <span>
-                          {`Based on ${Math.round(displayedWeeklyValueEstimate.usedPct)}% used · Not an official allowance`}
+                          {`Based on ${Math.round(displayedWeeklyValueEstimate.usedPct)}% used · ${USD_FORMAT.format(displayedWeeklyValueEstimate.observedCostUsd)} local`}
                         </span>
                         <span>
                           {valueIsLastEstimate
-                            ? 'Observed usage this week · snapshot not refreshed'
-                            : 'Observed usage this week'}
+                            ? `${COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.observedTokens)} observed tokens · Not an official allowance · snapshot not refreshed`
+                            : `${COMPACT_TOKEN_FORMAT.format(displayedWeeklyValueEstimate.observedTokens)} observed tokens · Not an official allowance`}
+                        </span>
+                        <span>
+                          Standard API prices · Not a bill
                         </span>
                       </div>
                     </>

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -382,15 +382,16 @@ describe('Codex weekly pace', () => {
     expect(rendered_text(renderer)).not.toContain('Likely to exhaust');
     expect(rendered_text(renderer)).not.toContain('% at reset');
     expect(rendered_text(renderer)).toContain('API-equivalent week');
-    expect(rendered_text(renderer)).toContain('Rough full week ≈$200');
+    expect(rendered_text(renderer)).toContain('$200.00');
     expect(rendered_text(renderer)).toContain('4M');
     expect(rendered_text(renderer)).toContain('tokens at current mix');
     expect(rendered_text(renderer)).toContain('Local estimate');
     expect(rendered_text(renderer)).toContain('Based on 40% used');
-    expect(renderer.root.findByProps({ className: 'weekly-value-amount' }).children.join('')).toBe('≈$80.00');
+    expect(renderer.root.findByProps({ className: 'weekly-value-amount' }).children.join('')).toBe('≈$200.00');
     expect(rendered_text(renderer)).toContain('Standard API prices · Not a bill');
-    expect(renderer.root.findByProps({ className: 'weekly-value-token-row' }).findByType('strong').children.join('')).toBe('1.6M');
-    expect(rendered_text(renderer)).toContain('observed tokens');
+    expect(renderer.root.findByProps({ className: 'weekly-value-token-row' }).findByType('strong').children.join('')).toBe('≈4M');
+    expect(rendered_text(renderer)).toContain('1.6M observed tokens');
+    expect(rendered_text(renderer)).toContain('$80.00 local');
     expect(rendered_text(renderer)).toContain('Not an official allowance');
     expect(renderer.root.findByProps({
       'aria-label': 'Estimate based on 40% used',
@@ -432,12 +433,12 @@ describe('Codex weekly pace', () => {
     });
 
     expect(rendered_text(renderer)).toContain('API-equivalent week');
-    expect(rendered_text(renderer)).toContain('Rough full week ≈$200');
+    expect(rendered_text(renderer)).toContain('$200.00');
     expect(rendered_text(renderer)).not.toContain('Local pace:');
     await unmount(renderer);
   });
 
-  it('rounds the full-week extrapolation while keeping observed cost prominent at low usage', async () => {
+  it('keeps the full-week estimate prominent at low usage', async () => {
     const renderer = await render_codex({
       valueEstimate: {
         observedAt: new Date().toISOString(),
@@ -450,9 +451,10 @@ describe('Codex weekly pace', () => {
         estimatedWeeklyTokens: 20_000_000,
       },
     }, null, { usedPercent: 5, windowMinutes: 10_080, resetsAt: 1_787_961_600 });
-    expect(renderer.root.findByProps({ className: 'weekly-value-amount' }).children.join('')).toBe('≈$123.46');
-    expect(rendered_text(renderer)).toContain('Rough full week ≈$2,500');
-    expect(rendered_text(renderer)).not.toContain('$2,469.12');
+    expect(renderer.root.findByProps({ className: 'weekly-value-amount' }).children.join('')).toBe('≈$2,469.12');
+    expect(renderer.root.findByProps({ className: 'weekly-value-token-row' }).findByType('strong').children.join('')).toBe('≈20M');
+    expect(rendered_text(renderer)).toContain('$123.46 local');
+    expect(rendered_text(renderer)).toContain('1M observed tokens');
     await unmount(renderer);
   });
 
@@ -518,7 +520,7 @@ describe('Codex weekly pace', () => {
 
     expect(rendered_text(renderer)).toContain('API-equivalent week');
     expect(rendered_text(renderer)).toContain('Last estimate');
-    expect(rendered_text(renderer)).toContain('Rough full week ≈$200');
+    expect(rendered_text(renderer)).toContain('$200.00');
     expect(rendered_text(renderer)).not.toContain('Weekly value unavailable');
     expect(rendered_text(renderer)).toContain('Local extras paused');
     await unmount(renderer);


### PR DESCRIPTION
Restore the full-week API-equivalent cost and token estimate as the primary Codex card metrics. Observed cost and tokens return to the footer, alongside the quota percentage and standard API pricing explanation. Restore the original currency and compact-token formatting.

The pricing and official quota-window fixes from #132 remain intact.

Validation: 475 frontend tests pass; the production macOS app build succeeds. Installed and relaunched the corrected local bundle.
