### PR TITLE
fix(claude): drive tray and alerts from the hottest window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,12 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Drive the Claude tray, switcher percent, and 80/95 alerts from the hottest quota window instead of `weeklyTotal`.
 - Explain remaining quota and reset timing in high-usage tips, distinguish imminent resets, and suppress advice from stale data.
-
 - Enlarge provider labels, wrap navigation and freshness text, lead Overview with remaining quota, and collapse secondary usage details. Clarify API-price estimates are not actual bills.
-
 - Automatically show detected services until users choose their own panel visibility; keep disconnected services reachable and add a setup shortcut.
-
 - Replace the misleading All percentage with connection counts and label each provider percentage with its quota window.
-
 - Track successful quota refreshes per service; failed refreshes no longer advance the displayed timestamp.
-
 - Start new installs on Overview with service detection, login instructions, and connection checks.
 
 ## 0.5.0 - 2026-09-06

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ This `v0.4.0` screenshot was refreshed on 2026-08-31 from the production React U
 ## Quota Semantics
 
 - Claude tray value:
-  - prefers `weeklyTotal`
-  - falls back to max of `weeklyOpus`, `weeklySonnet`, `weeklyDesign`, and `weeklyFable5`
-  - falls back to current session usage
+  - uses the hottest Claude window (same ranking as the overview/header)
+  - includes the 5-hour session, 7-day All models (`weeklyTotal`), Opus, Sonnet, Design, and Fable 5 windows
+  - keeps `weeklyTotal` as a labeled card, not the implicit tray or 80/95 alert headline
 - Codex tray value:
   - prefers `secondary_window.used_percent`
   - falls back to `primary_window.used_percent`

--- a/src/services/app_state.ts
+++ b/src/services/app_state.ts
@@ -1,7 +1,7 @@
 import type { ThemeName } from '../components/ThemeSelector';
 import type { QuotaData } from '../types/models';
 import { SERVICES } from './service_meta';
-import type { AppTabName } from './provider_summary';
+import { buildClaudeQuotaWindows, sortMostConstrained, type AppTabName } from './provider_summary';
 import { readStorageValue, writeStorageItem } from './storage';
 import { getSavedTrayEnabled, saveTrayEnabled, type TrayServiceName } from './tray_visibility';
 import type { TrayStyle } from './tray_style';
@@ -126,28 +126,7 @@ export function getInitialTrayEnabledState(): TrayEnabledState {
 }
 
 export function getClaudeTrayUsedPercent(quota: QuotaData | null): number | null {
-  if (!quota) return null;
-
-  if (quota.weeklyTotal) {
-    return quota.weeklyTotal.percentage;
-  }
-
-  const weeklyUsedCandidates = [
-    quota.weeklyOpus?.percentage,
-    quota.weeklySonnet?.percentage,
-    quota.weeklyDesign?.percentage,
-    quota.weeklyFable5?.percentage,
-  ]
-    .filter((value): value is number => typeof value === 'number');
-  if (weeklyUsedCandidates.length > 0) {
-    return Math.max(...weeklyUsedCandidates);
-  }
-
-  if (quota.session) {
-    return quota.session.percentage;
-  }
-
-  return null;
+  return sortMostConstrained(buildClaudeQuotaWindows(quota))[0]?.usedPercent ?? null;
 }
 
 export function isClaudeAuthError(error: string): boolean {

--- a/tests/claude_tray_percent.test.ts
+++ b/tests/claude_tray_percent.test.ts
@@ -5,6 +5,7 @@ import {
   getClaudeTrayUsedPercent,
   keepClaudeQuotaOnError,
 } from '../src/App';
+import { buildClaudeQuotaWindows, sortMostConstrained } from '../src/services/provider_summary';
 import type { QuotaData, UsageInfo } from '../src/types/models';
 
 const usage = (percentage: number): UsageInfo => ({
@@ -14,13 +15,35 @@ const usage = (percentage: number): UsageInfo => ({
 });
 
 describe('getClaudeTrayUsedPercent', () => {
-  test('uses weekly total before individual weekly buckets', () => {
-    expect(getClaudeTrayUsedPercent({
+  test('uses the hottest Claude window, not weeklyTotal', () => {
+    const quota: QuotaData = {
       connected: true,
       weeklyTotal: usage(42),
       weeklyDesign: usage(91),
       weeklyFable5: usage(96),
-    })).toBe(42);
+    };
+
+    expect(getClaudeTrayUsedPercent(quota)).toBe(96);
+    expect(getClaudeTrayUsedPercent(quota)).toBe(
+      sortMostConstrained(buildClaudeQuotaWindows(quota))[0]?.usedPercent,
+    );
+  });
+
+  test('keeps weeklyTotal when it is the most constrained window', () => {
+    expect(getClaudeTrayUsedPercent({
+      connected: true,
+      session: usage(12),
+      weeklyTotal: usage(88),
+      weeklyOpus: usage(20),
+    })).toBe(88);
+  });
+
+  test('lets a hotter 5-hour session beat a cooler weeklyTotal', () => {
+    expect(getClaudeTrayUsedPercent({
+      connected: true,
+      session: usage(99),
+      weeklyTotal: usage(42),
+    })).toBe(99);
   });
 
   test('includes Claude Design in weekly bucket fallback', () => {


### PR DESCRIPTION
## Summary

- Drive the Claude tray, switcher percent, and 80/95 alerts from the same most-constrained window as the overview/header (`sortMostConstrained` over `buildClaudeQuotaWindows`).
- Keep All-models `weeklyTotal` as a labeled card instead of the implicit headline. A cooler weekly total no longer hides an exhausted Opus/Design/Fable 5 or 5-hour window.

Fixes #142

## Verification

- [x] `npm test` — 518 passed
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

No Rust changes. Frontend tests updated in `tests/claude_tray_percent.test.ts` to lock Fable 5 96% over weeklyTotal 42%, plus hottest-weeklyTotal and hotter-session cases.

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)