### PR TITLE
fix(ui): clear tray after later Codex and Cursor fetch failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Clear Codex and Cursor tray connection after a later current-generation fetch failure instead of keeping the previous percent.
 - Keep Codex used percent above 100 when ChatGPT reports an over-limit week, instead of clamping it to 100 at parse. Tray PNG digits still cap at 100.
 - Align the marketing site with 0.5.0 and honest privacy copy: quota polling talks to providers you already use, tokens never go to QuotaBar, and cost estimates stay local.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -1,5 +1,5 @@
 import { workspaceCopy } from '../utils/quota_format';
-import { useEffect, useState, useCallback, useRef, type CSSProperties } from 'react';
+import { useEffect, useState, useCallback, type CSSProperties } from 'react';
 import { backend } from '../services/backend';
 import CostSummarySection from './CostSummarySection';
 import ProviderDetailHeader from './ProviderDetailHeader';
@@ -213,7 +213,6 @@ export default function CodexPanel({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [rateLimitsError, setRateLimitsError] = useState<string | null>(null);
-  const hasResolvedData = useRef(false);
   const request_generation = useLatestRequestGeneration();
   const weekly_request_generation = useLatestRequestGeneration();
 
@@ -252,7 +251,6 @@ export default function CodexPanel({
       ]);
       if (!request_generation.isCurrent(generation)) return;
 
-      hasResolvedData.current = true;
       setCodexData(info);
       setRateLimits(limits);
       onQuotaWindowsChange?.(buildCodexQuotaWindows(limits));
@@ -281,11 +279,9 @@ export default function CodexPanel({
       setError(message);
       onReadResult?.(message);
       setRateLimitsError(message);
-      if (!hasResolvedData.current) {
-        onConnectionChange?.(false);
-        onUsageChange?.(null);
-        onQuotaWindowsChange?.([]);
-      }
+      onConnectionChange?.(false);
+      onUsageChange?.(null);
+      onQuotaWindowsChange?.([]);
     } finally {
       if (request_generation.isCurrent(generation)) {
         setLoading(false);

--- a/src/components/CursorPanel.tsx
+++ b/src/components/CursorPanel.tsx
@@ -1,6 +1,5 @@
 import { workspaceCopy } from '../utils/quota_format';
 import { useEffect, useState, useCallback } from 'react';
-import { useRef } from 'react';
 import { backend } from '../services/backend';
 import CostSummarySection from './CostSummarySection';
 import ProviderDetailHeader from './ProviderDetailHeader';
@@ -73,7 +72,6 @@ export default function CursorPanel({
   const [cursorData, setCursorData] = useState<CursorData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const hasResolvedData = useRef(false);
   const request_generation = useLatestRequestGeneration();
 
   const fetchData = useCallback(async () => {
@@ -84,7 +82,6 @@ export default function CursorPanel({
       const data = await backend.getCursorInfo();
       if (!request_generation.isCurrent(generation)) return;
       setCursorData(data);
-      hasResolvedData.current = true;
       if (data.error) {
         setError(data.error);
       }
@@ -97,11 +94,9 @@ export default function CursorPanel({
       const message = err instanceof Error ? err.message : 'Failed to fetch Cursor data';
       setError(message);
       onReadResult?.(message);
-      if (!hasResolvedData.current) {
-        onConnectionChange?.(false);
-        onUsageChange?.(null);
-        onQuotaWindowsChange?.([]);
-      }
+      onConnectionChange?.(false);
+      onUsageChange?.(null);
+      onQuotaWindowsChange?.([]);
     } finally {
       if (request_generation.isCurrent(generation)) {
         setLoading(false);

--- a/tests/panel_status_ui.test.tsx
+++ b/tests/panel_status_ui.test.tsx
@@ -227,7 +227,7 @@ describe('provider status UI', () => {
     await act(async () => renderer.unmount());
   });
 
-  it('labels retained Cursor data as stale after a rejected refresh', async () => {
+  it('clears parent Cursor tray after a later rejected refresh', async () => {
     vi.spyOn(backend, 'getCursorInfo')
       .mockResolvedValueOnce({ connected: true, fastUsed: 231, fastLimit: 500, percentage: 46.2 })
       .mockRejectedValueOnce(new Error('Cursor refresh failed'));
@@ -268,13 +268,13 @@ describe('provider status UI', () => {
     expect(text).toContain('Stale data');
     expect(text).toContain('Showing last known data');
     expect(text).toContain('231 / 500 · 46%');
-    expect(onConnectionChange).not.toHaveBeenCalled();
-    expect(onUsageChange).not.toHaveBeenCalled();
-    expect(onQuotaWindowsChange).not.toHaveBeenCalled();
+    expect(onConnectionChange).toHaveBeenCalledWith(false);
+    expect(onUsageChange).toHaveBeenCalledWith(null);
+    expect(onQuotaWindowsChange).toHaveBeenCalledWith([]);
     await act(async () => renderer.unmount());
   });
 
-  it('keeps parent Codex summaries after a rejected refresh', async () => {
+  it('clears parent Codex tray after a later rejected refresh', async () => {
     vi.spyOn(backend, 'getCodexInfo')
       .mockResolvedValueOnce({ connected: true, planType: 'pro' })
       .mockRejectedValueOnce(new Error('Codex refresh failed'));
@@ -325,9 +325,9 @@ describe('provider status UI', () => {
     expect(text).toContain('Codex refresh failed');
     expect(text).toContain('Stale data');
     expect(text).toContain('5h · 64% used');
-    expect(onConnectionChange).not.toHaveBeenCalled();
-    expect(onUsageChange).not.toHaveBeenCalled();
-    expect(onQuotaWindowsChange).not.toHaveBeenCalled();
+    expect(onConnectionChange).toHaveBeenCalledWith(false);
+    expect(onUsageChange).toHaveBeenCalledWith(null);
+    expect(onQuotaWindowsChange).toHaveBeenCalledWith([]);
     await act(async () => renderer.unmount());
   });
 


### PR DESCRIPTION
## Summary

- After a successful Codex or Cursor payload, a later current-generation IPC failure now publishes `connected=false` and `usage=null` instead of gating those clears on `!hasResolvedData`.
- Match GrokPanel's always-clear failure path. Last-good payloads that already include an error still flow through the success path.

Fixes #147

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)