### PR TITLE
fix(cursor): alert on the most-constrained window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Drive Cursor 80/95 alerts from the most-constrained dashboard window; the tray still shows Cursor Models.
 - Keep Codex used percent above 100 when ChatGPT reports an over-limit week, instead of clamping it to 100 at parse. Tray PNG digits still cap at 100.
 - Align the marketing site with 0.5.0 and honest privacy copy: quota polling talks to providers you already use, tokens never go to QuotaBar, and cost estimates stay local.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -406,7 +406,7 @@ export default function App({ workspace = false }: { workspace?: boolean }) {
     if (!workspace) persistEvents(events);
   }, [events, workspace]);
 
-  useServiceEvents(quota, connected, usedPercent, notifSettings, logEvent, !workspace);
+  useServiceEvents(quota, connected, usedPercent, notifSettings, logEvent, !workspace, providerQuotaWindows.cursor);
 
   const showSwitcherGuardToast = useCallback(() => {
     if (switcherGuardTimerRef.current !== null) {

--- a/src/hooks/use_service_events.ts
+++ b/src/hooks/use_service_events.ts
@@ -8,6 +8,7 @@ import {
 } from '../services/notifications';
 import type { EventLevel } from '../services/event_log';
 import type { QuotaData } from '../types/models';
+import { getCursorAlertUsedPercent, type QuotaWindowSummary } from '../services/provider_summary';
 import { STORAGE_READ_FAILURE_MESSAGE, subscribeStorageReadFailures } from '../services/storage';
 import { TRAY_GUARD_TOAST_MS } from '../services/app_state';
 
@@ -38,6 +39,7 @@ export function useServiceEvents(
   notifSettings: NotificationSettings,
   logEvent: (level: EventLevel, text: string) => void,
   enabled = true,
+  cursorWindows: QuotaWindowSummary[] = [],
 ): void {
   const prevServiceStateRef = useRef<ServiceMap<ServiceSnapshot> | null>(null);
 
@@ -46,7 +48,11 @@ export function useServiceEvents(
     const current = SERVICES.reduce((acc, svc) => {
       acc[svc] = {
         connected: svc === 'claude' ? quota?.connected ?? false : connected[svc],
-        used: svc === 'claude' ? getClaudeTrayUsedPercent(quota) : usedPercent[svc],
+        used: svc === 'claude'
+          ? getClaudeTrayUsedPercent(quota)
+          : svc === 'cursor'
+            ? (getCursorAlertUsedPercent(cursorWindows) ?? usedPercent.cursor)
+            : usedPercent[svc],
       };
       return acc;
     }, {} as ServiceMap<ServiceSnapshot>);
@@ -99,5 +105,5 @@ export function useServiceEvents(
         }
       }
     }
-  }, [quota, connected, usedPercent, logEvent, notifSettings.q80, notifSettings.q95, notifSettings.q100, enabled]);
+  }, [quota, connected, usedPercent, logEvent, notifSettings.q80, notifSettings.q95, notifSettings.q100, enabled, cursorWindows]);
 }

--- a/src/services/provider_summary.ts
+++ b/src/services/provider_summary.ts
@@ -187,6 +187,14 @@ export function getCursorTrayUsedPercent(cursorData: CursorData | null): number 
   return null;
 }
 
+export function getCursorAlertUsedPercent(
+  source: CursorData | QuotaWindowSummary[] | null,
+): number | null {
+  if (source == null) return null;
+  const windows = Array.isArray(source) ? source : buildCursorQuotaWindows(source);
+  return sortMostConstrained(windows)[0]?.usedPercent ?? null;
+}
+
 export function buildGrokQuotaWindows(grokData: GrokData | null): QuotaWindowSummary[] {
   if (!grokData?.connected || typeof grokData.percentage !== 'number') return [];
   const windows: QuotaWindowSummary[] = [{

--- a/tests/provider_summary.test.ts
+++ b/tests/provider_summary.test.ts
@@ -5,6 +5,7 @@ import {
   buildClaudeQuotaWindows,
   buildCursorQuotaWindows,
   buildGrokQuotaWindows,
+  getCursorAlertUsedPercent,
   getCursorTrayUsedPercent,
   sortMostConstrained,
   sortUpcomingResets,
@@ -87,6 +88,31 @@ describe('provider summary helpers', () => {
       percentage: 46.2,
     })).toBe(46.2);
     expect(getCursorTrayUsedPercent(null)).toBeNull();
+  });
+
+  test('drives Cursor alerts from the most-constrained window, not Cursor Models', () => {
+    expect(getCursorAlertUsedPercent({
+      connected: true,
+      percentage: 91.082,
+      autoPercent: 2.888,
+      apiPercent: 91.082,
+    })).toBe(91.082);
+    expect(getCursorAlertUsedPercent({
+      connected: true,
+      autoPercent: 17,
+      apiPercent: 10,
+    })).toBe(17);
+    expect(getCursorAlertUsedPercent({
+      connected: true,
+      percentage: 46.2,
+    })).toBe(46.2);
+    expect(getCursorAlertUsedPercent(null)).toBeNull();
+    expect(getCursorAlertUsedPercent({ connected: false, autoPercent: 3, apiPercent: 90 })).toBeNull();
+    expect(getCursorAlertUsedPercent(buildCursorQuotaWindows({
+      connected: true,
+      autoPercent: 2.888,
+      apiPercent: 91.082,
+    }))).toBe(91.082);
   });
 
   test('uses a neutral label for summary fallback usage', () => {

--- a/tests/service_events.test.tsx
+++ b/tests/service_events.test.tsx
@@ -29,15 +29,24 @@ function Host({
   used,
   settings = ALL_ON,
   enabled = true,
+  cursorWindows = [],
   logEvent,
 }: {
   used: ServiceMap<number | null>;
   settings?: NotificationSettings;
   enabled?: boolean;
+  cursorWindows?: Array<{ provider: 'cursor'; providerLabel: string; label: string; usedPercent: number }>;
   logEvent: (level: 'info' | 'warning' | 'critical', text: string) => void;
 }) {
-  useServiceEvents(null, defaultServiceMap(true), used, settings, logEvent, enabled);
+  useServiceEvents(null, defaultServiceMap(true), used, settings, logEvent, enabled, cursorWindows);
   return null;
+}
+
+function cursorDashboardWindows(autoPercent: number, apiPercent: number) {
+  return [
+    { provider: 'cursor' as const, providerLabel: 'Cursor', label: 'Cursor Models', usedPercent: autoPercent },
+    { provider: 'cursor' as const, providerLabel: 'Cursor', label: 'Other Models', usedPercent: apiPercent },
+  ];
 }
 
 describe('useServiceEvents 100% crossings', () => {
@@ -126,6 +135,90 @@ describe('useServiceEvents 100% crossings', () => {
     });
 
     expect(logEvent.mock.calls.some((call) => String(call[1]).includes('bonus reset'))).toBe(false);
+    await act(async () => renderer.unmount());
+  });
+});
+
+describe('useServiceEvents Cursor hottest-window alerts', () => {
+  afterEach(() => {
+    vi.mocked(notifications.notify).mockClear();
+  });
+
+  it('fires 80/95 from Other Models even when the tray stays on Cursor Models', async () => {
+    const logEvent = vi.fn();
+    const trayUsed = { ...defaultServiceMap<number | null>(null), cursor: 2.888 };
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(Host, {
+        used: trayUsed,
+        cursorWindows: cursorDashboardWindows(2.888, 70),
+        logEvent,
+      }));
+    });
+    await act(async () => {
+      renderer.update(createElement(Host, {
+        used: trayUsed,
+        cursorWindows: cursorDashboardWindows(2.888, 96),
+        logEvent,
+      }));
+    });
+
+    expect(logEvent).toHaveBeenCalledWith('critical', 'Cursor usage crossed 95%');
+    expect(logEvent).not.toHaveBeenCalledWith('warning', 'Cursor usage crossed 80%');
+    expect(vi.mocked(notifications.notify).mock.calls.map((call) => call[1])).toEqual([
+      'Cursor usage crossed 95%',
+    ]);
+    await act(async () => renderer.unmount());
+  });
+
+  it('fires 80 from Other Models while the tray Models percent stays low', async () => {
+    const logEvent = vi.fn();
+    const trayUsed = { ...defaultServiceMap<number | null>(null), cursor: 3 };
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(Host, {
+        used: trayUsed,
+        cursorWindows: cursorDashboardWindows(3, 70),
+        logEvent,
+      }));
+    });
+    await act(async () => {
+      renderer.update(createElement(Host, {
+        used: trayUsed,
+        cursorWindows: cursorDashboardWindows(3, 81),
+        logEvent,
+      }));
+    });
+
+    expect(logEvent).toHaveBeenCalledWith('warning', 'Cursor usage crossed 80%');
+    expect(logEvent).not.toHaveBeenCalledWith('critical', 'Cursor usage crossed 95%');
+    expect(vi.mocked(notifications.notify).mock.calls.map((call) => call[1])).toEqual([
+      'Cursor usage crossed 80%',
+    ]);
+    await act(async () => renderer.unmount());
+  });
+
+  it('does not fire Cursor 80/95 from the Models tray percent when Other Models is already the hottest window', async () => {
+    const logEvent = vi.fn();
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(Host, {
+        used: { ...defaultServiceMap<number | null>(null), cursor: 3 },
+        cursorWindows: cursorDashboardWindows(3, 90),
+        logEvent,
+      }));
+    });
+    await act(async () => {
+      renderer.update(createElement(Host, {
+        used: { ...defaultServiceMap<number | null>(null), cursor: 81 },
+        cursorWindows: cursorDashboardWindows(81, 90),
+        logEvent,
+      }));
+    });
+
+    expect(logEvent).not.toHaveBeenCalledWith('warning', 'Cursor usage crossed 80%');
+    expect(logEvent).not.toHaveBeenCalledWith('critical', 'Cursor usage crossed 95%');
+    expect(notifications.notify).not.toHaveBeenCalled();
     await act(async () => renderer.unmount());
   });
 });


### PR DESCRIPTION
## Summary

- Drive Cursor 80/95 alerts from the most-constrained dashboard window (`max` of Cursor Models / Other Models via `sortMostConstrained`).
- Keep the Cursor tray on Cursor Models (`autoPercent`); `CursorPanel` `onUsageChange` is unchanged.
- Fixes #143.

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)