### PR TITLE
fix(codex): show n/a when credit balance is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Show n/a when Codex credits exist without a balance instead of treating a missing value as 0.
 - Keep unpriced local-cost days as a sparkline gap or n/a instead of drawing them as $0.00.
 - Ignore slower in-flight tray IPC completions so the skip-cache cannot hide a newer icon tuple until the 60s force tick.
 - Omit Grok product rows that lack `usagePercent` instead of drawing a fake 0%.

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -595,7 +595,7 @@ export default function CodexPanel({
                       <span className="quota-value">
                         {rateLimits.credits.unlimited
                           ? 'Unlimited'
-                          : rateLimits.credits.balance || '0'}
+                          : rateLimits.credits.balance ?? 'n/a'}
                       </span>
                     </div>
                   </div>

--- a/tests/panel_status_ui.test.tsx
+++ b/tests/panel_status_ui.test.tsx
@@ -489,6 +489,49 @@ describe('provider status UI', () => {
     expect(progress.props['aria-label']).toBe('Cursor usage');
     await act(async () => renderer.unmount());
   });
+
+  it('shows n/a when Codex credits exist without a balance', async () => {
+    async function renderCredits(credits: { hasCredits: boolean; unlimited: boolean; balance?: string }) {
+      vi.spyOn(backend, 'getCodexInfo').mockResolvedValue({ connected: true, planType: 'plus' });
+      vi.spyOn(backend, 'getCodexRateLimits').mockResolvedValue({
+        connected: true,
+        planType: 'plus',
+        primary: { usedPercent: 10, windowMinutes: 300 },
+        credits,
+      });
+      vi.spyOn(backend, 'getCodexResetCredits').mockResolvedValue({
+        connected: true,
+        availableCount: 0,
+        credits: [],
+      });
+      vi.spyOn(backend, 'getCodexWeeklyQuota').mockResolvedValue({});
+      let renderer!: ReactTestRenderer;
+      await act(async () => {
+        renderer = create(createElement(CodexPanel, {
+          autoRefreshIntervalMs: 0,
+          showCostSummary: false,
+          sections: hiddenSections,
+        }));
+        await Promise.resolve();
+      });
+      return renderer;
+    }
+
+    function creditValue(renderer: ReactTestRenderer): string {
+      const label = renderer.root.findAllByProps({ className: 'quota-label' })
+        .find((node) => node.children.includes('Credits'));
+      expect(label).toBeDefined();
+      return label!.parent!.findByProps({ className: 'quota-value' }).children.join('');
+    }
+
+    const missing = await renderCredits({ hasCredits: true, unlimited: false });
+    expect(creditValue(missing)).toBe('n/a');
+    await act(async () => missing.unmount());
+
+    const zero = await renderCredits({ hasCredits: true, unlimited: false, balance: '0' });
+    expect(creditValue(zero)).toBe('0');
+    await act(async () => zero.unmount());
+  });
 });
 
 


### PR DESCRIPTION
## Summary

- Render Codex credits as `n/a` when `hasCredits` is true but `balance` is omitted, instead of `balance || '0'`.
- Keep numeric `0` only when the backend sent `"0"`.

Fixes #154

Stacked on #160.

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)