### PR TITLE
fix(cursor): move state.vscdb sqlite reads off the async worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Move Cursor `state.vscdb` sqlite open and query onto `spawn_blocking` so a locked database cannot stall other quota and tray commands.
 - Apply the saved Hide Dock preference during native startup so the Dock icon does not flash before the webview mounts.
 - Keep Codex used percent above 100 when ChatGPT reports an over-limit week, instead of clamping it to 100 at parse. Tray PNG digits still cap at 100.
 - Align the marketing site with 0.5.0 and honest privacy copy: quota polling talks to providers you already use, tokens never go to QuotaBar, and cost estimates stay local.

--- a/src-tauri/src/services/cursor.rs
+++ b/src-tauri/src/services/cursor.rs
@@ -265,9 +265,14 @@ pub async fn fetch_cursor_info() -> CursorData {
         return cached;
     }
 
-    let session = match get_cursor_session() {
-        Ok(session) => session,
-        Err(error) => return fallback_or_disconnected(error),
+    // rusqlite open+query on state.vscdb can block on a locked DB; keep it off
+    // the async worker the same way Claude OAuth and cost summaries do.
+    let session = match tauri::async_runtime::spawn_blocking(get_cursor_session).await {
+        Ok(Ok(session)) => session,
+        Ok(Err(error)) => return fallback_or_disconnected(error),
+        Err(error) => {
+            return fallback_or_disconnected(format!("Cursor session task failed: {error}"))
+        }
     };
 
     let cookie = match workos_cookie_value(&session.token) {


### PR DESCRIPTION
## Summary

- Run Cursor `state.vscdb` rusqlite open+query on `spawn_blocking` so a locked database cannot stall other quota and tray commands on the Tauri async worker. `fetch_cursor_info` stays async; `busy_timeout` is unchanged.

Fixes #148

## Verification

- [x] `npm test` (run on stacked follow-up)
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.


Made with [Cursor](https://cursor.com)