### PR TITLE
fix(cursor): skip the 120s success cache on manual refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Let Cursor Refresh skip the 120s success cache so a manual refresh hits the network like Claude.
 - Keep unpriced local-cost days as a sparkline gap or n/a instead of drawing them as $0.00.
 - Ignore slower in-flight tray IPC completions so the skip-cache cannot hide a newer icon tuple until the 60s force tick.
 - Omit Grok product rows that lack `usagePercent` instead of drawing a fake 0%.

--- a/scripts/check_latest_request_wiring.mjs
+++ b/scripts/check_latest_request_wiring.mjs
@@ -52,7 +52,7 @@ const owner_configs = [
     loading_setter: 'setLoading',
     await_kind: 'direct',
     target_scope: 'component',
-    backend_arguments: { getCursorInfo: [] },
+    backend_arguments: { getCursorInfo: ['manual'] },
   },
   {
     path: 'src/components/AntigravityPanel.tsx',

--- a/scripts/check_latest_request_wiring.test.mjs
+++ b/scripts/check_latest_request_wiring.test.mjs
@@ -193,8 +193,8 @@ test('rejects a generation hook moved outside its owning component', () => {
 test('rejects a wrong token in a terminal guard', () => {
   rejects_change(
     paths.cursor,
-    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
-    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(wrong_generation)) return;',
+    '      const data = await backend.getCursorInfo(manual);\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo(manual);\n      if (!request_generation.isCurrent(wrong_generation)) return;',
     /success guard/,
   );
 });
@@ -229,8 +229,8 @@ test('rejects a dead-code terminal guard', () => {
 test('rejects a current check that does not return', () => {
   rejects_change(
     paths.cursor,
-    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
-    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) console.error(generation);',
+    '      const data = await backend.getCursorInfo(manual);\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo(manual);\n      if (!request_generation.isCurrent(generation)) console.error(generation);',
     /success guard/,
   );
 });
@@ -238,16 +238,16 @@ test('rejects a current check that does not return', () => {
 test('accepts a fail-closed guard with a one-return block', () => {
   accepts_change(
     paths.cursor,
-    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
-    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) { return; }',
+    '      const data = await backend.getCursorInfo(manual);\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo(manual);\n      if (!request_generation.isCurrent(generation)) { return; }',
   );
 });
 
 test('rejects a terminal guard with the wrong prefix operator', () => {
   rejects_change(
     paths.cursor,
-    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
-    '      const data = await backend.getCursorInfo();\n      if (+request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo(manual);\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo(manual);\n      if (+request_generation.isCurrent(generation)) return;',
     /success guard/,
   );
 });
@@ -255,8 +255,8 @@ test('rejects a terminal guard with the wrong prefix operator', () => {
 test('rejects a terminal guard with extra token arguments', () => {
   rejects_change(
     paths.cursor,
-    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation)) return;',
-    '      const data = await backend.getCursorInfo();\n      if (!request_generation.isCurrent(generation, generation)) return;',
+    '      const data = await backend.getCursorInfo(manual);\n      if (!request_generation.isCurrent(generation)) return;',
+    '      const data = await backend.getCursorInfo(manual);\n      if (!request_generation.isCurrent(generation, generation)) return;',
     /success guard/,
   );
 });
@@ -323,14 +323,14 @@ for (const [name, replacement] of malformed_start_fixtures) {
 }
 
 test('rejects a wrong backend await mapping', () => {
-  rejects_change(paths.cursor, 'backend.getCursorInfo()', 'backend.getQuota()', /backend call count|await mapping/);
+  rejects_change(paths.cursor, 'backend.getCursorInfo(manual)', 'backend.getQuota()', /backend call count|await mapping/);
 });
 
 const attached_alias_call_fixtures = [
   [
     'direct',
     paths.cursor,
-    'backend.getCursorInfo()',
+    'backend.getCursorInfo(manual)',
     'backend.getCursorInfo(backend_alias.getCursorInfo())',
   ],
   [
@@ -382,7 +382,7 @@ test('rejects a duplicate expected backend method outside the owner target', () 
 test('rejects a nested dead compliant target in place of the direct owner target', () => {
   rejects_change(
     paths.cursor,
-    '  const fetchData = useCallback(async () => {',
+    '  const fetchData = useCallback(async (manual = false) => {',
     `  if (false) {
     const fetchData = useCallback(async () => {
       const generation = request_generation.begin();
@@ -406,8 +406,8 @@ test('rejects a nested dead compliant target in place of the direct owner target
 test('rejects an expected backend call that is not awaited', () => {
   rejects_change(
     paths.cursor,
-    'const data = await backend.getCursorInfo();',
-    'const data = (backend.getCursorInfo(), await Promise.resolve({ connected: true }));',
+    'const data = await backend.getCursorInfo(manual);',
+    'const data = (backend.getCursorInfo(manual), await Promise.resolve({ connected: true }));',
     /backend call owner/,
   );
 });
@@ -415,8 +415,8 @@ test('rejects an expected backend call that is not awaited', () => {
 test('rejects an identifier await operand with an attached backend call', () => {
   rejects_change(
     paths.cursor,
-    'const data = await backend.getCursorInfo();',
-    'const data = await getData(backend.getCursorInfo());',
+    'const data = await backend.getCursorInfo(manual);',
+    'const data = await getData(backend.getCursorInfo(manual));',
     /backend call owner/,
   );
 });
@@ -424,8 +424,8 @@ test('rejects an identifier await operand with an attached backend call', () => 
 test('rejects an expected backend call discarded inside the await operand', () => {
   rejects_change(
     paths.cursor,
-    'const data = await backend.getCursorInfo();',
-    'const data = await (backend.getCursorInfo(), Promise.resolve({ connected: true }));',
+    'const data = await backend.getCursorInfo(manual);',
+    'const data = await (backend.getCursorInfo(manual), Promise.resolve({ connected: true }));',
     /directly await/,
   );
 });

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -451,8 +451,12 @@ pub async fn get_codex_weekly_quota() -> Result<CodexWeeklyQuotaData, String> {
 }
 
 #[tauri::command]
-pub async fn get_cursor_info() -> Result<CursorData, String> {
-    Ok(provider_read(&CURSOR_READ, cursor::fetch_cursor_info()).await)
+pub async fn get_cursor_info(manual: Option<bool>) -> Result<CursorData, String> {
+    Ok(provider_read(
+        &CURSOR_READ,
+        cursor::fetch_cursor_info(manual.unwrap_or(false)),
+    )
+    .await)
 }
 
 #[tauri::command]

--- a/src-tauri/src/services/cursor.rs
+++ b/src-tauri/src/services/cursor.rs
@@ -205,6 +205,14 @@ fn get_cached_cursor() -> Option<CursorData> {
     }
 }
 
+fn cached_cursor_for_fetch(manual: bool) -> Option<CursorData> {
+    if manual {
+        None
+    } else {
+        get_cached_cursor()
+    }
+}
+
 /// Return last cached value regardless of TTL, but only if it represents a
 /// successful connection. Used to absorb transient OS errors without flashing
 /// the UI.
@@ -260,8 +268,8 @@ fn save_cursor_cache(data: &CursorData) {
     }
 }
 
-pub async fn fetch_cursor_info() -> CursorData {
-    if let Some(cached) = get_cached_cursor() {
+pub async fn fetch_cursor_info(manual: bool) -> CursorData {
+    if let Some(cached) = cached_cursor_for_fetch(manual) {
         return cached;
     }
 
@@ -678,6 +686,23 @@ mod tests {
         }));
         assert!(connected.connected);
         assert!(should_persist_cursor_cache(&connected));
+    }
+
+    #[test]
+    fn manual_refresh_skips_fresh_success_cache() {
+        let connected = parse_cursor_payload(&serde_json::json!({
+            "membershipType": "pro",
+            "individualUsage": {
+                "plan": { "totalPercentUsed": 12.0 }
+            }
+        }));
+        save_cursor_cache(&connected);
+        assert!(get_cached_cursor().is_some());
+        assert!(cached_cursor_for_fetch(false).is_some());
+        assert!(cached_cursor_for_fetch(true).is_none());
+        if let Ok(mut guard) = cursor_cache().lock() {
+            *guard = None;
+        }
     }
 
     #[test]

--- a/src/components/CursorPanel.tsx
+++ b/src/components/CursorPanel.tsx
@@ -74,12 +74,12 @@ export default function CursorPanel({
   const [error, setError] = useState<string | null>(null);
   const request_generation = useLatestRequestGeneration();
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (manual = false) => {
     const generation = request_generation.begin();
     try {
       setLoading(true);
       setError(null);
-      const data = await backend.getCursorInfo();
+      const data = await backend.getCursorInfo(manual);
       if (!request_generation.isCurrent(generation)) return;
       setCursorData(data);
       if (data.error) {
@@ -105,10 +105,12 @@ export default function CursorPanel({
   }, [onConnectionChange, onQuotaWindowsChange, onReadResult, onUsageChange, request_generation]);
 
   useEffect(() => {
-    fetchData();
+    void fetchData();
     // 0 pauses background polling.
     if (autoRefreshIntervalMs <= 0) return;
-    const interval = setInterval(fetchData, autoRefreshIntervalMs);
+    const interval = setInterval(() => {
+      void fetchData();
+    }, autoRefreshIntervalMs);
     return () => clearInterval(interval);
   }, [fetchData, autoRefreshIntervalMs]);
 
@@ -118,7 +120,7 @@ export default function CursorPanel({
 
   useEffect(() => {
     if (manualRefreshNonce > 0) {
-      fetchData();
+      void fetchData(true);
     }
   }, [manualRefreshNonce, fetchData]);
 

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -106,8 +106,8 @@ export const backend = {
     return invokeBackend<CodexWeeklyQuotaData>('get_codex_weekly_quota');
   },
 
-  getCursorInfo() {
-    return invokeBackend<CursorData>('get_cursor_info');
+  getCursorInfo(manual = false) {
+    return invokeBackend<CursorData>('get_cursor_info', { manual });
   },
 
   getAntigravityInfo() {

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -1096,10 +1096,13 @@ describe('provider read status propagation', () => {
     const element = (nonce: number) => createElement(CursorPanel, { autoRefreshIntervalMs: 0, showCostSummary: false, manualRefreshNonce: nonce, onReadResult: readResult });
     await act(async () => { renderer = create(element(0)); });
     expect(readResult).toHaveBeenLastCalledWith(null);
+    expect(backend.getCursorInfo).toHaveBeenLastCalledWith(false);
     await act(async () => renderer.update(element(1)));
     expect(readResult).toHaveBeenLastCalledWith('Temporary outage');
+    expect(backend.getCursorInfo).toHaveBeenLastCalledWith(true);
     await act(async () => renderer.update(element(2)));
     expect(readResult).toHaveBeenLastCalledWith('Offline');
+    expect(backend.getCursorInfo).toHaveBeenLastCalledWith(true);
     await unmount(renderer);
   });
 });


### PR DESCRIPTION
## Summary

- Add `fetch_cursor_info(manual)` so a Cursor Refresh skips the 120s success cache and hits the network, matching Claude.
- `get_cursor_info(manual: Option<bool>)` defaults to false; `backend.getCursorInfo(manual = false)` passes `{ manual }`.
- App already bumps `refreshNonces.cursor`; CursorPanel now calls `getCursorInfo(true)` on that nonce. No App rewrite.

Grok still uses the 120s success cache. This is the Cursor half only.

Stacked on #163.

Refs #145

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.


Made with [Cursor](https://cursor.com)