### PR TITLE
fix(codex): keep used percent above 100 at parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Keep Codex used percent above 100 when ChatGPT reports an over-limit week, instead of clamping it to 100 at parse. Tray PNG digits still cap at 100.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.
 - Drive the Claude tray, switcher percent, and 80/95 alerts from the hottest quota window instead of `weeklyTotal`.
 - Explain remaining quota and reset timing in high-usage tips, distinguish imminent resets, and suppress advice from stale data.

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -161,7 +161,7 @@ fn parse_used_percent(window: &serde_json::Value) -> Option<f64> {
     window
         .get("used_percent")
         .and_then(|value| value.as_f64().or_else(|| value.as_i64().map(|v| v as f64)))
-        .map(|value| value.clamp(0.0, 100.0))
+        .map(|value| value.max(0.0))
 }
 
 fn window_minutes_from_seconds(seconds: i64) -> i64 {
@@ -552,7 +552,7 @@ pub async fn fetch_codex_reset_credits() -> CodexResetCredits {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_rate_limit_window, parse_reset_credit, retain_last_good_info,
+        parse_rate_limit_window, parse_reset_credit, parse_used_percent, retain_last_good_info,
         should_preserve_for_status, should_preserve_transport_failure, window_minutes_from_seconds,
         AuthFileStamp, CodexData, LastGoodInfo,
     };
@@ -651,18 +651,24 @@ mod tests {
     }
 
     #[test]
-    fn parse_rate_limit_window_clamps_numeric_used_percent() {
-        let high = match parse_rate_limit_window(&json!({ "used_percent": 120 })) {
+    fn parse_used_percent_preserves_over_limit_usage() {
+        assert_eq!(
+            parse_used_percent(&json!({ "used_percent": 130 })),
+            Some(130.0)
+        );
+        let window = match parse_rate_limit_window(&json!({ "used_percent": 130 })) {
             Some(window) => window,
             None => panic!("numeric used_percent should parse"),
         };
-        let low = match parse_rate_limit_window(&json!({ "used_percent": -5 })) {
-            Some(window) => window,
-            None => panic!("numeric used_percent should parse"),
-        };
+        assert_eq!(window.used_percent, 130.0);
+    }
 
-        assert_eq!(high.used_percent, 100.0);
-        assert_eq!(low.used_percent, 0.0);
+    #[test]
+    fn parse_used_percent_floors_negative_usage() {
+        assert_eq!(
+            parse_used_percent(&json!({ "used_percent": -5 })),
+            Some(0.0)
+        );
     }
 
     fn auth_stamp(len: u64, secs: u64) -> AuthFileStamp {


### PR DESCRIPTION
## Summary

- Stop clamping Codex `used_percent` to 100 at parse so over-limit weeks keep their magnitude through IPC, the panel, and tray tooltips. CSS/aria progress bars still clamp; tray PNG digits still cap at 100.

Fixes #155

## Verification

- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

No TypeScript changes.

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)