### PR TITLE
fix(macos): apply Hide Dock preference at native startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Apply the saved Hide Dock preference during native startup so the Dock icon does not flash before the webview mounts.
 - Keep Codex used percent above 100 when ChatGPT reports an over-limit week, instead of clamping it to 100 at parse. Tray PNG digits still cap at 100.
 - Align the marketing site with 0.5.0 and honest privacy copy: quota polling talks to providers you already use, tokens never go to QuotaBar, and cost estimates stay local.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,9 +74,7 @@ pub fn run() {
         .setup(|app| {
             #[cfg(target_os = "macos")]
             {
-                use tauri::ActivationPolicy;
-                // Default to visible Dock; user can toggle to Accessory from UI.
-                app.set_activation_policy(ActivationPolicy::Regular);
+                services::window::apply_startup_activation_policy(app.handle());
             }
 
             services::tray::setup_tray(app.handle())?;

--- a/src-tauri/src/services/window.rs
+++ b/src-tauri/src/services/window.rs
@@ -1,3 +1,7 @@
+use std::fs;
+use std::path::Path;
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Mutex,
@@ -84,6 +88,66 @@ fn apply_dock_visibility(app: &AppHandle) -> tauri::Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+fn dock_pref_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|dir| dir.join("quotabar").join("dock-hidden"))
+}
+
+fn parse_dock_hidden(text: &str) -> Option<bool> {
+    match text.trim() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn read_dock_hidden_from(path: &Path) -> Option<bool> {
+    parse_dock_hidden(&fs::read_to_string(path).ok()?)
+}
+
+fn write_dock_hidden_to(path: &Path, hidden: bool) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to persist dock preference directory: {error}"))?;
+    }
+    fs::write(path, if hidden { "true\n" } else { "false\n" })
+        .map_err(|error| format!("Failed to persist dock preference: {error}"))
+}
+
+#[cfg(target_os = "macos")]
+fn persist_dock_hidden(hidden: bool) {
+    let Some(path) = dock_pref_path() else {
+        eprintln!("[Dock] data directory unavailable; skip persisting Hide Dock");
+        return;
+    };
+    if let Err(error) = write_dock_hidden_to(&path, hidden) {
+        eprintln!("[Dock] {error}");
+    }
+}
+
+fn dock_visible_from_pref(hidden: Option<bool>) -> bool {
+    !hidden.unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
+fn load_persisted_dock_visible() -> bool {
+    dock_visible_from_pref(dock_pref_path().and_then(|path| read_dock_hidden_from(&path)))
+}
+
+#[cfg(target_os = "macos")]
+pub fn apply_startup_activation_policy(app: &AppHandle) {
+    let visible = load_persisted_dock_visible();
+    DOCK_VISIBLE.store(visible, Ordering::SeqCst);
+    let policy = if visible {
+        tauri::ActivationPolicy::Regular
+    } else {
+        tauri::ActivationPolicy::Accessory
+    };
+    if let Err(error) = app.set_activation_policy(policy) {
+        eprintln!("Failed to apply dock preference: {error}");
+    }
+}
+
 pub async fn resize_window(app: AppHandle, height: f64) -> Result<(), String> {
     if let Some(window) = app.get_webview_window("main") {
         let size = LogicalSize::new(340.0, height);
@@ -93,6 +157,55 @@ pub async fn resize_window(app: AppHandle, height: f64) -> Result<(), String> {
 }
 
 pub async fn set_dock_visibility(app: AppHandle, visible: bool) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    persist_dock_hidden(!visible);
     DOCK_VISIBLE.store(visible, Ordering::SeqCst);
     apply_dock_visibility(&app).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        dock_visible_from_pref, parse_dock_hidden, read_dock_hidden_from, write_dock_hidden_to,
+    };
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_pref_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "quotabar-dock-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).expect("temp dock pref dir");
+        dir
+    }
+
+    #[test]
+    fn round_trips_dock_hidden_pref() {
+        let dir = temp_pref_dir();
+        let path = dir.join("dock-hidden");
+        write_dock_hidden_to(&path, true).expect("write hidden");
+        assert_eq!(read_dock_hidden_from(&path), Some(true));
+        write_dock_hidden_to(&path, false).expect("write visible");
+        assert_eq!(read_dock_hidden_from(&path), Some(false));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn missing_or_invalid_dock_pref_defaults_to_visible() {
+        let dir = temp_pref_dir();
+        let path = dir.join("dock-hidden");
+        assert_eq!(read_dock_hidden_from(&path), None);
+        fs::write(&path, "nope\n").expect("write invalid");
+        assert_eq!(parse_dock_hidden("nope"), None);
+        assert_eq!(read_dock_hidden_from(&path), None);
+        assert!(dock_visible_from_pref(None));
+        assert!(dock_visible_from_pref(Some(false)));
+        assert!(!dock_visible_from_pref(Some(true)));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
 }


### PR DESCRIPTION
## Summary

- Persist Hide Dock to `dirs::data_dir()/quotabar/dock-hidden` when `set_dock_visibility` runs, and apply Accessory or Regular from that file in setup before showing Regular. The existing `claude-quota-dock-hidden` localStorage key still drives the JS toggle.

Fixes #152

## Verification

- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

No TypeScript changes. macOS-only activation policy.

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)