### PR TITLE
fix: write Claude and Codex logs to OS-correct directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Write Claude and Codex diagnostic logs to the OS cache or local data directory on Windows and Linux, keep macOS on `~/Library/Logs/quotabar`, and skip logging when that directory cannot be resolved.
 - Keep Codex used percent above 100 when ChatGPT reports an over-limit week, instead of clamping it to 100 at parse. Tray PNG digits still cap at 100.
 - Align the marketing site with 0.5.0 and honest privacy copy: quota polling talks to providers you already use, tokens never go to QuotaBar, and cost estimates stay local.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.

--- a/src-tauri/src/services/claude.rs
+++ b/src-tauri/src/services/claude.rs
@@ -61,9 +61,9 @@ fn log_msg(msg: &str) {
 
     print!("{line}");
 
-    let log_dir = dirs::home_dir()
-        .unwrap_or_default()
-        .join("Library/Logs/quotabar");
+    let Some(log_dir) = super::log_path::diagnostic_log_dir() else {
+        return;
+    };
     if let Err(e) = std::fs::create_dir_all(&log_dir) {
         eprintln!("[log] failed to create log dir: {e}");
         return;

--- a/src-tauri/src/services/codex.rs
+++ b/src-tauri/src/services/codex.rs
@@ -30,14 +30,9 @@ fn log_msg(msg: &str) {
 
     print!("{line}");
 
-    let home_dir = match dirs::home_dir() {
-        Some(path) => path,
-        None => {
-            eprintln!("[CodexLog] failed to resolve home directory");
-            return;
-        }
+    let Some(log_dir) = super::log_path::diagnostic_log_dir() else {
+        return;
     };
-    let log_dir = home_dir.join("Library/Logs/quotabar");
     if let Err(error) = fs::create_dir_all(&log_dir) {
         eprintln!("[CodexLog] failed to create log directory: {error}");
         return;

--- a/src-tauri/src/services/log_path.rs
+++ b/src-tauri/src/services/log_path.rs
@@ -1,0 +1,85 @@
+use std::path::PathBuf;
+
+pub(crate) fn diagnostic_log_dir() -> Option<PathBuf> {
+    resolve_diagnostic_log_dir(dirs::home_dir(), dirs::cache_dir(), dirs::data_local_dir())
+}
+
+pub(crate) fn resolve_diagnostic_log_dir(
+    home_dir: Option<PathBuf>,
+    cache_dir: Option<PathBuf>,
+    data_local_dir: Option<PathBuf>,
+) -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = (cache_dir, data_local_dir);
+        home_dir.map(|home| home.join("Library/Logs/quotabar"))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = home_dir;
+        cache_dir.or(data_local_dir).map(|dir| dir.join("quotabar"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_diagnostic_log_dir;
+    use std::path::PathBuf;
+
+    #[test]
+    fn uses_os_correct_log_dir() {
+        #[cfg(target_os = "macos")]
+        {
+            let dir = resolve_diagnostic_log_dir(
+                Some(PathBuf::from("/Users/quota")),
+                Some(PathBuf::from("/Users/quota/Library/Caches")),
+                Some(PathBuf::from("/Users/quota/Library/Application Support")),
+            )
+            .expect("macOS log dir");
+            assert_eq!(dir, PathBuf::from("/Users/quota/Library/Logs/quotabar"));
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let via_cache = resolve_diagnostic_log_dir(
+                Some(PathBuf::from("/home/quota")),
+                Some(PathBuf::from("/home/quota/.cache")),
+                Some(PathBuf::from("/home/quota/.local/share")),
+            )
+            .expect("cache log dir");
+            assert_eq!(via_cache, PathBuf::from("/home/quota/.cache/quotabar"));
+            assert!(!via_cache
+                .components()
+                .any(|component| component.as_os_str() == "Library"));
+
+            let via_data = resolve_diagnostic_log_dir(
+                Some(PathBuf::from("/home/quota")),
+                None,
+                Some(PathBuf::from("/home/quota/.local/share")),
+            )
+            .expect("data-local log dir");
+            assert_eq!(via_data, PathBuf::from("/home/quota/.local/share/quotabar"));
+        }
+    }
+
+    #[test]
+    fn skips_logging_when_os_dir_is_missing() {
+        #[cfg(target_os = "macos")]
+        {
+            assert_eq!(
+                resolve_diagnostic_log_dir(
+                    None,
+                    Some(PathBuf::from("/cache")),
+                    Some(PathBuf::from("/data")),
+                ),
+                None
+            );
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert_eq!(
+                resolve_diagnostic_log_dir(Some(PathBuf::from("/home/quota")), None, None),
+                None
+            );
+        }
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -11,6 +11,7 @@ pub mod grok;
 mod grok_local;
 pub mod http;
 pub mod link;
+mod log_path;
 pub mod tray;
 pub mod tray_icon;
 pub mod window;


### PR DESCRIPTION
## Summary

- Resolve Claude and Codex diagnostic log directories with `dirs::cache_dir` or `dirs::data_local_dir` on Windows and Linux. macOS still uses `~/Library/Logs/quotabar`. Skip logging when the OS directory cannot be resolved, and keep Claude's 2MB log rotation.

Fixes #157

## Verification

- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

No TypeScript changes.

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)