### PR TITLE
fix(grok): omit product rows without usage percent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Omit Grok product rows that lack `usagePercent` instead of drawing a fake 0%.
 - Apply the saved Hide Dock preference during native startup so the Dock icon does not flash before the webview mounts.
 - Keep Codex used percent above 100 when ChatGPT reports an over-limit week, instead of clamping it to 100 at parse. Tray PNG digits still cap at 100.
 - Align the marketing site with 0.5.0 and honest privacy copy: quota polling talks to providers you already use, tokens never go to QuotaBar, and cost estimates stay local.

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -340,8 +340,8 @@ impl AntigravityData {
 pub struct GrokProductUsage {
     pub product: String,
     pub label: String,
-    #[serde(rename = "usagePercent")]
-    pub usage_percent: f64,
+    #[serde(rename = "usagePercent", skip_serializing_if = "Option::is_none")]
+    pub usage_percent: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src-tauri/src/services/grok.rs
+++ b/src-tauri/src/services/grok.rs
@@ -216,11 +216,12 @@ fn parse_products(value: &serde_json::Value) -> Vec<GrokProductUsage> {
         .iter()
         .filter_map(|item| {
             let raw = item.get("product").and_then(serde_json::Value::as_str)?;
+            let usage_percent = parse_percent(&item["usagePercent"])?;
             let (product, label) = map_product(raw);
             Some(GrokProductUsage {
                 product,
                 label,
-                usage_percent: parse_percent(&item["usagePercent"]).unwrap_or(0.0),
+                usage_percent: Some(usage_percent),
             })
         })
         .collect()
@@ -238,7 +239,7 @@ fn scale_used_pct(pool_pct: Option<f64>, products: &[GrokProductUsage]) -> Resul
     let build = products
         .iter()
         .find(|product| product.product == "build")
-        .map(|product| product.usage_percent)
+        .and_then(|product| product.usage_percent)
         .filter(|pct| pct.is_finite() && *pct > 0.0);
     if let Some(pct) = build {
         return Ok(pct);
@@ -368,7 +369,10 @@ fn parse_billing_payload(data: &serde_json::Value, email: Option<String>) -> Gro
             None
         } else {
             Some(clamp_percent(
-                products.iter().map(|product| product.usage_percent).sum(),
+                products
+                    .iter()
+                    .filter_map(|product| product.usage_percent)
+                    .sum(),
             ))
         }
     });
@@ -583,11 +587,10 @@ mod tests {
             data.period_started_at.as_deref(),
             Some("2026-08-23T15:25:10.879112+00:00")
         );
-        assert_eq!(data.products.len(), 2);
+        assert_eq!(data.products.len(), 1);
         assert_eq!(data.products[0].label, "Build");
-        assert_eq!(data.products[0].usage_percent, 4.0);
-        assert_eq!(data.products[1].label, "Chat");
-        assert_eq!(data.products[1].usage_percent, 0.0);
+        assert_eq!(data.products[0].usage_percent, Some(4.0));
+        assert!(data.products.iter().all(|product| product.label != "Chat"));
         assert!(data.extra.is_none());
     }
 
@@ -626,7 +629,27 @@ mod tests {
         });
         let data = parse_billing_payload(&payload, None);
         assert_eq!(data.percentage, None);
-        assert_eq!(data.products[1].usage_percent, 0.0);
+        assert_eq!(data.products.len(), 1);
+        assert_eq!(data.products[0].label, "Build");
+        assert_eq!(data.products[0].usage_percent, Some(12.5));
+        assert!(data.products.iter().all(|product| product.label != "Chat"));
+    }
+
+    #[test]
+    fn reported_zero_product_percent_is_kept() {
+        let payload = json!({
+            "config": {
+                "creditUsagePercent": 4.0,
+                "productUsage": [
+                    {"product": "GrokBuild", "usagePercent": 4.0},
+                    {"product": "GrokChat", "usagePercent": 0.0}
+                ]
+            }
+        });
+        let data = parse_billing_payload(&payload, None);
+        assert_eq!(data.products.len(), 2);
+        assert_eq!(data.products[1].label, "Chat");
+        assert_eq!(data.products[1].usage_percent, Some(0.0));
     }
 
     #[test]
@@ -682,12 +705,12 @@ mod tests {
             GrokProductUsage {
                 product: "build".to_string(),
                 label: "Build".to_string(),
-                usage_percent: 4.0,
+                usage_percent: Some(4.0),
             },
             GrokProductUsage {
                 product: "chat".to_string(),
                 label: "Chat".to_string(),
-                usage_percent: 21.0,
+                usage_percent: Some(21.0),
             },
         ];
         assert_eq!(scale_used_pct(Some(25.0), &products).unwrap(), 4.0);

--- a/src/components/GrokPanel.tsx
+++ b/src/components/GrokPanel.tsx
@@ -33,6 +33,12 @@ function poolLabel(data: GrokData): string {
   return data.periodLabel ? `${data.periodLabel} pool` : 'Usage pool';
 }
 
+function grokProductUsagePercent(usagePercent: number | null | undefined): number | null {
+  return typeof usagePercent === 'number' && Number.isFinite(usagePercent)
+    ? usagePercent
+    : null;
+}
+
 const USD_FORMAT = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
@@ -127,7 +133,9 @@ export default function GrokPanel({
   const windows = buildGrokQuotaWindows(grokData);
   const topWindow = sortMostConstrained(windows)[0];
   const extra = grokData?.extra;
-  const products = grokData?.products ?? [];
+  const products = (grokData?.products ?? []).filter(
+    (product) => grokProductUsagePercent(product.usagePercent) != null,
+  );
   const resetLabel = grokData?.resetAt
     ? formatResetTime(grokData.resetAt, { expiredLabel: 'soon' })
     : '';
@@ -251,17 +259,21 @@ export default function GrokPanel({
             <div className="section">
               <div className="section-title">By product</div>
               <div className="quota-group">
-                {products.map((product) => (
-                  <div className="quota-card" key={product.product}>
-                    <div className="quota-header">
-                      <span className="quota-label">{product.label}</span>
-                      <span className="quota-value">{`${Math.round(product.usagePercent)}%`}</span>
+                {products.map((product) => {
+                  const usagePercent = grokProductUsagePercent(product.usagePercent);
+                  if (usagePercent == null) return null;
+                  return (
+                    <div className="quota-card" key={product.product}>
+                      <div className="quota-header">
+                        <span className="quota-label">{product.label}</span>
+                        <span className="quota-value">{`${Math.round(usagePercent)}%`}</span>
+                      </div>
+                      <div className="progress-bar">
+                        <div className="progress-fill" style={getProgressStyle(usagePercent)} />
+                      </div>
                     </div>
-                    <div className="progress-bar">
-                      <div className="progress-fill" style={getProgressStyle(product.usagePercent)} />
-                    </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
               <p className="hint" style={{ marginTop: 8, fontSize: 11, opacity: 0.65 }}>
                 Share of the same {grokData.periodLabel?.toLowerCase() ?? 'usage'} pool, not a separate limit.

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -117,7 +117,7 @@ export interface AntigravityData {
 export interface GrokProductUsage {
   product: string;
   label: string;
-  usagePercent: number;
+  usagePercent?: number | null;
 }
 
 export interface GrokExtraCredits {

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -728,6 +728,25 @@ describe('Grok period value', () => {
     await unmount(renderer);
   });
 
+  it('omits product rows without usagePercent instead of drawing 0%', async () => {
+    const renderer = await render_grok({
+      connected: true,
+      percentage: 4,
+      periodLabel: 'Weekly',
+      products: [
+        { product: 'build', label: 'Build', usagePercent: 4 },
+        { product: 'chat', label: 'Chat' },
+      ],
+    });
+
+    const text = rendered_text(renderer);
+    expect(text).toContain('Build');
+    expect(text).toContain('4%');
+    expect(text).not.toContain('Chat');
+    expect(text).not.toMatch(/Chat[\s\S]*0%/);
+    await unmount(renderer);
+  });
+
   it('keeps the pool value error visible without hiding official usage', async () => {
     const renderer = await render_grok({
       connected: true,


### PR DESCRIPTION
## Summary

- Grok product mix no longer treats a missing `usagePercent` as 0%. Incomplete product rows are omitted from the payload and panel instead of drawing a fake 0% bar.
- Missing billing fields fail closed; a reported 0% is still shown.

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Fixes #135

Made with [Cursor](https://cursor.com)