### PR TITLE
fix(tray): ignore stale IPC before updating skip-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Ignore slower in-flight tray IPC completions so the skip-cache cannot hide a newer icon tuple until the 60s force tick.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.
 - Drive the Claude tray, switcher percent, and 80/95 alerts from the hottest quota window instead of `weeklyTotal`.
 - Explain remaining quota and reset timing in high-usage tips, distinguish imminent resets, and suppress advice from stale data.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,6 +181,7 @@ export default function App({ workspace = false }: { workspace?: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const windowVisible = usePopoverWindow(containerRef, [activeView, quota, connected], !workspace);
   const lastTrayIconRequestRef = useRef<Partial<Record<TrayServiceName, TrayIconRequest>>>({});
+  const trayIconGenerationRef = useRef<Partial<Record<TrayServiceName, number>>>({});
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -291,8 +292,12 @@ export default function App({ workspace = false }: { workspace?: boolean }) {
       return;
     }
 
+    const generation = (trayIconGenerationRef.current[service] ?? 0) + 1;
+    trayIconGenerationRef.current[service] = generation;
+
     try {
       await backend.updateTrayIcon(service, percentage, visible, force, style);
+      if (trayIconGenerationRef.current[service] !== generation) return;
       lastTrayIconRequestRef.current[service] = { percentage, visible, style };
     } catch (err) {
       console.error(`Failed to update ${service} tray icon:`, err);

--- a/tests/tray_sync.test.tsx
+++ b/tests/tray_sync.test.tsx
@@ -1,9 +1,10 @@
 import { createElement } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi, type Mock } from 'vitest';
 import { backend } from '../src/services/backend';
 import { SERVICES } from '../src/services/service_meta';
 import type { TrayServiceName } from '../src/services/tray_visibility';
+import type { QuotaData } from '../src/types/models';
 
 vi.mock('../src/hooks/use_popover_window', () => ({
   usePopoverWindow: () => false,
@@ -50,6 +51,27 @@ function visible_calls(update: ReturnType<typeof vi.spyOn>) {
     visible.set(service, args[2] as boolean);
   }
   return visible;
+}
+
+function quota_with_percent(percentage: number): QuotaData {
+  return {
+    connected: true,
+    weeklyTotal: { used: percentage, limit: 100, percentage },
+  };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function claude_visible_calls(): unknown[][] {
+  return (backend.updateTrayIcon as unknown as Mock).mock.calls.filter(
+    (args) => args[0] === 'claude' && args[2] === true,
+  );
 }
 
 beforeAll(() => {
@@ -118,6 +140,86 @@ describe('tray icon sync', () => {
     expect(visible.get('cursor')).toBe(false);
     expect(visible.get('antigravity')).toBe(false);
     expect(SERVICES.every((service) => visible.has(service))).toBe(true);
+
+    await unmount(renderer);
+  });
+
+  test('ignores a slower tray IPC completion so the skip-cache keeps the newer tuple', async () => {
+    (globalThis as Record<string, unknown>).localStorage = memoryStorage({
+      'claude-tray-enabled': 'true',
+      'codex-tray-enabled': 'false',
+      'cursor-tray-enabled': 'false',
+      'grok-tray-enabled': 'false',
+      'antigravity-tray-enabled': 'false',
+      'claude-quota-tray-cycle': 'false',
+    });
+
+    const hung = () => new Promise<never>(() => {});
+    vi.spyOn(backend, 'getCodexInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getCodexRateLimits').mockImplementation(hung);
+    vi.spyOn(backend, 'getCodexResetCredits').mockImplementation(hung);
+    vi.spyOn(backend, 'getCodexWeeklyQuota').mockImplementation(hung);
+    vi.spyOn(backend, 'getCursorInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getGrokInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getAntigravityInfo').mockImplementation(hung);
+
+    let quotaPercent = 10;
+    vi.spyOn(backend, 'getQuota').mockImplementation(async () => quota_with_percent(quotaPercent));
+
+    const inflight: Array<{ percentage: number | null; resolve(): void }> = [];
+    vi.spyOn(backend, 'updateTrayIcon').mockImplementation((service, percentage, visible) => {
+      if (service !== 'claude' || !visible || percentage == null) {
+        return Promise.resolve();
+      }
+      return new Promise((resolve) => {
+        inflight.push({
+          percentage,
+          resolve: () => resolve(undefined),
+        });
+      });
+    });
+
+    const renderer = await render_app();
+    await flush();
+    await flush();
+
+    expect(inflight.length).toBeGreaterThan(0);
+    expect(inflight.every((call) => call.percentage === 10)).toBe(true);
+
+    quotaPercent = 20;
+    await act(async () => {
+      renderer.root.findByProps({ 'aria-label': 'Refresh current provider' }).props.onClick();
+    });
+    await flush();
+    await flush();
+
+    const newer = inflight.filter((call) => call.percentage === 20);
+    expect(newer.length).toBeGreaterThan(0);
+    const latest = inflight[inflight.length - 1];
+    expect(latest.percentage).toBe(20);
+
+    await act(async () => {
+      latest.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    for (const call of inflight.slice(0, -1)) {
+      await act(async () => {
+        call.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+
+    const callsAfterRace = claude_visible_calls().length;
+
+    await act(async () => {
+      renderer.root.findByProps({ 'aria-label': 'Refresh current provider' }).props.onClick();
+    });
+    await flush();
+    await flush();
+
+    expect(claude_visible_calls()).toHaveLength(callsAfterRace);
 
     await unmount(renderer);
   });


### PR DESCRIPTION
## Summary

- Give each provider tray IPC a generation token so a slower in-flight `updateTrayIcon` cannot overwrite `lastTrayIconRequestRef` after a newer request has already won.
- Keep the skip-cache aligned with the latest requested tuple, so the next identical sync is skipped for the right reason instead of hiding a newer icon until the 60s force tick.

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Fixes #146

Made with [Cursor](https://cursor.com)