### PR TITLE
fix(cost): keep missing daily spend as n/a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Keep unpriced local-cost days as a sparkline gap or n/a instead of drawing them as $0.00.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.
 - Drive the Claude tray, switcher percent, and 80/95 alerts from the hottest quota window instead of `weeklyTotal`.
 - Explain remaining quota and reset timing in high-usage tips, distinguish imminent resets, and suppress advice from stale data.

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -38,8 +38,13 @@ export function sliceSparkDays(days: CostDailyPoint[], range: SparkRange): CostD
   return range === '7d' ? days.slice(-7) : days.slice(-30);
 }
 
-export function sumDailyCost(days: CostDailyPoint[]): number {
-  return days.reduce((total, day) => total + (day.costUsd ?? day.cost ?? 0), 0);
+export function dayCost(day: Pick<CostDailyPoint, 'cost' | 'costUsd'>): number | null {
+  const value = day.costUsd ?? day.cost;
+  return value == null || !Number.isFinite(value) ? null : value;
+}
+
+export function sumDailyCost(days: CostDailyPoint[]): number | null {
+  return sumNullable(days.map((day) => dayCost(day)));
 }
 
 export function startCostSummaryAutoRefresh(
@@ -366,7 +371,8 @@ export default function CostSummarySection({
               {showTrend && daily && daily.length > 0 ? (
                 (() => {
                   const sparkDays = sliceSparkDays(daily, sparkRange);
-                  const maxCost = Math.max(...sparkDays.map((day) => day.costUsd ?? day.cost ?? 0), 0);
+                  const knownCosts = sparkDays.map((day) => dayCost(day)).filter((value): value is number => value != null);
+                  const maxCost = knownCosts.length > 0 ? Math.max(...knownCosts) : 0;
                   const focusedIndex = focusedDay
                     ? sparkDays.findIndex((day) => day.date === focusedDay.date)
                     : -1;
@@ -377,7 +383,7 @@ export default function CostSummarySection({
                   const inspectedDay = inspectedIndex >= 0 ? sparkDays[inspectedIndex] : null;
                   const activeIndex = inspectedIndex >= 0 ? inspectedIndex : sparkDays.length - 1;
                   const activeDay = sparkDays[activeIndex];
-                  const activeValue = activeDay?.costUsd ?? activeDay?.cost ?? 0;
+                  const activeValue = activeDay ? dayCost(activeDay) : null;
                   const focusDay = (index: number) => {
                     const day = sparkDays[index];
                     if (day) setFocusedDay(day);
@@ -392,7 +398,7 @@ export default function CostSummarySection({
                         aria-valuemin={1}
                         aria-valuemax={sparkDays.length}
                         aria-valuenow={activeIndex + 1}
-                        aria-valuetext={`${activeDay.date}: ${formatMoney(activeValue, primaryRange.currency)}`}
+                        aria-valuetext={activeDay ? `${activeDay.date}: ${formatMoney(activeValue, primaryRange.currency)}` : 'n/a'}
                         onFocus={() => focusDay(activeIndex)}
                         onBlur={() => setFocusedDay(null)}
                         onMouseLeave={() => setHoveredDay(null)}
@@ -410,20 +416,27 @@ export default function CostSummarySection({
                         }}
                       >
                         {sparkDays.map((day, index) => {
-                          const value = day.costUsd ?? day.cost ?? 0;
-                          const height = maxCost > 0 ? Math.max(8, (value / maxCost) * 100) : 8;
+                          const value = dayCost(day);
+                          const isGap = value == null;
+                          const height = isGap
+                            ? 0
+                            : maxCost > 0
+                              ? Math.max(8, (value / maxCost) * 100)
+                              : 8;
                           const isHovered = inspectedDay?.date === day.date;
                           return (
                             <span
-                              className={`spark-bar-hit ${isHovered ? 'hovered' : ''}`}
+                              className={`spark-bar-hit${isHovered ? ' hovered' : ''}${isGap ? ' gap' : ''}`}
                               key={day.date}
                               onMouseEnter={() => setHoveredDay(day)}
                               aria-hidden="true"
                             >
-                              <span
-                                className={`spark-bar ${index === sparkDays.length - 1 ? 'latest' : ''} ${isHovered ? 'hovered' : ''}`}
-                                style={{ height: `${height}%` }}
-                              />
+                              {isGap ? null : (
+                                <span
+                                  className={`spark-bar ${index === sparkDays.length - 1 ? 'latest' : ''} ${isHovered ? 'hovered' : ''}`}
+                                  style={{ height: `${height}%` }}
+                                />
+                              )}
                             </span>
                           );
                         })}
@@ -431,7 +444,7 @@ export default function CostSummarySection({
                       <div className="cost-footer">
                         <span className={inspectedDay ? 'spark-hover-label' : undefined}>
                           {inspectedDay
-                            ? `${inspectedDay.date} · ${formatMoney(inspectedDay.costUsd ?? inspectedDay.cost ?? 0, primaryRange.currency)}`
+                            ? `${inspectedDay.date} · ${formatMoney(dayCost(inspectedDay), primaryRange.currency)}`
                             : `${sparkRange === '7d' ? 'Past 7 days' : 'Past 30 days'} · ${formatMoney(sumDailyCost(sparkDays), primaryRange.currency)}`}
                         </span>
                         <span className="spark-range-chips">

--- a/src/redesign/panels.css
+++ b/src/redesign/panels.css
@@ -882,6 +882,14 @@
   background: color-mix(in srgb, var(--acc) 12%, transparent);
 }
 
+.spark-bar-hit.gap::after {
+  content: '';
+  width: 100%;
+  height: 2px;
+  border-radius: 1px;
+  background: color-mix(in srgb, var(--sub) 32%, transparent);
+}
+
 .spark-bar {
   flex: 1;
   border-radius: 2px;

--- a/tests/cost_daily.test.ts
+++ b/tests/cost_daily.test.ts
@@ -48,4 +48,9 @@ describe('daily cost helpers', () => {
     expect(sliceSparkDays(days, '30d')).toHaveLength(30);
     expect(sumDailyCost(sliceSparkDays(days, '7d'))).toBe(7);
   });
+
+  test('keeps unpriced days as null instead of summing them as zero', () => {
+    expect(sumDailyCost([day('2026-07-05', null, 1200)])).toBeNull();
+    expect(sumDailyCost([day('2026-07-04', 2), day('2026-07-05', null, 50)])).toBe(2);
+  });
 });

--- a/tests/cost_spark_null.test.tsx
+++ b/tests/cost_spark_null.test.tsx
@@ -1,0 +1,92 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import CostSummarySection from '../src/components/CostSummarySection';
+import { backend } from '../src/services/backend';
+import type { CostDailyPoint, CostOverview } from '../src/types/models';
+
+const emptyTokens = {
+  inputTokens: 0,
+  outputTokens: 0,
+  reasoningTokens: 0,
+  cacheCreationTokens: 0,
+  cacheReadTokens: 0,
+  totalTokens: 40,
+};
+
+function overview(): CostOverview {
+  return {
+    source: 'claude',
+    displayName: 'Claude',
+    currency: 'USD',
+    generatedAt: '2026-08-24T08:00:00Z',
+    cached: false,
+    ranges: [{
+      range: 'today',
+      label: 'Today',
+      currency: 'USD',
+      cost: null,
+      costUsd: null,
+      tokens: emptyTokens,
+      models: [],
+      validEntries: 1,
+      skippedEntries: 0,
+      elapsedMs: 1,
+    }],
+  };
+}
+
+function unpricedDay(date: string): CostDailyPoint {
+  return { date, cost: null, costUsd: null, totalTokens: 40 };
+}
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+  const values = new Map<string, string>();
+  (globalThis as Record<string, unknown>).localStorage = {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() { return values.size; },
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+  delete (globalThis as Record<string, unknown>).localStorage;
+});
+
+describe('CostSummarySection missing daily cost', () => {
+  it('renders unpriced days as n/a or a gap and never as $0.00', async () => {
+    vi.spyOn(backend, 'getCostOverview').mockResolvedValue(overview());
+    vi.spyOn(backend, 'getCostDaily').mockResolvedValue({
+      source: 'claude',
+      currency: 'USD',
+      generatedAt: '2026-08-24T08:00:00Z',
+      cached: false,
+      days: Array.from({ length: 7 }, (_, index) => unpricedDay(`2026-08-${String(index + 18).padStart(2, '0')}`)),
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CostSummarySection, { source: 'claude', autoRefreshIntervalMs: 0 }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const markup = JSON.stringify(renderer.toJSON());
+    expect(markup).not.toContain('$0.00');
+    expect(markup).toContain('n/a');
+    expect(markup).toContain('spark-bar-hit gap');
+
+    const trend = renderer.root.findByProps({ role: 'slider' });
+    expect(trend.props['aria-valuetext']).toContain('n/a');
+    expect(trend.props['aria-valuetext']).not.toContain('$0.00');
+
+    await act(async () => renderer.unmount());
+  });
+});


### PR DESCRIPTION
## Summary

- Unpriced sparkline days no longer coerce `costUsd`/`cost` to `$0.00`.
- `sumDailyCost`, hover labels, and keyboard values keep `null` and render `n/a`.
- Missing-cost days draw as a gap instead of a zero-height-looking bar.

Fixes #139

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.


Made with [Cursor](https://cursor.com)