### PR TITLE
fix(cost): keep incomplete local cost visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Surface skipped and parse-error counts on local cost summaries, and prefer ccstats estimated USD when recorded cost is missing.
 - Keep unpriced local-cost days as a sparkline gap or n/a instead of drawing them as $0.00.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.
 - Drive the Claude tray, switcher percent, and 80/95 alerts from the hottest quota window instead of `weeklyTotal`.

--- a/src-tauri/src/services/cost.rs
+++ b/src-tauri/src/services/cost.rs
@@ -62,8 +62,12 @@ pub struct CostRangeSummary {
     pub cost_usd: Option<f64>,
     pub tokens: CostTokenBreakdown,
     pub models: Vec<CostModelSummary>,
+    pub cost_kind: String,
+    pub estimated_cost: Option<f64>,
+    pub estimated_cost_usd: Option<f64>,
     pub valid_entries: i64,
     pub skipped_entries: i64,
+    pub parse_error_entries: i64,
     pub elapsed_ms: f64,
 }
 
@@ -475,16 +479,20 @@ impl CostRangeSummary {
             since: summary.since.map(|date| date.to_string()),
             until: summary.until.map(|date| date.to_string()),
             currency: summary.currency,
-            cost: summary.cost,
-            cost_usd: summary.cost_usd,
+            cost: summary.cost.or(summary.estimated_cost),
+            cost_usd: summary.cost_usd.or(summary.estimated_cost_usd),
             tokens: CostTokenBreakdown::from(summary.tokens),
             models: summary
                 .models
                 .into_iter()
                 .map(CostModelSummary::from)
                 .collect(),
+            cost_kind: summary.cost_kind,
+            estimated_cost: summary.estimated_cost,
+            estimated_cost_usd: summary.estimated_cost_usd,
             valid_entries: summary.valid_entries,
             skipped_entries: summary.skipped_entries,
+            parse_error_entries: i64::try_from(summary.parse_error_entries).unwrap_or(i64::MAX),
             elapsed_ms: summary.elapsed_ms,
         }
     }
@@ -647,6 +655,43 @@ mod tests {
             .ranges
             .iter()
             .all(|range| range.cost_usd == Some(12.34)));
+    }
+
+    #[test]
+    fn prefers_estimated_usd_and_copies_completeness_fields() {
+        let mut item = summary(UsageRange::Today, 3);
+        item.cost = None;
+        item.cost_usd = None;
+        item.estimated_cost = Some(4.25);
+        item.estimated_cost_usd = Some(4.25);
+        item.cost_kind = "estimated_proxy".to_string();
+        item.skipped_entries = 5;
+        item.parse_error_entries = 2;
+
+        let mapped = CostRangeSummary::from_summary("today", "Today", item);
+        assert_eq!(mapped.cost, Some(4.25));
+        assert_eq!(mapped.cost_usd, Some(4.25));
+        assert_eq!(mapped.estimated_cost, Some(4.25));
+        assert_eq!(mapped.estimated_cost_usd, Some(4.25));
+        assert_eq!(mapped.cost_kind, "estimated_proxy");
+        assert_eq!(mapped.skipped_entries, 5);
+        assert_eq!(mapped.parse_error_entries, 2);
+    }
+
+    #[test]
+    fn recorded_cost_is_not_replaced_by_estimated() {
+        let mut item = summary(UsageRange::Today, 1);
+        item.cost = Some(1.5);
+        item.cost_usd = Some(1.5);
+        item.estimated_cost = Some(9.0);
+        item.estimated_cost_usd = Some(9.0);
+        item.cost_kind = "real".to_string();
+
+        let mapped = CostRangeSummary::from_summary("today", "Today", item);
+        assert_eq!(mapped.cost, Some(1.5));
+        assert_eq!(mapped.cost_usd, Some(1.5));
+        assert_eq!(mapped.estimated_cost_usd, Some(9.0));
+        assert_eq!(mapped.cost_kind, "real");
     }
 
     #[test]

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -122,7 +122,7 @@ export function formatCostCompleteness(overview: CostOverview): string {
   );
   if (kinds.has('mixed') || kinds.size > 1) parts.push('mixed');
   else if (kinds.has('estimated_proxy')) parts.push('estimated');
-  else if (kinds.size === 1) parts.push([...kinds][0].replaceAll('_', ' '));
+  else if (kinds.size === 1) parts.push([...kinds][0].split('_').join(' '));
   return parts.join(' · ');
 }
 

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -109,6 +109,30 @@ function formatCostNote(range: CostRangeSummary | null): string {
   return `${formatCompactNumber(range.tokens.totalTokens)} tokens`;
 }
 
+export function formatCostCompleteness(overview: CostOverview): string {
+  const skipped = overview.ranges.reduce((total, range) => total + (range.skippedEntries ?? 0), 0);
+  const parseErrors = overview.ranges.reduce((total, range) => total + (range.parseErrorEntries ?? 0), 0);
+  const parts: string[] = [];
+  if (skipped > 0) parts.push(`${skipped} skipped`);
+  if (parseErrors > 0) parts.push(`${parseErrors} parse errors`);
+  const kinds = new Set(
+    overview.ranges
+      .map((range) => range.costKind)
+      .filter((kind): kind is string => Boolean(kind) && kind !== 'real' && kind !== 'none'),
+  );
+  if (kinds.has('mixed') || kinds.size > 1) parts.push('mixed');
+  else if (kinds.has('estimated_proxy')) parts.push('estimated');
+  else if (kinds.size === 1) parts.push([...kinds][0].replaceAll('_', ' '));
+  return parts.join(' · ');
+}
+
+function mergeCostKinds(kinds: string[]): string {
+  const unique = [...new Set(kinds.filter(Boolean))];
+  if (unique.length === 0) return 'none';
+  if (unique.length === 1) return unique[0];
+  return 'mixed';
+}
+
 function pickPrimaryRange(overview: CostOverview | null): CostRangeSummary | null {
   if (!overview) return null;
   return (
@@ -195,6 +219,10 @@ export function mergeCostOverviews(overviews: CostOverview[]): CostOverview {
       models: Array.from(modelMap.values()).sort((left, right) => (right.costUsd ?? right.cost ?? 0) - (left.costUsd ?? left.cost ?? 0)),
       validEntries: matching.reduce((total, range) => total + range.validEntries, 0),
       skippedEntries: matching.reduce((total, range) => total + range.skippedEntries, 0),
+      parseErrorEntries: matching.reduce((total, range) => total + (range.parseErrorEntries ?? 0), 0),
+      costKind: mergeCostKinds(matching.map((range) => range.costKind)),
+      estimatedCost: sumNullable(matching.map((range) => range.estimatedCost)),
+      estimatedCostUsd: sumNullable(matching.map((range) => range.estimatedCostUsd)),
       elapsedMs: matching.reduce((total, range) => total + range.elapsedMs, 0),
     };
   });
@@ -484,7 +512,11 @@ export default function CostSummarySection({
 
           <div className="cost-footer">
             <span>{primaryRange?.label ?? overview.displayName}</span>
-            <span>{formatUpdatedAt(overview.generatedAt)}</span>
+            <span>
+              {[formatCostCompleteness(overview), formatUpdatedAt(overview.generatedAt)]
+                .filter((part) => part.length > 0)
+                .join(' · ')}
+            </span>
           </div>
 
           {error && <div className="cost-inline-error compact">{error}</div>}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -179,10 +179,14 @@ export interface CostRangeSummary {
   currency: string;
   cost?: number | null;
   costUsd?: number | null;
+  costKind: string;
+  estimatedCost?: number | null;
+  estimatedCostUsd?: number | null;
   tokens: CostTokenBreakdown;
   models: CostModelSummary[];
   validEntries: number;
   skippedEntries: number;
+  parseErrorEntries: number;
   elapsedMs: number;
 }
 

--- a/tests/cost_completeness.test.tsx
+++ b/tests/cost_completeness.test.tsx
@@ -1,0 +1,104 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, describe, expect, it, test, vi } from 'vitest';
+import CostSummarySection, { formatCostCompleteness } from '../src/components/CostSummarySection';
+import { backend } from '../src/services/backend';
+import type { CostOverview, CostRangeSummary } from '../src/types/models';
+
+const tokens = {
+  inputTokens: 10,
+  outputTokens: 20,
+  reasoningTokens: 0,
+  cacheCreationTokens: 0,
+  cacheReadTokens: 0,
+  totalTokens: 30,
+};
+
+function range(overrides: Partial<CostRangeSummary> = {}): CostRangeSummary {
+  return {
+    range: 'today',
+    label: 'Today',
+    currency: 'USD',
+    cost: 12,
+    costUsd: 12,
+    costKind: 'real',
+    tokens,
+    models: [],
+    validEntries: 1,
+    skippedEntries: 0,
+    parseErrorEntries: 0,
+    elapsedMs: 1,
+    ...overrides,
+  };
+}
+
+function overview(ranges: CostRangeSummary[]): CostOverview {
+  return {
+    source: 'claude',
+    displayName: 'Claude',
+    currency: 'USD',
+    generatedAt: '2026-08-24T08:00:00Z',
+    cached: false,
+    ranges,
+  };
+}
+
+describe('formatCostCompleteness', () => {
+  test('stays empty when records are complete', () => {
+    expect(formatCostCompleteness(overview([range()]))).toBe('');
+  });
+
+  test('names skipped and parse-error counts', () => {
+    expect(formatCostCompleteness(overview([
+      range({ skippedEntries: 3, parseErrorEntries: 2, costKind: 'estimated_proxy' }),
+    ]))).toBe('3 skipped · 2 parse errors · estimated');
+  });
+});
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+  const values = new Map<string, string>();
+  (globalThis as Record<string, unknown>).localStorage = {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    get length() { return values.size; },
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+afterAll(() => {
+  delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+  delete (globalThis as Record<string, unknown>).localStorage;
+});
+
+describe('CostSummarySection completeness footer', () => {
+  it('shows skipped and parse-error counts in the cost footer', async () => {
+    vi.spyOn(backend, 'getCostOverview').mockResolvedValue(overview([
+      range({ skippedEntries: 4, parseErrorEntries: 1, costKind: 'estimated_proxy' }),
+    ]));
+    vi.spyOn(backend, 'getCostDaily').mockResolvedValue({
+      source: 'claude',
+      currency: 'USD',
+      generatedAt: '2026-08-24T08:00:00Z',
+      cached: false,
+      days: [],
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CostSummarySection, { source: 'claude', autoRefreshIntervalMs: 0, showTrend: false }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const markup = JSON.stringify(renderer.toJSON());
+    expect(markup).toContain('4 skipped');
+    expect(markup).toContain('1 parse errors');
+    expect(markup).toContain('estimated');
+    await act(async () => renderer.unmount());
+  });
+});

--- a/tests/cost_spark_null.test.tsx
+++ b/tests/cost_spark_null.test.tsx
@@ -31,6 +31,8 @@ function overview(): CostOverview {
       models: [],
       validEntries: 1,
       skippedEntries: 0,
+      parseErrorEntries: 0,
+      costKind: 'none',
       elapsedMs: 1,
     }],
   };

--- a/tests/panel_shell_ui.test.tsx
+++ b/tests/panel_shell_ui.test.tsx
@@ -192,6 +192,8 @@ describe('panel shell UI', () => {
         models: [],
         validEntries: 1,
         skippedEntries: 0,
+        parseErrorEntries: 0,
+        costKind: 'real',
         elapsedMs: 1,
       }, {
         range: 'month',
@@ -203,6 +205,8 @@ describe('panel shell UI', () => {
         models: [],
         validEntries: 1,
         skippedEntries: 0,
+        parseErrorEntries: 0,
+        costKind: 'real',
         elapsedMs: 1,
       }],
     });

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -899,6 +899,8 @@ function cost_overview(marker: number): CostOverview {
       models: [],
       validEntries: 1,
       skippedEntries: 0,
+      parseErrorEntries: 0,
+      costKind: 'real',
       elapsedMs: 1,
     }],
   };


### PR DESCRIPTION
## Summary

- Plumb ccstats `cost_kind`, `estimated_cost(_usd)`, and `parse_error_entries` through `CostRangeSummary` IPC and TS types.
- Prefer estimated USD when recorded cost is `None`; keep recorded cost when present.
- Show skipped and parse-error counts in the cost footer so partial parses are not unlabeled complete totals.

Fixes #140

Stacked on https://github.com/majiayu000/quotabar/pull/172

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.