### PR TITLE
fix(cost): version cost cache and label stale data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Version local cost cache keys and snapshots, reject future timestamps, and label cached or stale cost data.
 - Surface skipped and parse-error counts on local cost summaries, and prefer ccstats estimated USD when recorded cost is missing.
 - Keep unpriced local-cost days as a sparkline gap or n/a instead of drawing them as $0.00.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.

--- a/src-tauri/src/services/cost.rs
+++ b/src-tauri/src/services/cost.rs
@@ -47,6 +47,7 @@ pub struct CostOverview {
     pub currency: String,
     pub generated_at: String,
     pub cached: bool,
+    pub stale: bool,
     pub ranges: Vec<CostRangeSummary>,
 }
 
@@ -98,6 +99,7 @@ pub struct CostDailySeries {
     pub currency: String,
     pub generated_at: String,
     pub cached: bool,
+    pub stale: bool,
     pub days: Vec<CostDailyPoint>,
 }
 
@@ -140,13 +142,13 @@ fn build_cost_daily(
     let source = UsageSource::from_str(&source).map_err(|err| err.to_string())?;
     let currency = normalize_optional(currency);
     let timezone = normalize_optional(timezone);
-    let cache_key = format!(
-        "daily|{}|{}|{}|{}",
+    let cache_key = disk::versioned_key(&[
+        "daily",
         source.as_str(),
-        days,
+        &days.to_string(),
         currency.as_deref().unwrap_or("USD"),
-        timezone.as_deref().unwrap_or("local")
-    );
+        timezone.as_deref().unwrap_or("local"),
+    ]);
 
     if !force {
         if let Some(cached) = get_cached_daily(&cache_key)? {
@@ -215,6 +217,7 @@ fn build_daily_series_from_batch(
         currency: batch.currency,
         generated_at: batch.generated_at,
         cached: false,
+        stale: false,
         days: ranges
             .into_iter()
             .map(|range| CostDailyPoint {
@@ -240,6 +243,7 @@ fn get_cached_daily(cache_key: &str) -> Result<Option<CostDailySeries>, String> 
 
     let mut series = cached.series.clone();
     series.cached = true;
+    series.stale = false;
     Ok(Some(series))
 }
 
@@ -262,22 +266,34 @@ fn set_cached_daily(cache_key: String, series: CostDailySeries) -> Result<(), St
 fn load_daily_snapshot(cache_key: &str) -> Option<CostDailySeries> {
     let (age, mut series): (Duration, CostDailySeries) = disk::read_snapshot(cache_key)?;
     match disk::classify_snapshot(age, CACHE_TTL, stale_already_served(cache_key)) {
-        SnapshotUse::Fresh => {}
-        SnapshotUse::ServeStaleOnce => mark_stale_served(cache_key),
+        SnapshotUse::Fresh => {
+            series.cached = true;
+            series.stale = false;
+        }
+        SnapshotUse::ServeStaleOnce => {
+            mark_stale_served(cache_key);
+            series.cached = true;
+            series.stale = true;
+        }
         SnapshotUse::Ignore => return None,
     }
-    series.cached = true;
     Some(series)
 }
 
 fn load_overview_snapshot(cache_key: &str) -> Option<CostOverview> {
     let (age, mut overview): (Duration, CostOverview) = disk::read_snapshot(cache_key)?;
     match disk::classify_snapshot(age, CACHE_TTL, stale_already_served(cache_key)) {
-        SnapshotUse::Fresh => {}
-        SnapshotUse::ServeStaleOnce => mark_stale_served(cache_key),
+        SnapshotUse::Fresh => {
+            overview.cached = true;
+            overview.stale = false;
+        }
+        SnapshotUse::ServeStaleOnce => {
+            mark_stale_served(cache_key);
+            overview.cached = true;
+            overview.stale = true;
+        }
         SnapshotUse::Ignore => return None,
     }
-    overview.cached = true;
     Some(overview)
 }
 
@@ -336,12 +352,11 @@ fn build_cost_overview(
     let source = UsageSource::from_str(&source).map_err(|err| err.to_string())?;
     let currency = normalize_optional(currency);
     let timezone = normalize_optional(timezone);
-    let cache_key = format!(
-        "{}|{}|{}",
+    let cache_key = disk::versioned_key(&[
         source.as_str(),
         currency.as_deref().unwrap_or("USD"),
-        timezone.as_deref().unwrap_or("local")
-    );
+        timezone.as_deref().unwrap_or("local"),
+    ]);
 
     if !force {
         if let Some(cached) = get_cached_overview(&cache_key)? {
@@ -406,6 +421,7 @@ fn build_overview_from_batch(
         currency: batch.currency,
         generated_at: batch.generated_at,
         cached: false,
+        stale: false,
         ranges,
     })
 }
@@ -455,6 +471,7 @@ fn get_cached_overview(cache_key: &str) -> Result<Option<CostOverview>, String> 
 
     let mut overview = cached.overview.clone();
     overview.cached = true;
+    overview.stale = false;
     Ok(Some(overview))
 }
 

--- a/src-tauri/src/services/cost_disk_cache.rs
+++ b/src-tauri/src/services/cost_disk_cache.rs
@@ -10,8 +10,17 @@ use std::{
 /// Snapshots older than this are ignored entirely.
 pub const STALE_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
+/// Bump when the cost snapshot or range payload schema changes.
+pub const COST_CACHE_SCHEMA_VERSION: u32 = 1;
+
+/// Keep in sync with the `ccstats` version in `src-tauri/Cargo.toml`.
+pub const CCSTATS_VERSION: &str = "0.7.0";
+
 #[derive(serde::Serialize, serde::Deserialize)]
 struct Snapshot<T> {
+    schema_version: u32,
+    app_version: String,
+    ccstats_version: String,
     saved_at_unix_ms: u64,
     payload: T,
 }
@@ -25,6 +34,17 @@ pub enum SnapshotUse {
     ServeStaleOnce,
     /// Too old (or callers already served it once): ignore.
     Ignore,
+}
+
+pub fn cache_identity() -> String {
+    format!(
+        "v{COST_CACHE_SCHEMA_VERSION}|app{}|ccstats{CCSTATS_VERSION}",
+        env!("CARGO_PKG_VERSION"),
+    )
+}
+
+pub fn versioned_key(parts: &[&str]) -> String {
+    format!("{}|{}", cache_identity(), parts.join("|"))
 }
 
 pub fn classify_snapshot(age: Duration, ttl: Duration, already_served: bool) -> SnapshotUse {
@@ -61,6 +81,21 @@ pub fn write_snapshot<T: Serialize>(cache_key: &str, payload: &T) {
     write_snapshot_in(&base_dir, cache_key, payload);
 }
 
+fn current_identity() -> (u32, &'static str, &'static str) {
+    (
+        COST_CACHE_SCHEMA_VERSION,
+        env!("CARGO_PKG_VERSION"),
+        CCSTATS_VERSION,
+    )
+}
+
+fn snapshot_identity_matches<T>(snapshot: &Snapshot<T>) -> bool {
+    let (schema, app, ccstats) = current_identity();
+    snapshot.schema_version == schema
+        && snapshot.app_version == app
+        && snapshot.ccstats_version == ccstats
+}
+
 fn read_snapshot_in<T: DeserializeOwned>(
     base_dir: &Path,
     cache_key: &str,
@@ -83,10 +118,24 @@ fn read_snapshot_in<T: DeserializeOwned>(
         }
     };
 
+    if !snapshot_identity_matches(&snapshot) {
+        eprintln!(
+            "[CostCache] discarding incompatible snapshot {}",
+            path.display()
+        );
+        let _removed = fs::remove_file(&path);
+        return None;
+    }
+
     let saved_at = UNIX_EPOCH + Duration::from_millis(snapshot.saved_at_unix_ms);
-    let age = SystemTime::now()
-        .duration_since(saved_at)
-        .unwrap_or(Duration::ZERO);
+    let age = match SystemTime::now().duration_since(saved_at) {
+        Ok(age) => age,
+        Err(_) => {
+            eprintln!("[CostCache] discarding future snapshot {}", path.display());
+            let _removed = fs::remove_file(&path);
+            return None;
+        }
+    };
     Some((age, snapshot.payload))
 }
 
@@ -98,7 +147,20 @@ fn write_snapshot_in<T: Serialize>(base_dir: &Path, cache_key: &str, payload: &T
             return;
         }
     };
+    write_snapshot_in_at(base_dir, cache_key, payload, saved_at_unix_ms);
+}
+
+fn write_snapshot_in_at<T: Serialize>(
+    base_dir: &Path,
+    cache_key: &str,
+    payload: &T,
+    saved_at_unix_ms: u64,
+) {
+    let (schema_version, app_version, ccstats_version) = current_identity();
     let snapshot = Snapshot {
+        schema_version,
+        app_version: app_version.to_string(),
+        ccstats_version: ccstats_version.to_string(),
         saved_at_unix_ms,
         payload,
     };
@@ -174,13 +236,65 @@ mod tests {
     #[test]
     fn cache_keys_map_to_distinct_sanitized_files() {
         let base = PathBuf::from("/base");
-        let overview = snapshot_path(&base, "overview|claude|USD|local");
-        let daily = snapshot_path(&base, "daily|claude|30|USD|local");
-        assert_ne!(overview, daily);
-        assert_eq!(
-            overview.file_name().and_then(|name| name.to_str()),
-            Some("cost-overview-claude-USD-local.json")
+        let overview = snapshot_path(&base, &versioned_key(&["claude", "USD", "local"]));
+        let daily = snapshot_path(
+            &base,
+            &versioned_key(&["daily", "claude", "30", "USD", "local"]),
         );
+        assert_ne!(overview, daily);
+        let overview_name = overview
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("file name");
+        assert!(overview_name.starts_with("cost-v1-app"));
+        assert!(overview_name.contains("ccstats0-7-0"));
+        assert!(overview_name.contains("claude-USD-local"));
+    }
+
+    #[test]
+    fn versioned_keys_include_schema_app_and_ccstats() {
+        let key = versioned_key(&["claude", "USD", "local"]);
+        assert!(key.starts_with(&format!("v{COST_CACHE_SCHEMA_VERSION}|app")));
+        assert!(key.contains(&format!("ccstats{CCSTATS_VERSION}")));
+        assert!(key.contains(env!("CARGO_PKG_VERSION")));
+        assert!(key.ends_with("|claude|USD|local"));
+    }
+
+    #[test]
+    fn future_saved_at_is_invalid() {
+        let base = temp_base();
+        let future_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_millis() as u64
+            + 60_000;
+        write_snapshot_in_at(&base, "future", &vec![1_i64], future_ms);
+        let path = snapshot_path(&base, "future");
+        assert!(path.exists());
+        let result: Option<(Duration, Vec<i64>)> = read_snapshot_in(&base, "future");
+        assert!(result.is_none());
+        assert!(!path.exists(), "future snapshot should be deleted");
+        let _cleanup = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn mismatched_schema_is_discarded() {
+        let base = temp_base();
+        std::fs::create_dir_all(&base).expect("temp dir should create");
+        let snapshot = Snapshot {
+            schema_version: COST_CACHE_SCHEMA_VERSION + 1,
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+            ccstats_version: CCSTATS_VERSION.to_string(),
+            saved_at_unix_ms: 1,
+            payload: vec![1_i64],
+        };
+        let path = snapshot_path(&base, "mismatch");
+        std::fs::write(&path, serde_json::to_vec(&snapshot).expect("json"))
+            .expect("snapshot should write");
+        let result: Option<(Duration, Vec<i64>)> = read_snapshot_in(&base, "mismatch");
+        assert!(result.is_none());
+        assert!(!path.exists());
+        let _cleanup = std::fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -126,6 +126,12 @@ export function formatCostCompleteness(overview: CostOverview): string {
   return parts.join(' · ');
 }
 
+export function formatCostFreshness(overview: CostOverview): string {
+  if (overview.stale) return 'Stale';
+  if (overview.cached) return 'Cached';
+  return '';
+}
+
 function mergeCostKinds(kinds: string[]): string {
   const unique = [...new Set(kinds.filter(Boolean))];
   if (unique.length === 0) return 'none';
@@ -233,6 +239,7 @@ export function mergeCostOverviews(overviews: CostOverview[]): CostOverview {
     currency: 'USD',
     generatedAt: latestTimestamp(overviews.map((overview) => overview.generatedAt)),
     cached: overviews.every((overview) => overview.cached),
+    stale: overviews.some((overview) => Boolean(overview.stale)),
     ranges,
   };
 }
@@ -513,7 +520,7 @@ export default function CostSummarySection({
           <div className="cost-footer">
             <span>{primaryRange?.label ?? overview.displayName}</span>
             <span>
-              {[formatCostCompleteness(overview), formatUpdatedAt(overview.generatedAt)]
+              {[formatCostCompleteness(overview), formatCostFreshness(overview), formatUpdatedAt(overview.generatedAt)]
                 .filter((part) => part.length > 0)
                 .join(' · ')}
             </span>

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -196,6 +196,7 @@ export interface CostOverview {
   currency: string;
   generatedAt: string;
   cached: boolean;
+  stale?: boolean;
   ranges: CostRangeSummary[];
 }
 
@@ -211,5 +212,6 @@ export interface CostDailySeries {
   currency: string;
   generatedAt: string;
   cached: boolean;
+  stale?: boolean;
   days: CostDailyPoint[];
 }

--- a/tests/cost_completeness.test.tsx
+++ b/tests/cost_completeness.test.tsx
@@ -1,7 +1,7 @@
 import { createElement } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterAll, afterEach, beforeAll, describe, expect, it, test, vi } from 'vitest';
-import CostSummarySection, { formatCostCompleteness } from '../src/components/CostSummarySection';
+import CostSummarySection, { formatCostCompleteness, formatCostFreshness } from '../src/components/CostSummarySection';
 import { backend } from '../src/services/backend';
 import type { CostOverview, CostRangeSummary } from '../src/types/models';
 
@@ -55,6 +55,14 @@ describe('formatCostCompleteness', () => {
   });
 });
 
+describe('formatCostFreshness', () => {
+  test('labels cached and stale overviews', () => {
+    expect(formatCostFreshness(overview([range()]))).toBe('');
+    expect(formatCostFreshness({ ...overview([range()]), cached: true })).toBe('Cached');
+    expect(formatCostFreshness({ ...overview([range()]), cached: true, stale: true })).toBe('Stale');
+  });
+});
+
 beforeAll(() => {
   (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
   const values = new Map<string, string>();
@@ -99,6 +107,59 @@ describe('CostSummarySection completeness footer', () => {
     expect(markup).toContain('4 skipped');
     expect(markup).toContain('1 parse errors');
     expect(markup).toContain('estimated');
+    await act(async () => renderer.unmount());
+  });
+
+  it('labels cached and stale overviews instead of presenting them as live', async () => {
+    vi.spyOn(backend, 'getCostOverview').mockResolvedValue({
+      ...overview([range()]),
+      cached: true,
+      stale: true,
+    });
+    vi.spyOn(backend, 'getCostDaily').mockResolvedValue({
+      source: 'claude',
+      currency: 'USD',
+      generatedAt: '2026-08-24T08:00:00Z',
+      cached: true,
+      stale: true,
+      days: [],
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CostSummarySection, { source: 'claude', autoRefreshIntervalMs: 0, showTrend: false }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const markup = JSON.stringify(renderer.toJSON());
+    expect(markup).toContain('Stale');
+    expect(markup).not.toContain('Cached');
+    await act(async () => renderer.unmount());
+  });
+
+  it('labels a cache hit as Cached', async () => {
+    vi.spyOn(backend, 'getCostOverview').mockResolvedValue({
+      ...overview([range()]),
+      cached: true,
+      stale: false,
+    });
+    vi.spyOn(backend, 'getCostDaily').mockResolvedValue({
+      source: 'claude',
+      currency: 'USD',
+      generatedAt: '2026-08-24T08:00:00Z',
+      cached: true,
+      days: [],
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CostSummarySection, { source: 'claude', autoRefreshIntervalMs: 0, showTrend: false }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(JSON.stringify(renderer.toJSON())).toContain('Cached');
     await act(async () => renderer.unmount());
   });
 });


### PR DESCRIPTION
## Summary

- Prefix cost cache keys and disk snapshots with schema, app, and ccstats versions so pricing/schema bumps cannot reuse old dollars.
- Treat future `saved_at` as invalid instead of age-zero fresh data.
- Render `Cached` or `Stale` in the cost footer from the existing `cached` flag (and `stale` for the 24h serve-once path).

Fixes #141

Stacked on https://github.com/majiayu000/quotabar/pull/173

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.