### PR TITLE
fix(security): scope opener URLs and deny reveal

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,14 +1,13 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capabilities for the tray panel and analysis workspace",
+  "description": "Shared capabilities for the tray panel and analysis workspace. The analysis window does not open URLs.",
   "windows": [
     "main",
     "analysis"
   ],
   "permissions": [
     "core:default",
-    "opener:default",
     "notification:default",
     "autostart:default"
   ]

--- a/src-tauri/capabilities/tray-opener.json
+++ b/src-tauri/capabilities/tray-opener.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "tray-opener",
+  "description": "Allow the tray webview to open only the first-party provider dashboards already used by link.rs",
+  "windows": [
+    "main"
+  ],
+  "permissions": [
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        { "url": "https://console.anthropic.com/settings/usage" },
+        { "url": "https://chatgpt.com" },
+        { "url": "https://www.cursor.com/settings" },
+        { "url": "https://antigravity.google.com" },
+        { "url": "https://grok.com/?_s=usage" }
+      ]
+    },
+    "opener:deny-reveal-item-in-dir"
+  ]
+}

--- a/src-tauri/src/services/link.rs
+++ b/src-tauri/src/services/link.rs
@@ -1,3 +1,6 @@
+//! First-party dashboard URLs. Keep these in sync with
+//! `src-tauri/capabilities/tray-opener.json`.
+
 pub fn open_claude_dashboard() -> Result<(), String> {
     tauri_plugin_opener::open_url("https://console.anthropic.com/settings/usage", None::<&str>)
         .map_err(|e| e.to_string())


### PR DESCRIPTION
## Summary

- Replace `opener:default` on the shared tray/analysis capability with a tray-only `opener:allow-open-url` allowlist of the five dashboards already opened by `link.rs`.
- Deny `reveal_item_in_dir`. The analysis window keeps core/notification/autostart permissions and does not get opener URL access. Rust `link.rs` remains the opener.

Fixes #151

## Verification

- [x] `cd src-tauri && cargo check`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.
- [x] Tauri opener / capability change: webview `open_url` is limited to the five first-party dashboards; reveal is denied.

Made with [Cursor](https://cursor.com)