### PR TITLE
fix(overview): label cost as Claude, Codex, Cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.
 - Drive the Claude tray, switcher percent, and 80/95 alerts from the hottest quota window instead of `weeklyTotal`.
 - Explain remaining quota and reset timing in high-usage tips, distinguish imminent resets, and suppress advice from stale data.
 - Enlarge provider labels, wrap navigation and freshness text, lead Overview with remaining quota, and collapse secondary usage details. Clarify API-price estimates are not actual bills.

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -153,7 +153,9 @@ function latestTimestamp(values: string[]): string {
   });
 }
 
-function mergeCostOverviews(overviews: CostOverview[]): CostOverview {
+export const MERGED_COST_DISPLAY_NAME = 'Claude, Codex, Cursor';
+
+export function mergeCostOverviews(overviews: CostOverview[]): CostOverview {
   if (overviews.length === 1) return overviews[0];
 
   const rangeOrder = overviews[0]?.ranges.map((range) => range.range) ?? [];
@@ -194,7 +196,7 @@ function mergeCostOverviews(overviews: CostOverview[]): CostOverview {
 
   return {
     source: 'all',
-    displayName: 'All providers',
+    displayName: MERGED_COST_DISPLAY_NAME,
     currency: 'USD',
     generatedAt: latestTimestamp(overviews.map((overview) => overview.generatedAt)),
     cached: overviews.every((overview) => overview.cached),
@@ -305,7 +307,7 @@ export default function CostSummarySection({
         </span>
       </div>
 
-      <p className="cost-estimate-explanation">Estimated at API prices from local logs. Not your actual bill.</p>
+      <p className="cost-estimate-explanation">Estimated at API prices from local Claude, Codex, and Cursor logs. Not your actual bill. Grok and Antigravity are not included.</p>
 
       {loading && !overview && (
         <div className="cost-loading">Loading cost...</div>

--- a/src/components/CostSummarySection.tsx
+++ b/src/components/CostSummarySection.tsx
@@ -307,7 +307,11 @@ export default function CostSummarySection({
         </span>
       </div>
 
-      <p className="cost-estimate-explanation">Estimated at API prices from local Claude, Codex, and Cursor logs. Not your actual bill. Grok and Antigravity are not included.</p>
+      <p className="cost-estimate-explanation">
+        {Array.isArray(source)
+          ? 'Estimated at API prices from local Claude, Codex, and Cursor logs. Not your actual bill. Grok and Antigravity are not included.'
+          : 'Estimated at API prices from local logs. Not your actual bill.'}
+      </p>
 
       {loading && !overview && (
         <div className="cost-loading">Loading cost...</div>

--- a/src/components/OverviewPanel.tsx
+++ b/src/components/OverviewPanel.tsx
@@ -22,6 +22,7 @@ import ResetTimeline from './ResetTimeline';
 import { calendarDays, HourlyPlot, PeriodComparison, TokenComposition, UsageActivity } from './UsageExtras';
 import { defaultPanelSections, type PanelSectionVisibility } from '../services/panel_sections';
 
+// Log-backed CostSource values only. Grok and Antigravity are not merged here.
 const ALL_COST_SOURCES = ['claude', 'codex', 'cursor'] as const;
 
 type WorkspaceView = AnalysisView | 'quota' | 'settings';
@@ -463,7 +464,7 @@ export default function OverviewPanel({
         service="claude"
         label="Overview"
         status={`${connectedCount} of ${summaries.length} connected`}
-        plan="All providers"
+        plan="Claude, Codex, Cursor"
         tone={connectedCount > 0 ? 'online' : 'offline'}
       />
 

--- a/tests/cost_overview_label.test.ts
+++ b/tests/cost_overview_label.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+import { MERGED_COST_DISPLAY_NAME, mergeCostOverviews } from '../src/components/CostSummarySection';
+import type { CostOverview, CostRangeSummary } from '../src/types/models';
+
+function range(label: string, cost: number): CostRangeSummary {
+  return {
+    range: 'today',
+    label,
+    currency: 'USD',
+    cost,
+    costUsd: cost,
+    tokens: {
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      totalTokens: 0,
+    },
+    models: [],
+    validEntries: 1,
+    skippedEntries: 0,
+    elapsedMs: 0,
+  };
+}
+
+function overview(source: 'claude' | 'codex', cost: number): CostOverview {
+  return {
+    source,
+    displayName: source === 'claude' ? 'Claude' : 'Codex',
+    currency: 'USD',
+    generatedAt: '2026-09-08T00:00:00Z',
+    cached: false,
+    ranges: [range('Today', cost)],
+  };
+}
+
+describe('merged overview cost label', () => {
+  test('names Claude, Codex, and Cursor instead of All providers', () => {
+    const merged = mergeCostOverviews([overview('claude', 1.5), overview('codex', 2.25)]);
+    expect(merged.displayName).toBe('Claude, Codex, Cursor');
+    expect(merged.displayName).toBe(MERGED_COST_DISPLAY_NAME);
+    expect(merged.displayName.toLowerCase()).not.toContain('all providers');
+  });
+});

--- a/tests/panel_shell_ui.test.tsx
+++ b/tests/panel_shell_ui.test.tsx
@@ -229,7 +229,8 @@ describe('panel shell UI', () => {
     const text = JSON.stringify(renderer.toJSON());
     expect(text).toContain('API-equivalent usage');
     expect(text).toContain('Local estimate');
-    expect(text).toContain('Not your actual bill.');
+    expect(text).toContain('Estimated at API prices from local logs. Not your actual bill.');
+    expect(text).not.toContain('Grok and Antigravity are not included');
     const trendButtons = renderer.root.findAll((node) => (
       node.type === 'button'
       && typeof node.props.className === 'string'
@@ -276,6 +277,39 @@ describe('panel shell UI', () => {
     await act(async () => trend.props.onKeyDown({ key: 'End', preventDefault: vi.fn() }));
     expect(renderer.root.findByProps({ role: 'slider' }).props['aria-valuenow']).toBe(30);
     expect(renderer.root.findAllByProps({ role: 'progressbar' })).toHaveLength(1);
+    await act(async () => renderer.unmount());
+  });
+
+  it('names Claude, Codex, and Cursor only on the merged overview cost disclaimer', async () => {
+    vi.spyOn(backend, 'getCostOverview').mockResolvedValue({
+      source: 'claude',
+      displayName: 'Claude',
+      currency: 'USD',
+      generatedAt: '2026-08-24T08:00:00Z',
+      cached: false,
+      ranges: [],
+    });
+    vi.spyOn(backend, 'getCostDaily').mockResolvedValue({
+      source: 'claude',
+      currency: 'USD',
+      generatedAt: '2026-08-24T08:00:00Z',
+      cached: false,
+      days: [],
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(CostSummarySection, {
+        source: ['claude', 'codex', 'cursor'],
+        autoRefreshIntervalMs: 0,
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const text = JSON.stringify(renderer.toJSON());
+    expect(text).toContain('local Claude, Codex, and Cursor logs');
+    expect(text).toContain('Grok and Antigravity are not included');
     await act(async () => renderer.unmount());
   });
 });

--- a/tests/panel_status_ui.test.tsx
+++ b/tests/panel_status_ui.test.tsx
@@ -67,6 +67,8 @@ describe('provider status UI', () => {
     const text = renderedText(renderer);
     expect(text).toContain('Overview');
     expect(text).toContain('1 of 2 connected');
+    expect(text).toContain('Claude, Codex, Cursor');
+    expect(text).not.toContain('All providers');
   });
 
   it('keeps last-known Claude data visible after a refresh error', async () => {


### PR DESCRIPTION
## Summary

- Rename the Overview cost headline from All providers to Claude, Codex, Cursor.
- Say Grok and Antigravity are not in that local-log total. `CostSource` is unchanged.

Fixes #153

## Verification

- [x] `npx vitest run tests/provider_summary.test.ts tests/panel_status_ui.test.tsx tests/cost_overview_label.test.ts tests/panel_shell_ui.test.tsx`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)