### PR TITLE
fix(antigravity): show Preview instead of Offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Show Antigravity as Preview instead of Offline while quota tracking is still a placeholder.
 - Keep Codex used percent above 100 when ChatGPT reports an over-limit week, instead of clamping it to 100 at parse. Tray PNG digits still cap at 100.
 - Align the marketing site with 0.5.0 and honest privacy copy: quota polling talks to providers you already use, tokens never go to QuotaBar, and cost estimates stay local.
 - Label Overview local cost as Claude, Codex, and Cursor instead of All providers, and say Grok and Antigravity are not in that total.

--- a/src/services/provider_summary.ts
+++ b/src/services/provider_summary.ts
@@ -46,9 +46,18 @@ export function getProviderStatusText(
   loading: boolean,
   connected: boolean,
   usedPercent: number | null,
+  options?: { status?: string; connectedHint?: string },
 ): string {
   if (loading) return 'Syncing';
-  if (!connected) return 'Offline';
+  if (!connected) {
+    const status = options?.status?.trim().toLowerCase();
+    const isPreview =
+      status === 'preview' ||
+      status === 'placeholder' ||
+      options?.connectedHint === 'Preview';
+    if (isPreview) return options?.connectedHint ?? 'Preview';
+    return 'Offline';
+  }
   if (usedPercent == null) return 'Ready';
   return `${Math.round(usedPercent)}% used`;
 }
@@ -73,7 +82,9 @@ export function buildProviderSummaries(
       connected: isConnected,
       loading: isLoading,
       usedPercent: pct,
-      statusText: getProviderStatusText(isLoading, isConnected, pct),
+      statusText: getProviderStatusText(isLoading, isConnected, pct, {
+        connectedHint: meta.connectedHint,
+      }),
       readState: reads?.[id],
     };
   });

--- a/tests/provider_summary.test.ts
+++ b/tests/provider_summary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   buildProviderSummaries,
+  getProviderStatusText,
   summaryUsageLabel,
   buildClaudeQuotaWindows,
   buildCursorQuotaWindows,
@@ -24,6 +25,20 @@ describe('provider summary helpers', () => {
     expect(summaries.find((summary) => summary.id === 'cursor')?.statusText).toBe('Offline');
     expect(summaries.find((summary) => summary.id === 'antigravity')?.statusText).toBe('Syncing');
     expect(summaries.find((summary) => summary.id === 'grok')?.statusText).toBe('12% used');
+  });
+
+  test('shows Antigravity Preview instead of Offline for the placeholder', () => {
+    const summaries = buildProviderSummaries(
+      { claude: false, codex: false, cursor: false, grok: false, antigravity: false },
+      { claude: false, codex: false, cursor: false, grok: false, antigravity: false },
+      { claude: null, codex: null, cursor: null, grok: null, antigravity: null },
+    );
+
+    expect(summaries.find((summary) => summary.id === 'antigravity')?.statusText).toBe('Preview');
+    expect(summaries.find((summary) => summary.id === 'cursor')?.statusText).toBe('Offline');
+    expect(getProviderStatusText(false, false, null, { status: 'preview' })).toBe('Preview');
+    expect(getProviderStatusText(false, false, null, { status: 'placeholder' })).toBe('Preview');
+    expect(getProviderStatusText(false, false, null)).toBe('Offline');
   });
 
   test('builds and sorts only real quota windows', () => {


### PR DESCRIPTION
## Summary

- `getProviderStatusText` now shows Preview (from `SERVICE_META.antigravity.connectedHint` or a `preview` / `placeholder` status) instead of Offline while Antigravity quota is still a placeholder.

Fixes #158

## Verification

- [x] `npx vitest run tests/provider_summary.test.ts`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [ ] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Made with [Cursor](https://cursor.com)