### PR TITLE
fix(tray): mark stale tray percents as last known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Keep last-known tray percents labeled in the tooltip when a provider refresh returns an error, without changing the percent, ring, or icon style.
 - Keep unpriced local-cost days as a sparkline gap or n/a instead of drawing them as $0.00.
 - Ignore slower in-flight tray IPC completions so the skip-cache cannot hide a newer icon tuple until the 60s force tick.
 - Omit Grok product rows that lack `usagePercent` instead of drawing a fake 0%.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -530,6 +530,7 @@ pub async fn update_tray_icon(
     visible: bool,
     force: Option<bool>,
     style: Option<tray_icon::TrayIconStyle>,
+    stale: Option<bool>,
 ) -> Result<(), String> {
     tray::update_tray_icon(
         app,
@@ -539,6 +540,7 @@ pub async fn update_tray_icon(
         visible,
         force.unwrap_or(false),
         style,
+        stale.unwrap_or(false),
     )
     .await
 }

--- a/src-tauri/src/services/tray.rs
+++ b/src-tauri/src/services/tray.rs
@@ -35,6 +35,7 @@ struct TraySnapshot {
     percentage: Option<u8>,
     visible: bool,
     style: tray_icon::TrayIconStyle,
+    stale: bool,
 }
 
 #[derive(Default)]
@@ -380,8 +381,9 @@ fn set_status_item_collapsed(app: &AppHandle, tray_id: &str, collapsed: bool) {
     });
 }
 
-fn format_tooltip(service: TrayService, percentage: Option<u8>) -> String {
+fn format_tooltip(service: TrayService, percentage: Option<u8>, stale: bool) -> String {
     match percentage {
+        Some(value) if stale => format!("{}: {}% used (last known)", service.label(), value),
         Some(value) => format!("{}: {}% used", service.label(), value),
         None => format!("{}: unavailable", service.label()),
     }
@@ -518,6 +520,7 @@ pub async fn update_tray_icon(
     visible: bool,
     force: bool,
     style: Option<tray_icon::TrayIconStyle>,
+    stale: bool,
 ) -> Result<(), String> {
     let runtime = tray_state.runtime.clone();
     let style = style.unwrap_or_default();
@@ -525,6 +528,7 @@ pub async fn update_tray_icon(
         percentage,
         visible,
         style,
+        stale,
     };
     let request_generation = {
         let mut state = runtime
@@ -592,7 +596,7 @@ pub async fn update_tray_icon(
                 .map_err(|e| e.to_string())?;
             tray.set_title(Some(service.extra_title()))
                 .map_err(|e| e.to_string())?;
-            tray.set_tooltip(Some(format_tooltip(service, percentage)))
+            tray.set_tooltip(Some(format_tooltip(service, percentage, stale)))
                 .map_err(|e| e.to_string())?;
             tray.set_visible(true).map_err(|e| e.to_string())?;
 
@@ -628,15 +632,23 @@ mod tests {
     #[test]
     fn tooltip_marks_unavailable() {
         assert_eq!(
-            format_tooltip(TrayService::Claude, None),
+            format_tooltip(TrayService::Claude, None, false),
             "Claude Code: unavailable"
+        );
+    }
+
+    #[test]
+    fn tooltip_marks_stale_last_known_percent() {
+        assert_eq!(
+            format_tooltip(TrayService::Claude, Some(42), true),
+            "Claude Code: 42% used (last known)"
         );
     }
 
     #[test]
     fn tooltip_preserves_over_limit_usage() {
         assert_eq!(
-            format_tooltip(TrayService::Codex, Some(130)),
+            format_tooltip(TrayService::Codex, Some(130), false),
             "Codex: 130% used"
         );
     }
@@ -648,6 +660,7 @@ mod tests {
             percentage: Some(100),
             visible: true,
             style: TrayIconStyle::Percent,
+            stale: false,
         };
 
         assert_eq!(state.snapshot(TrayService::Claude), None);
@@ -666,12 +679,21 @@ mod tests {
             percentage: Some(42),
             visible: true,
             style: TrayIconStyle::Percent,
+            stale: false,
         };
 
         state.set_snapshot(TrayService::Claude, snapshot);
 
         assert!(state.should_skip_update(TrayService::Claude, snapshot, false));
         assert!(!state.should_skip_update(TrayService::Claude, snapshot, true));
+        assert!(!state.should_skip_update(
+            TrayService::Claude,
+            TraySnapshot {
+                stale: true,
+                ..snapshot
+            },
+            false
+        ));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ import {
   getClaudeRefreshIntervalMs,
   getClaudeTrayUsedPercent,
   keepClaudeQuotaOnError,
+  isStaleTrayPercent,
   getInitialTrayEnabledState,
   getSavedDockHidden,
   getSavedSettingsExpanded,
@@ -110,6 +111,7 @@ export {
   getClaudeRefreshIntervalMs,
   getClaudeTrayUsedPercent,
   keepClaudeQuotaOnError,
+  isStaleTrayPercent,
   providerRefreshIntervalMs,
 } from './services/app_state';
 
@@ -281,13 +283,15 @@ export default function App({ workspace = false }: { workspace?: boolean }) {
     visible: boolean,
     force = false,
     style: TrayStyle = 'percent',
+    stale = false,
   ) => {
     const previous = lastTrayIconRequestRef.current[service];
     if (
       !force &&
       previous?.percentage === percentage &&
       previous.visible === visible &&
-      previous.style === style
+      previous.style === style &&
+      previous.stale === stale
     ) {
       return;
     }
@@ -296,9 +300,9 @@ export default function App({ workspace = false }: { workspace?: boolean }) {
     trayIconGenerationRef.current[service] = generation;
 
     try {
-      await backend.updateTrayIcon(service, percentage, visible, force, style);
+      await backend.updateTrayIcon(service, percentage, visible, force, style, stale);
       if (trayIconGenerationRef.current[service] !== generation) return;
-      lastTrayIconRequestRef.current[service] = { percentage, visible, style };
+      lastTrayIconRequestRef.current[service] = { percentage, visible, style, stale };
     } catch (err) {
       console.error(`Failed to update ${service} tray icon:`, err);
     }
@@ -377,9 +381,10 @@ export default function App({ workspace = false }: { workspace?: boolean }) {
     for (const svc of SERVICES) {
       const pct = svc === 'claude' ? getClaudeTrayUsedPercent(quota) : usedPercent[svc];
       const visible = resolveTrayVisible(svc, candidates, trayCycle, trayCycleIndex);
-      updateTrayIcon(svc, pct, visible, force, trayStyle);
+      const stale = isStaleTrayPercent(providerReads[svc].error, pct);
+      updateTrayIcon(svc, pct, visible, force, trayStyle, stale);
     }
-  }, [quota, connected, usedPercent, trayEnabled, trayCycle, trayCycleIndex, trayStyle, updateTrayIcon, workspace]);
+  }, [quota, connected, usedPercent, providerReads, trayEnabled, trayCycle, trayCycleIndex, trayStyle, updateTrayIcon, workspace]);
 
   useEffect(() => {
     syncTrayIcons();

--- a/src/services/app_state.ts
+++ b/src/services/app_state.ts
@@ -33,7 +33,12 @@ export type TrayIconRequest = {
   percentage: number | null;
   visible: boolean;
   style: TrayStyle;
+  stale: boolean;
 };
+
+export function isStaleTrayPercent(error: string | null | undefined, percent: number | null): boolean {
+  return percent != null && Boolean(error);
+}
 
 export function defaultServiceMap<T>(value: T): ServiceMap<T> {
   return SERVICES.reduce((acc, svc) => {

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -106,7 +106,7 @@ export const backend = {
     return invokeBackend<CodexWeeklyQuotaData>('get_codex_weekly_quota');
   },
 
-  getCursorInfo() {
+  getCursorInfo(_manual = false) {
     return invokeBackend<CursorData>('get_cursor_info');
   },
 
@@ -114,7 +114,7 @@ export const backend = {
     return invokeBackend<AntigravityData>('get_antigravity_info');
   },
 
-  getGrokInfo() {
+  getGrokInfo(_manual = false) {
     return invokeBackend<GrokData>('get_grok_info');
   },
 
@@ -163,6 +163,7 @@ export const backend = {
     visible: boolean,
     force = false,
     style: 'percent' | 'ring' | 'icon' = 'percent',
+    stale = false,
   ) {
     return invokeBackend<void>('update_tray_icon', {
       service,
@@ -170,6 +171,7 @@ export const backend = {
       visible,
       force,
       style,
+      stale,
     });
   },
 

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -106,7 +106,7 @@ export const backend = {
     return invokeBackend<CodexWeeklyQuotaData>('get_codex_weekly_quota');
   },
 
-  getCursorInfo(_manual = false) {
+  getCursorInfo() {
     return invokeBackend<CursorData>('get_cursor_info');
   },
 
@@ -114,7 +114,7 @@ export const backend = {
     return invokeBackend<AntigravityData>('get_antigravity_info');
   },
 
-  getGrokInfo(_manual = false) {
+  getGrokInfo() {
     return invokeBackend<GrokData>('get_grok_info');
   },
 

--- a/tests/claude_tray_percent.test.ts
+++ b/tests/claude_tray_percent.test.ts
@@ -4,6 +4,7 @@ import {
   getClaudeRefreshIntervalMs,
   getClaudeTrayUsedPercent,
   keepClaudeQuotaOnError,
+  isStaleTrayPercent,
 } from '../src/App';
 import { buildClaudeQuotaWindows, sortMostConstrained } from '../src/services/provider_summary';
 import type { QuotaData, UsageInfo } from '../src/types/models';
@@ -112,5 +113,13 @@ describe('keepClaudeQuotaOnError', () => {
       connected: false,
       error: 'API error: 401 Unauthorized',
     })).toBe(false);
+  });
+});
+
+describe('isStaleTrayPercent', () => {
+  test('marks a retained percent with an error as last known', () => {
+    expect(isStaleTrayPercent('API error: 429 Too Many Requests', 42)).toBe(true);
+    expect(isStaleTrayPercent(null, 42)).toBe(false);
+    expect(isStaleTrayPercent('API error: 429 Too Many Requests', null)).toBe(false);
   });
 });

--- a/tests/tray_ipc_boundary.test.ts
+++ b/tests/tray_ipc_boundary.test.ts
@@ -26,6 +26,22 @@ describe('tray IPC percentage boundary', () => {
       visible: true,
       force: false,
       style: 'percent',
+      stale: false,
+    });
+  });
+
+  it('passes a last-known stale flag without changing the user style', async () => {
+    vi.stubGlobal('window', { __TAURI_INTERNALS__: {} });
+
+    await backend.updateTrayIcon('claude', 42, true, false, 'percent', true);
+
+    expect(tauri.invoke).toHaveBeenCalledWith('update_tray_icon', {
+      service: 'claude',
+      percentage: 42,
+      visible: true,
+      force: false,
+      style: 'percent',
+      stale: true,
     });
   });
 

--- a/tests/tray_sync.test.tsx
+++ b/tests/tray_sync.test.tsx
@@ -223,4 +223,77 @@ describe('tray icon sync', () => {
 
     await unmount(renderer);
   });
+
+  test('keeps the user tray style and marks a stale Claude percent as last known', async () => {
+    (globalThis as Record<string, unknown>).localStorage = memoryStorage({
+      'claude-tray-enabled': 'true',
+      'codex-tray-enabled': 'false',
+      'cursor-tray-enabled': 'false',
+      'grok-tray-enabled': 'false',
+      'antigravity-tray-enabled': 'false',
+      'claude-quota-tray-cycle': 'false',
+    });
+
+    const hung = () => new Promise<never>(() => {});
+    vi.spyOn(backend, 'getCodexInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getCodexRateLimits').mockImplementation(hung);
+    vi.spyOn(backend, 'getCodexResetCredits').mockImplementation(hung);
+    vi.spyOn(backend, 'getCodexWeeklyQuota').mockImplementation(hung);
+    vi.spyOn(backend, 'getCursorInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getGrokInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getAntigravityInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getQuota').mockResolvedValue({
+      ...quota_with_percent(42),
+      error: 'API error: 429 Too Many Requests',
+    });
+
+    const renderer = await render_app();
+    await flush();
+    await flush();
+
+    const staleCall = claude_visible_calls().find((args) => args[1] === 42);
+    expect(staleCall).toBeDefined();
+    expect(staleCall?.[4]).toBe('percent');
+    expect(staleCall?.[5]).toBe(true);
+
+    await unmount(renderer);
+  });
+
+  test('marks Cursor last-known percents stale when the DTO still carries an error', async () => {
+    (globalThis as Record<string, unknown>).localStorage = memoryStorage({
+      'claude-tray-enabled': 'false',
+      'codex-tray-enabled': 'false',
+      'cursor-tray-enabled': 'true',
+      'grok-tray-enabled': 'false',
+      'antigravity-tray-enabled': 'false',
+      'claude-quota-tray-cycle': 'false',
+    });
+
+    const hung = () => new Promise<never>(() => {});
+    vi.spyOn(backend, 'getCodexInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getCodexRateLimits').mockImplementation(hung);
+    vi.spyOn(backend, 'getCodexResetCredits').mockImplementation(hung);
+    vi.spyOn(backend, 'getCodexWeeklyQuota').mockImplementation(hung);
+    vi.spyOn(backend, 'getGrokInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getAntigravityInfo').mockImplementation(hung);
+    vi.spyOn(backend, 'getQuota').mockImplementation(hung);
+    vi.spyOn(backend, 'getCursorInfo').mockResolvedValue({
+      connected: true,
+      percentage: 22,
+      error: 'Network error: timed out',
+    });
+
+    const renderer = await render_app();
+    await flush();
+    await flush();
+
+    const staleCall = (backend.updateTrayIcon as unknown as Mock).mock.calls.find(
+      (args) => args[0] === 'cursor' && args[2] === true && args[1] === 22,
+    );
+    expect(staleCall).toBeDefined();
+    expect(staleCall?.[4]).toBe('percent');
+    expect(staleCall?.[5]).toBe(true);
+
+    await unmount(renderer);
+  });
 });


### PR DESCRIPTION
## Summary

- When a provider still shows a percent after a failed refresh, keep the user's percent/ring/icon tray style and send a stale flag so the tooltip reads `{n}% used (last known)` instead of a live used percent.
- Applies to Claude and to other providers whose DTO still includes `error` with a retained percent. Cursor/Grok `manual=true` is not wired here because those Rust commands do not accept it on main (#145).

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Depends on #170. Fixes #144

Made with [Cursor](https://cursor.com)