### PR TITLE
fix(grok): label Full pool dollars as Build-share scaled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Keep last-good Grok usage across 429 and other non-auth HTTP errors instead of flashing disconnected.
+
 - Return Grok last-good usage with an error and a 15-minute age cap instead of presenting it as a fresh success.
 
 - Hide Grok extra credits unless used, cap, and prepaid cents all parse; missing cents are not $0.00.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Hide Grok extra credits unless used, cap, and prepaid cents all parse; missing cents are not $0.00.
 - Keep unpriced local-cost days as a sparkline gap or n/a instead of drawing them as $0.00.
 - Ignore slower in-flight tray IPC completions so the skip-cache cannot hide a newer icon tuple until the 60s force tick.
 - Omit Grok product rows that lack `usagePercent` instead of drawing a fake 0%.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Return Grok last-good usage with an error and a 15-minute age cap instead of presenting it as a fresh success.
+
 - Hide Grok extra credits unless used, cap, and prepaid cents all parse; missing cents are not $0.00.
 - Keep unpriced local-cost days as a sparkline gap or n/a instead of drawing them as $0.00.
 - Ignore slower in-flight tray IPC completions so the skip-cache cannot hide a newer icon tuple until the 60s force tick.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable QuotaBar changes should be summarized here before a release is cut.
 
 ## Unreleased
 
+- Label Grok Full pool dollars as extrapolated from the Build share, not the pool gauge percent.
+
 - Keep last-good Grok usage across 429 and other non-auth HTTP errors instead of flashing disconnected.
 
 - Return Grok last-good usage with an error and a 15-minute age cap instead of presenting it as a fresh success.

--- a/src-tauri/src/domain/models.rs
+++ b/src-tauri/src/domain/models.rs
@@ -364,6 +364,10 @@ pub struct GrokValueEstimate {
     pub resets_at: String,
     #[serde(rename = "usedPct")]
     pub used_pct: f64,
+    #[serde(rename = "scaleUsedPct")]
+    pub scale_used_pct: f64,
+    #[serde(rename = "scaleProduct", skip_serializing_if = "Option::is_none")]
+    pub scale_product: Option<String>,
     #[serde(rename = "observedCostUsd")]
     pub observed_cost_usd: f64,
     #[serde(rename = "estimatedPeriodValueUsd")]

--- a/src-tauri/src/services/grok.rs
+++ b/src-tauri/src/services/grok.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 const BILLING_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
 const TOKEN_AUTH_HEADER: &str = "xai-grok-cli";
 const QUOTA_CACHE_TTL: Duration = Duration::from_secs(120);
+const MAX_STALE_GROK_AGE: Duration = Duration::from_secs(15 * 60);
 
 struct CachedGrok {
     data: GrokData,
@@ -24,13 +25,13 @@ struct CachedGrok {
 }
 
 static GROK_CACHE: OnceLock<Mutex<Option<CachedGrok>>> = OnceLock::new();
-static LAST_GOOD: OnceLock<Mutex<Option<GrokData>>> = OnceLock::new();
+static LAST_GOOD: OnceLock<Mutex<Option<CachedGrok>>> = OnceLock::new();
 
 fn grok_cache() -> &'static Mutex<Option<CachedGrok>> {
     GROK_CACHE.get_or_init(|| Mutex::new(None))
 }
 
-fn last_good() -> &'static Mutex<Option<GrokData>> {
+fn last_good() -> &'static Mutex<Option<CachedGrok>> {
     LAST_GOOD.get_or_init(|| Mutex::new(None))
 }
 
@@ -439,21 +440,53 @@ fn save_cache(data: &GrokData) {
             cached_at: Instant::now(),
         });
     }
-    if data.connected {
+    if data.connected && data.error.is_none() {
         if let Ok(mut guard) = last_good().lock() {
-            *guard = Some(data.clone());
+            *guard = Some(CachedGrok {
+                data: data.clone(),
+                cached_at: Instant::now(),
+            });
         }
     }
+}
+
+fn mark_grok_data_stale(mut data: GrokData, error: String) -> GrokData {
+    data.error = Some(error);
+    data
+}
+
+fn stale_grok_usable(connected: bool, age: Duration) -> bool {
+    connected && age < MAX_STALE_GROK_AGE
+}
+
+fn last_good_or_disconnected(
+    error: String,
+    snapshot: Option<&GrokData>,
+    age: Duration,
+) -> GrokData {
+    match snapshot {
+        Some(data) if stale_grok_usable(data.connected, age) => {
+            mark_grok_data_stale(data.clone(), error)
+        }
+        _ => GrokData::disconnected(error),
+    }
+}
+
+fn last_good_snapshot_fallback(error: String) -> GrokData {
+    let (snapshot, age) = match last_good().lock() {
+        Ok(guard) => match guard.as_ref() {
+            Some(cached) => (Some(cached.data.clone()), cached.cached_at.elapsed()),
+            None => (None, Duration::ZERO),
+        },
+        Err(_) => (None, Duration::ZERO),
+    };
+    last_good_or_disconnected(error, snapshot.as_ref(), age)
 }
 
 fn fallback_or_disconnected(error: impl Into<String>) -> GrokData {
     let error = error.into();
     if is_transient_os_error(&error) {
-        if let Ok(guard) = last_good().lock() {
-            if let Some(stale) = guard.as_ref() {
-                return stale.clone();
-            }
-        }
+        return last_good_snapshot_fallback(error);
     }
     GrokData::disconnected(error)
 }
@@ -534,9 +567,31 @@ pub async fn fetch_grok_info() -> GrokData {
 
 #[cfg(test)]
 mod tests {
-    use super::{map_product, parse_billing_payload, pick_credential, scale_used_pct};
-    use crate::domain::models::GrokProductUsage;
+    use super::{
+        last_good_or_disconnected, map_product, mark_grok_data_stale, parse_billing_payload,
+        pick_credential, scale_used_pct, stale_grok_usable, MAX_STALE_GROK_AGE,
+    };
+    use crate::domain::models::{GrokData, GrokProductUsage};
     use serde_json::json;
+    use std::time::Duration;
+
+    fn sample_connected_grok() -> GrokData {
+        GrokData {
+            connected: true,
+            plan_type: Some("SuperGrok".into()),
+            email: None,
+            percentage: Some(4.0),
+            reset_at: None,
+            period_started_at: None,
+            period_type: Some("weekly".into()),
+            period_label: Some("Weekly".into()),
+            products: Vec::new(),
+            extra: None,
+            value_estimate: None,
+            value_estimate_error: None,
+            error: None,
+        }
+    }
 
     #[test]
     fn maps_live_and_proto_product_names() {
@@ -786,5 +841,37 @@ mod tests {
         };
         assert!(err.contains("expired"));
         assert!(!err.contains("expired-token"));
+    }
+
+    #[test]
+    fn last_good_fallback_is_connected_with_error_not_clean_success() {
+        let data = sample_connected_grok();
+        let stale = last_good_or_disconnected(
+            "Too many open files (os error 24)".to_string(),
+            Some(&data),
+            Duration::from_secs(30),
+        );
+        assert!(stale.connected);
+        assert_eq!(stale.percentage, Some(4.0));
+        assert_eq!(
+            stale.error.as_deref(),
+            Some("Too many open files (os error 24)")
+        );
+        assert_ne!(stale.error, None);
+
+        let marked = mark_grok_data_stale(data.clone(), "EMFILE".to_string());
+        assert!(marked.connected);
+        assert_eq!(marked.error.as_deref(), Some("EMFILE"));
+
+        assert!(stale_grok_usable(true, Duration::from_secs(60)));
+        assert!(!stale_grok_usable(false, Duration::from_secs(1)));
+        assert!(!stale_grok_usable(true, MAX_STALE_GROK_AGE));
+        let expired = last_good_or_disconnected(
+            "Too many open files (os error 24)".to_string(),
+            Some(&data),
+            MAX_STALE_GROK_AGE,
+        );
+        assert!(!expired.connected);
+        assert!(expired.error.unwrap().contains("Too many open files"));
     }
 }

--- a/src-tauri/src/services/grok.rs
+++ b/src-tauri/src/services/grok.rs
@@ -491,6 +491,10 @@ fn fallback_or_disconnected(error: impl Into<String>) -> GrokData {
     GrokData::disconnected(error)
 }
 
+fn is_grok_auth_status(status: reqwest::StatusCode) -> bool {
+    status.as_u16() == 401 || status.as_u16() == 403
+}
+
 pub async fn fetch_grok_info() -> GrokData {
     if let Some(cached) = get_cached() {
         return cached;
@@ -522,13 +526,13 @@ pub async fn fetch_grok_info() -> GrokData {
     };
 
     let status = response.status();
-    if status.as_u16() == 401 || status.as_u16() == 403 {
-        return GrokData::disconnected(
-            "Grok session expired. Run 'grok login', then click Refresh.",
-        );
-    }
     if !status.is_success() {
-        return GrokData::disconnected(format!("Grok billing API error: {status}"));
+        if is_grok_auth_status(status) {
+            return GrokData::disconnected(
+                "Grok session expired. Run 'grok login', then click Refresh.",
+            );
+        }
+        return last_good_snapshot_fallback(format!("Grok billing API error: {status}"));
     }
 
     let data = match response.json::<serde_json::Value>().await {
@@ -568,12 +572,26 @@ pub async fn fetch_grok_info() -> GrokData {
 #[cfg(test)]
 mod tests {
     use super::{
-        last_good_or_disconnected, map_product, mark_grok_data_stale, parse_billing_payload,
-        pick_credential, scale_used_pct, stale_grok_usable, MAX_STALE_GROK_AGE,
+        is_grok_auth_status, last_good_or_disconnected, map_product, mark_grok_data_stale,
+        parse_billing_payload, pick_credential, scale_used_pct, stale_grok_usable,
+        MAX_STALE_GROK_AGE,
     };
     use crate::domain::models::{GrokData, GrokProductUsage};
     use serde_json::json;
     use std::time::Duration;
+
+    fn grok_from_http_status(
+        status: reqwest::StatusCode,
+        snapshot: Option<&GrokData>,
+        age: Duration,
+    ) -> GrokData {
+        if is_grok_auth_status(status) {
+            return GrokData::disconnected(
+                "Grok session expired. Run 'grok login', then click Refresh.",
+            );
+        }
+        last_good_or_disconnected(format!("Grok billing API error: {status}"), snapshot, age)
+    }
 
     fn sample_connected_grok() -> GrokData {
         GrokData {
@@ -873,5 +891,38 @@ mod tests {
         );
         assert!(!expired.connected);
         assert!(expired.error.unwrap().contains("Too many open files"));
+    }
+
+    #[test]
+    fn http_429_keeps_last_good_with_error_instead_of_disconnecting() {
+        let data = sample_connected_grok();
+        let stale = grok_from_http_status(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            Some(&data),
+            Duration::from_secs(10),
+        );
+        assert!(stale.connected);
+        assert_eq!(stale.percentage, Some(4.0));
+        assert!(stale
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("Grok billing API error: 429"));
+
+        let server = grok_from_http_status(
+            reqwest::StatusCode::BAD_GATEWAY,
+            Some(&data),
+            Duration::from_secs(10),
+        );
+        assert!(server.connected);
+        assert!(server.error.as_deref().unwrap().contains("502"));
+
+        let unauthorized = grok_from_http_status(
+            reqwest::StatusCode::UNAUTHORIZED,
+            Some(&data),
+            Duration::from_secs(10),
+        );
+        assert!(!unauthorized.connected);
+        assert!(unauthorized.error.unwrap().contains("expired"));
     }
 }

--- a/src-tauri/src/services/grok.rs
+++ b/src-tauri/src/services/grok.rs
@@ -151,12 +151,14 @@ fn read_auth_json() -> Result<serde_json::Value, String> {
     serde_json::from_str(&content).map_err(|err| format!("Failed to parse Grok auth: {err}"))
 }
 
-fn parse_cent(value: &serde_json::Value) -> i64 {
+fn parse_cent(value: &serde_json::Value) -> Option<i64> {
+    if value.is_null() {
+        return None;
+    }
     value
         .get("val")
         .and_then(|val| val.as_i64().or_else(|| val.as_f64().map(|n| n as i64)))
         .or_else(|| value.as_i64())
-        .unwrap_or(0)
 }
 
 fn clamp_percent(value: f64) -> f64 {
@@ -377,18 +379,19 @@ fn parse_billing_payload(data: &serde_json::Value, email: Option<String>) -> Gro
         }
     });
     let (period_type, period_label, period_started_at, reset_at) = period_from_config(config);
-    let extra = GrokExtraCredits {
-        on_demand_used_cents: parse_cent(&config["onDemandUsed"]),
-        on_demand_cap_cents: parse_cent(&config["onDemandCap"]),
-        prepaid_balance_cents: parse_cent(&config["prepaidBalance"]),
-    };
-    let extra = if extra.on_demand_used_cents == 0
-        && extra.on_demand_cap_cents == 0
-        && extra.prepaid_balance_cents == 0
-    {
-        None
-    } else {
-        Some(extra)
+    let extra = match (
+        parse_cent(&config["onDemandUsed"]),
+        parse_cent(&config["onDemandCap"]),
+        parse_cent(&config["prepaidBalance"]),
+    ) {
+        (Some(used), Some(cap), Some(prepaid)) if used != 0 || cap != 0 || prepaid != 0 => {
+            Some(GrokExtraCredits {
+                on_demand_used_cents: used,
+                on_demand_cap_cents: cap,
+                prepaid_balance_cents: prepaid,
+            })
+        }
+        _ => None,
     };
 
     let plan_type = data
@@ -669,6 +672,33 @@ mod tests {
         assert_eq!(extra.on_demand_cap_cents, 5000);
         assert_eq!(extra.on_demand_used_cents, 300);
         assert_eq!(extra.prepaid_balance_cents, 1250);
+    }
+
+    #[test]
+    fn extra_credits_hide_when_used_cents_are_missing() {
+        let payload = json!({
+            "config": {
+                "creditUsagePercent": 4.0,
+                "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY", "end": "2026-09-01T00:00:00Z"},
+                "onDemandCap": {"val": 5000},
+                "prepaidBalance": {"val": 0}
+            }
+        });
+        assert!(parse_billing_payload(&payload, None).extra.is_none());
+    }
+
+    #[test]
+    fn extra_credits_hide_when_cents_are_malformed() {
+        let payload = json!({
+            "config": {
+                "creditUsagePercent": 4.0,
+                "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY", "end": "2026-09-01T00:00:00Z"},
+                "onDemandCap": {"val": 5000},
+                "onDemandUsed": {"val": "unknown"},
+                "prepaidBalance": {"val": 0}
+            }
+        });
+        assert!(parse_billing_payload(&payload, None).extra.is_none());
     }
 
     #[test]

--- a/src-tauri/src/services/grok.rs
+++ b/src-tauri/src/services/grok.rs
@@ -252,6 +252,15 @@ fn scale_used_pct(pool_pct: Option<f64>, products: &[GrokProductUsage]) -> Resul
         .ok_or_else(|| "The official Grok pool usage is unavailable.".to_string())
 }
 
+fn scale_product_id(products: &[GrokProductUsage]) -> Option<String> {
+    products
+        .iter()
+        .find(|product| product.product == "build")
+        .and_then(|product| product.usage_percent)
+        .filter(|pct| pct.is_finite() && *pct > 0.0)
+        .map(|_| "build".to_string())
+}
+
 fn period_from_config(
     config: &serde_json::Value,
 ) -> (
@@ -333,6 +342,7 @@ fn estimate_grok_period_value(
     let display_pct =
         used_pct.ok_or_else(|| "The official Grok pool usage is unavailable.".to_string())?;
     let scale_pct = scale_used_pct(used_pct, &products)?;
+    let scale_product = scale_product_id(&products);
     let started = started_at
         .and_then(parse_rfc3339)
         .ok_or_else(|| "The official Grok period start is unavailable.".to_string())?;
@@ -352,6 +362,8 @@ fn estimate_grok_period_value(
         window_started_at: started.to_rfc3339(),
         resets_at: resets.to_rfc3339(),
         used_pct: display_pct,
+        scale_used_pct: scale_pct,
+        scale_product,
         observed_cost_usd: usage.observed_cost_usd,
         estimated_period_value_usd: period_usd,
         observed_tokens: usage.observed_tokens,
@@ -573,8 +585,8 @@ pub async fn fetch_grok_info() -> GrokData {
 mod tests {
     use super::{
         is_grok_auth_status, last_good_or_disconnected, map_product, mark_grok_data_stale,
-        parse_billing_payload, pick_credential, scale_used_pct, stale_grok_usable,
-        MAX_STALE_GROK_AGE,
+        parse_billing_payload, pick_credential, scale_product_id, scale_used_pct,
+        stale_grok_usable, MAX_STALE_GROK_AGE,
     };
     use crate::domain::models::{GrokData, GrokProductUsage};
     use serde_json::json;
@@ -818,6 +830,8 @@ mod tests {
         ];
         assert_eq!(scale_used_pct(Some(25.0), &products).unwrap(), 4.0);
         assert_eq!(scale_used_pct(Some(25.0), &[]).unwrap(), 25.0);
+        assert_eq!(scale_product_id(&products).as_deref(), Some("build"));
+        assert_eq!(scale_product_id(&[]), None);
     }
 
     #[test]

--- a/src/components/GrokPanel.tsx
+++ b/src/components/GrokPanel.tsx
@@ -39,6 +39,10 @@ function grokProductUsagePercent(usagePercent: number | null | undefined): numbe
     : null;
 }
 
+function grokExtraCents(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
 const USD_FORMAT = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
@@ -133,6 +137,9 @@ export default function GrokPanel({
   const windows = buildGrokQuotaWindows(grokData);
   const topWindow = sortMostConstrained(windows)[0];
   const extra = grokData?.extra;
+  const extraUsedCents = grokExtraCents(extra?.onDemandUsedCents);
+  const extraCapCents = grokExtraCents(extra?.onDemandCapCents);
+  const extraPrepaidCents = grokExtraCents(extra?.prepaidBalanceCents);
   const products = (grokData?.products ?? []).filter(
     (product) => grokProductUsagePercent(product.usagePercent) != null,
   );
@@ -281,33 +288,33 @@ export default function GrokPanel({
             </div>
           )}
 
-          {extra && (
+          {extraUsedCents != null && extraCapCents != null && extraPrepaidCents != null && (
             <div className="section">
               <div className="section-title">Extra credits</div>
               <div className="quota-group">
-                {extra.onDemandCapCents > 0 && (
+                {extraCapCents > 0 && (
                   <div className="quota-card">
                     <div className="quota-header">
                       <span className="quota-label">On-demand</span>
                       <span className="quota-value">
-                        {`${formatCents(extra.onDemandUsedCents)} / ${formatCents(extra.onDemandCapCents)}`}
+                        {`${formatCents(extraUsedCents)} / ${formatCents(extraCapCents)}`}
                       </span>
                     </div>
                     <div className="progress-bar">
                       <div
                         className="progress-fill"
                         style={getProgressStyle(
-                          Math.min(100, (extra.onDemandUsedCents / extra.onDemandCapCents) * 100),
+                          Math.min(100, (extraUsedCents / extraCapCents) * 100),
                         )}
                       />
                     </div>
                   </div>
                 )}
-                {extra.prepaidBalanceCents > 0 && (
+                {extraPrepaidCents > 0 && (
                   <div className="quota-card">
                     <div className="quota-header">
                       <span className="quota-label">Prepaid remaining</span>
-                      <span className="quota-value">{formatCents(extra.prepaidBalanceCents)}</span>
+                      <span className="quota-value">{formatCents(extraPrepaidCents)}</span>
                     </div>
                   </div>
                 )}

--- a/src/components/GrokPanel.tsx
+++ b/src/components/GrokPanel.tsx
@@ -43,6 +43,14 @@ function grokExtraCents(value: number | null | undefined): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
+function grokScaleBasisCopy(estimate: { scaleProduct?: string; scaleUsedPct?: number }): string | null {
+  if (estimate.scaleProduct !== 'build') return null;
+  if (typeof estimate.scaleUsedPct !== 'number' || !Number.isFinite(estimate.scaleUsedPct)) {
+    return null;
+  }
+  return `Full pool dollars are extrapolated from Build ${Math.round(estimate.scaleUsedPct)}%, not from the pool gauge percent.`;
+}
+
 const USD_FORMAT = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
@@ -232,6 +240,11 @@ export default function GrokPanel({
                               ≈{USD_FORMAT.format(displayedGrokValueEstimate.estimatedPeriodValueUsd)}
                             </strong>
                           </span>
+                          {grokScaleBasisCopy(displayedGrokValueEstimate) ? (
+                            <span className="weekly-value-token-row">
+                              {grokScaleBasisCopy(displayedGrokValueEstimate)}
+                            </span>
+                          ) : null}
                         </div>
                         <div
                           className="weekly-value-gauge"

--- a/src/services/provider_summary.ts
+++ b/src/services/provider_summary.ts
@@ -217,7 +217,13 @@ export function buildGrokQuotaWindows(grokData: GrokData | null): QuotaWindowSum
     resetAtMs: resetAtMsFromValue(grokData.resetAt),
   }];
   const extra = grokData.extra;
-  if (extra && extra.onDemandCapCents > 0) {
+  if (
+    extra
+    && typeof extra.onDemandUsedCents === 'number'
+    && Number.isFinite(extra.onDemandUsedCents)
+    && typeof extra.onDemandCapCents === 'number'
+    && extra.onDemandCapCents > 0
+  ) {
     windows.push({
       provider: 'grok',
       providerLabel: SERVICE_META.grok.label,

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -131,6 +131,8 @@ export interface GrokValueEstimate {
   windowStartedAt: string;
   resetsAt: string;
   usedPct: number;
+  scaleUsedPct?: number;
+  scaleProduct?: string;
   observedCostUsd: number;
   estimatedPeriodValueUsd: number;
   observedTokens: number;

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -121,9 +121,9 @@ export interface GrokProductUsage {
 }
 
 export interface GrokExtraCredits {
-  onDemandUsedCents: number;
-  onDemandCapCents: number;
-  prepaidBalanceCents: number;
+  onDemandUsedCents?: number | null;
+  onDemandCapCents?: number | null;
+  prepaidBalanceCents?: number | null;
 }
 
 export interface GrokValueEstimate {

--- a/tests/panel_status_ui.test.tsx
+++ b/tests/panel_status_ui.test.tsx
@@ -5,6 +5,7 @@ import AntigravityPanel from '../src/components/AntigravityPanel';
 import ClaudePanel from '../src/components/ClaudePanel';
 import CodexPanel from '../src/components/CodexPanel';
 import CursorPanel from '../src/components/CursorPanel';
+import GrokPanel from '../src/components/GrokPanel';
 import OverviewPanel from '../src/components/OverviewPanel';
 import ProviderDetailHeader from '../src/components/ProviderDetailHeader';
 import { backend } from '../src/services/backend';
@@ -353,6 +354,30 @@ describe('provider status UI', () => {
     expect(text).toContain('Cursor network refresh failed');
     expect(text).toContain('Stale data');
     expect(text).toContain('Showing last known data');
+    await act(async () => renderer.unmount());
+  });
+
+  it('labels connected Grok last-good fallback as stale', async () => {
+    vi.spyOn(backend, 'getGrokInfo').mockResolvedValue({
+      connected: true,
+      percentage: 4,
+      products: [],
+      error: 'Too many open files (os error 24)',
+    });
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(GrokPanel, {
+        autoRefreshIntervalMs: 0,
+        sections: hiddenSections,
+      }));
+      await Promise.resolve();
+    });
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Too many open files');
+    expect(text).toContain('Stale data');
+    expect(text).toContain('Showing last known data');
+    expect(text).toContain('4%');
     await act(async () => renderer.unmount());
   });
 

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -728,6 +728,33 @@ describe('Grok period value', () => {
     await unmount(renderer);
   });
 
+  it('labels Full pool dollars as extrapolated from Build share, not the pool gauge', async () => {
+    const renderer = await render_grok({
+      connected: true,
+      percentage: 25,
+      periodType: 'weekly',
+      products: [{ product: 'build', label: 'Build', usagePercent: 4 }],
+      valueEstimate: {
+        observedAt: new Date().toISOString(),
+        windowStartedAt: '2026-08-23T15:25:10.879Z',
+        resetsAt: '2026-08-30T15:25:10.879Z',
+        usedPct: 25,
+        scaleUsedPct: 4,
+        scaleProduct: 'build',
+        observedCostUsd: 8,
+        estimatedPeriodValueUsd: 200,
+        observedTokens: 2_000,
+        estimatedPeriodTokens: 50_000,
+      },
+    });
+
+    const text = rendered_text(renderer);
+    expect(text).toContain('Full pool');
+    expect(text).toContain('$200.00');
+    expect(text).toContain('Full pool dollars are extrapolated from Build 4%, not from the pool gauge percent.');
+    await unmount(renderer);
+  });
+
   it('omits product rows without usagePercent instead of drawing 0%', async () => {
     const renderer = await render_grok({
       connected: true,

--- a/tests/provider_refresh_races.test.tsx
+++ b/tests/provider_refresh_races.test.tsx
@@ -747,6 +747,20 @@ describe('Grok period value', () => {
     await unmount(renderer);
   });
 
+  it('does not show $0.00 extra used against a cap when used cents are missing', async () => {
+    const renderer = await render_grok({
+      connected: true,
+      percentage: 4,
+      products: [],
+      extra: { onDemandCapCents: 5000, prepaidBalanceCents: 0 },
+    });
+
+    const text = rendered_text(renderer);
+    expect(text).not.toContain('Extra credits');
+    expect(text).not.toContain('$0.00 / $50.00');
+    await unmount(renderer);
+  });
+
   it('keeps the pool value error visible without hiding official usage', async () => {
     const renderer = await render_grok({
       connected: true,

--- a/tests/provider_summary.test.ts
+++ b/tests/provider_summary.test.ts
@@ -168,6 +168,12 @@ describe('provider summary helpers', () => {
     expect(windows[0].usedPercent).toBe(42);
     expect(windows[1].usedPercent).toBe(6);
     expect(buildGrokQuotaWindows({ connected: true, products: [] })).toEqual([]);
+    expect(buildGrokQuotaWindows({
+      connected: true,
+      percentage: 42,
+      products: [],
+      extra: { onDemandCapCents: 5000, prepaidBalanceCents: 0 },
+    }).map((window) => window.label)).toEqual(['Usage pool']);
   });
 });
 


### PR DESCRIPTION
## Summary

- Grok Full pool dollars still scale by the Build product share (GH106). The DTO now ships `scaleUsedPct` / `scaleProduct` so the panel can label that basis.
- The pool gauge remains the official pool percent. Copy states Full pool dollars are extrapolated from Build X%, not from the pool gauge percent. Missing scale fields fail closed (no fake 0% label).

## Verification

- [x] `npm test`
- [ ] `npm run build`
- [ ] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

## Scope

- [x] No provider tokens, cookies, sessions, or secrets are committed.
- [x] User-visible missing data fails closed or renders blank; it does not silently show zero usage.

Fixes #149

Made with [Cursor](https://cursor.com)